### PR TITLE
Added "--disable-tls" and "--disable-examples" options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,14 +64,6 @@ AC_CHECK_FUNCS([socket])
 AC_CHECK_FUNCS([signal])
 AC_CHECK_LIB(network,socket)
 
-# Requirements
-TAO_REQUIRE_LIBWOLFSSL
-#REQUIRE_CYASSL([scep])
-#REQUIRE_WOLFCRYPT([aes rsa dh])
-
-# since we have autoconf available, we can use cyassl options header
-AM_CPPFLAGS="$AM_CPPFLAGS -DHAVE_CYASSL_OPTIONS"
-
 # DEBUG
 DEBUG_CFLAGS="-g -O0"
 DEBUG_CPPFLAGS="-DDEBUG -DDEBUG_WOLFMQTT"
@@ -85,6 +77,7 @@ AS_IF([test "x$ax_enable_debug" = "xyes"],
 
 AX_PTHREAD([AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"])
 
+
 # Checks for typedefs, structures, and compiler characteristics.
 if test "$ac_cv_sizeof_long" = "8"; then
    AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG=8"
@@ -93,6 +86,36 @@ else
         AM_CPPFLAGS="$AM_CPPFLAGS -DSIZEOF_LONG_LONG=8"
     fi
 fi
+
+
+# TLS Support with wolfSSL
+# Examples, used to disable examples
+AC_ARG_ENABLE([tls],
+    [  --enable-tls            Enable TLS support with wolfSSL  (default: enabled)],
+    [ ENABLED_TLS=$enableval ],
+    [ ENABLED_TLS=yes ]
+    )
+
+if test "x$ENABLED_TLS" = "xyes"
+then
+    AM_CPPFLAGS="$AM_CPPFLAGS -DENABLE_MQTT_TLS"
+
+    TAO_REQUIRE_LIBWOLFSSL
+    AM_CPPFLAGS="$AM_CPPFLAGS -DDHAVE_WOLFSSL_OPTIONS -DHAVE_CYASSL_OPTIONS"
+else
+    TAO_HAVE_LIBWOLFSSL
+fi
+
+
+# Examples
+AC_ARG_ENABLE([examples],
+    [  --enable-examples       Enable Examples  (default: enabled)],
+    [ ENABLED_EXAMPLES=$enableval ],
+    [ ENABLED_EXAMPLES=yes ]
+    )
+
+AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
+
 
 # HARDEN FLAGS
 AX_HARDEN_CC_COMPILER_FLAGS

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -97,6 +97,7 @@ static word16 mqttclient_get_packetid(void)
     return (word16)mPacketIdLast;
 }
 
+#ifdef ENABLE_MQTT_TLS
 static int mqttclient_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -139,6 +140,13 @@ static int mqttclient_tls_cb(MqttClient* client)
 
     return rc;
 }
+#else
+static int mqttclient_tls_cb(MqttClient* client)
+{
+    (void)client;
+    return 0;
+}
+#endif /* ENABLE_MQTT_TLS */
 
 static int fwfile_save(const char* filePath, byte* fileBuf, int fileLen)
 {

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -94,6 +94,7 @@ static word16 mqttclient_get_packetid(void)
     return (word16)mPacketIdLast;
 }
 
+#ifdef ENABLE_MQTT_TLS
 static int mqttclient_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -136,6 +137,13 @@ static int mqttclient_tls_cb(MqttClient* client)
 
     return rc;
 }
+#else
+static int mqttclient_tls_cb(MqttClient* client)
+{
+    (void)client;
+    return 0;
+}
+#endif /* ENABLE_MQTT_TLS */
 
 static int mqttclient_message_cb(MqttClient *client, MqttMessage *msg,
     byte msg_new, byte msg_done)

--- a/examples/include.am
+++ b/examples/include.am
@@ -1,13 +1,10 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
+if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/mqttclient/mqttclient \
                    examples/firmware/fwpush \
                    examples/firmware/fwclient
-noinst_HEADERS += examples/mqttclient/mqttclient.h \
-                  examples/firmware/fwpush.h \
-                  examples/firmware/fwclient.h \
-                  examples/firmware/firmware.h
 
 examples_mqttclient_mqttclient_SOURCES      = examples/mqttclient/mqttclient.c \
                                               examples/mqttnet.c
@@ -26,6 +23,12 @@ examples_firmware_fwclient_SOURCES          = examples/firmware/fwclient.c \
 examples_firmware_fwclient_LDADD            = src/libwolfmqtt.la
 examples_firmware_fwclient_DEPENDENCIES     = src/libwolfmqtt.la
 examples_firmware_fwclient_CPPFLAGS         = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
+endif
+
+noinst_HEADERS += examples/mqttclient/mqttclient.h \
+                  examples/firmware/fwpush.h \
+                  examples/firmware/fwclient.h \
+                  examples/firmware/firmware.h
 
 dist_example_DATA+= examples/mqttclient/mqttclient.c \
                     examples/firmware/fwpush.c \

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -77,6 +77,7 @@ static word16 mqttclient_get_packetid(void)
     return (word16)mPacketIdLast;
 }
 
+#ifdef ENABLE_MQTT_TLS
 static int mqttclient_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -119,6 +120,13 @@ static int mqttclient_tls_cb(MqttClient* client)
 
     return rc;
 }
+#else
+static int mqttclient_tls_cb(MqttClient* client)
+{
+    (void)client;
+    return 0;
+}
+#endif /* ENABLE_MQTT_TLS */
 
 static int mqttclient_message_cb(MqttClient *client, MqttMessage *msg,
     byte msg_new, byte msg_done)

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -2,6 +2,7 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
-
+if BUILD_EXAMPLES
 dist_noinst_SCRIPTS += scripts/client.test \
                        scripts/firmware.test
+endif

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -31,10 +31,6 @@
     extern "C" {
 #endif
 
-/* Options */
-/* Use without WolfSSL (on by default) */
-#define ENABLE_MQTT_TLS
-
 #include "wolfmqtt/mqtt_types.h"
 #ifdef ENABLE_MQTT_TLS
 #include <wolfssl/options.h>


### PR DESCRIPTION
. The disable-tls option allows building wolfMQTT without the wolfSSL dependency. The disable-examples option prevents the examples from being built, which is useful when cross-compiling the library.