### PR TITLE
Fixed bug with include of the wolfSSL include of options.h, which cau…

### DIFF
--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -248,12 +248,13 @@ static int fw_message_build(const char* fwFile, byte **p_msgBuf, int *p_msgLen)
     }
 
     /* Sign Firmware */
-    sigLen = wc_SignatureGetSize(FIRMWARE_SIG_TYPE, &eccKey, sizeof(eccKey));
-    if (sigLen <= 0) {
+    rc = wc_SignatureGetSize(FIRMWARE_SIG_TYPE, &eccKey, sizeof(eccKey));
+    if (rc <= 0) {
         PRINTF("Signature type %d not supported!", FIRMWARE_SIG_TYPE);
         rc = EXIT_FAILURE;
         goto exit;
     }
+    sigLen = rc;
     sigBuf = (byte*)WOLFMQTT_MALLOC(sigLen);
     if (!sigBuf) {
         PRINTF("Signature malloc failed!");

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -37,6 +37,7 @@
 
 #include "wolfmqtt/mqtt_types.h"
 #ifdef ENABLE_MQTT_TLS
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #endif


### PR DESCRIPTION
…sing a define mismatch between the examples and the installed wolfSSL library; resulting in an erroneous failure of the firmware examples. Fix to properly handle negative return code from wc_SignatureGetSize.