### PR TITLE
Fixes for stdin capture and signal (ctrl+c) handling

### DIFF
--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -371,7 +371,7 @@ int fwclient_test(void* args)
     myoptind = 0; /* reset for test cases */
 
     /* Start example MQTT Client */
-    PRINTF("MQTT Firmware Client: QoS %d", qos);
+    PRINTF("MQTT Firmware Client: QoS %d, Use TLS %d", qos, use_tls);
 
     /* Initialize Network */
     rc = MqttClientNet_Init(&net);

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -433,7 +433,7 @@ int fwpush_test(void* args)
     (void)test_mode;
 
     /* Start example MQTT Client */
-    PRINTF("MQTT Firmware Push Client: QoS %d", qos);
+    PRINTF("MQTT Firmware Push Client: QoS %d, Use TLS %d", qos, use_tls);
 
     /* Load firmware, sign firmware and create message */
     rc = fw_message_build(fwFile, &msgBuf, &msgLen);

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -270,7 +270,7 @@ int mqttclient_test(void* args)
     myoptind = 0; /* reset for test cases */
 
     /* Start example MQTT Client */
-    PRINTF("MQTT Client: QoS %d", qos);
+    PRINTF("MQTT Client: QoS %d, Use TLS %d", qos, use_tls);
 
     /* Initialize Network */
     rc = MqttClientNet_Init(&net);
@@ -379,6 +379,7 @@ int mqttclient_test(void* args)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
+            MqttClientNet_CheckForCommand_Enable(&net);
             while (mStopRead == 0) {
                 /* Try and read packet */
                 rc = MqttClient_WaitMessage(&client, cmd_timeout_ms);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -31,21 +31,6 @@
 	#undef exit
 	#define exit(rc) return rc
 #endif
-#ifndef LINE_END
-    #define LINE_END    "\n"
-#endif
-#ifndef PRINTF
-    #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
-#endif
-
-#ifndef WOLFMQTT_NO_STDIO
-    #include <stdlib.h>
-    #include <string.h>
-    #include <stdio.h>
-#else
-    #undef PRINTF
-    #define PRINTF
-#endif
 
 /* Default Configurations */
 #define WOLFMQTT_TOPIC_NAME     "wolfMQTT/example/"

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -36,6 +36,7 @@ int MqttClientNet_Init(MqttNet* net);
 int MqttClientNet_DeInit(MqttNet* net);
 
 /* Standard In / Command handling */
+int MqttClientNet_CheckForCommand_Enable(MqttNet* net);
 int MqttClientNet_CheckForCommand(MqttNet* net, byte* buffer, word32 length);
 
 #ifdef __cplusplus

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -55,7 +55,7 @@ static int MqttClient_WaitType(MqttClient *client, int timeout_ms,
         msg_qos = MQTT_PACKET_FLAGS_GET_QOS(header->type_flags);
 
 #ifdef WOLFMQTT_DEBUG_CLIENT
-        printf("Read Packet: Len %d, Type %d, Qos %d\n",
+        PRINTF("Read Packet: Len %d, Type %d, Qos %d",
             packet_len, msg_type, msg_qos);
 #endif
 
@@ -218,7 +218,7 @@ static int MqttClient_WaitType(MqttClient *client, int timeout_ms,
             default:
                 /* Other types are server side only, ignore */
 #ifdef WOLFMQTT_DEBUG_CLIENT
-                printf("MqttClient_WaitMessage: Invalid client packet type %u!\n",
+                PRINTF("MqttClient_WaitMessage: Invalid client packet type %u!",
                     msg_type);
 #endif
                 break;
@@ -501,6 +501,8 @@ const char* MqttClient_ReturnCodeToString(int return_code)
             return "Error (Timeout)";
         case MQTT_CODE_ERROR_NETWORK:
             return "Error (Network)";
+        case MQTT_CODE_ERROR_MEMORY:
+            return "Error (Memory)";
     }
     return "Unknown";
 }

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -111,7 +111,7 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
         rc = wolfSSL_write(client->tls.ssl, (char*)buf, buf_len);
         error = wolfSSL_get_error(client->tls.ssl, 0);
 #ifdef WOLFMQTT_DEBUG_SOCKET
-        printf("MqttSocket_Write: Len=%d, Rc=%d, Error=%d\n",
+        PRINTF("MqttSocket_Write: Len=%d, Rc=%d, Error=%d",
             buf_len, rc, error);
 #endif
         if (error == SSL_ERROR_WANT_WRITE) {
@@ -125,7 +125,7 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
             timeout_ms);
 
 #ifdef WOLFMQTT_DEBUG_SOCKET
-        printf("MqttSocket_Write: Len=%d, Rc=%d\n", buf_len, rc);
+        PRINTF("MqttSocket_Write: Len=%d, Rc=%d", buf_len, rc);
 #endif
     }
 
@@ -156,7 +156,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
             rc = wolfSSL_read(client->tls.ssl, (char*)&buf[pos], len);
             error = wolfSSL_get_error(client->tls.ssl, 0);
 #ifdef WOLFMQTT_DEBUG_SOCKET
-            printf("MqttSocket_Read: Len=%d, Rc=%d, Error=%d\n",
+            PRINTF("MqttSocket_Read: Len=%d, Rc=%d, Error=%d",
                 len, rc, error);
 #endif
             if (error == SSL_ERROR_WANT_READ) {
@@ -170,7 +170,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
                 timeout_ms);
 
 #ifdef WOLFMQTT_DEBUG_SOCKET
-            printf("MqttSocket_Read: Len=%d, Rc=%d\n", len, rc);
+            PRINTF("MqttSocket_Read: Len=%d, Rc=%d", len, rc);
 #endif
         }
 
@@ -259,23 +259,17 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
                     }
                 }
                 else {
-#ifndef WOLFMQTT_NO_STDIO
-                    printf("MqttSocket_TlsConnect: wolfSSL_new error!\n");
-#endif
+                    PRINTF("MqttSocket_TlsConnect: wolfSSL_new error!");
                     rc = -1;
                 }
             }
             else {
-#ifndef WOLFMQTT_NO_STDIO
-                printf("MqttSocket_TlsConnect: wolfSSL_CTX_new error!\n");
-#endif
+                PRINTF("MqttSocket_TlsConnect: wolfSSL_CTX_new error!");
                 rc = -1;
             }
         }
         else {
-#ifndef WOLFMQTT_NO_STDIO
-            printf("MqttSocket_TlsConnect: TLS callback error!\n");
-#endif
+            PRINTF("MqttSocket_TlsConnect: TLS callback error!");
             rc = -1;
         }
 
@@ -289,7 +283,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
                 errstr = wolfSSL_ERR_reason_error_string(errnum);
             }
 
-            printf("MqttSocket_TlsConnect Error %d: Num %d, %s\n",
+            PRINTF("MqttSocket_TlsConnect Error %d: Num %d, %s",
                 rc, errnum, errstr);
 #endif
 
@@ -304,7 +298,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
 #endif /* ENABLE_MQTT_TLS */
 
 #ifdef WOLFMQTT_DEBUG_SOCKET
-    printf("MqttSocket_Connect: Rc=%d\n", rc);
+    PRINTF("MqttSocket_Connect: Rc=%d", rc);
 #endif
 
     /* Check for error */
@@ -333,7 +327,7 @@ int MqttSocket_Disconnect(MqttClient *client)
         client->flags &= ~MQTT_CLIENT_FLAG_IS_CONNECTED;
     }
 #ifdef WOLFMQTT_DEBUG_SOCKET
-    printf("MqttSocket_Disconnect: Rc=%d\n", rc);
+    PRINTF("MqttSocket_Disconnect: Rc=%d\n", rc);
 #endif
 
     /* Check for error */

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -77,6 +77,7 @@ enum MqttPacketResponseCodes {
     MQTT_CODE_ERROR_TLS_CONNECT = -6,
     MQTT_CODE_ERROR_TIMEOUT = -7,
     MQTT_CODE_ERROR_NETWORK = -8,
+    MQTT_CODE_ERROR_MEMORY = -9,
 };
 
 
@@ -136,6 +137,27 @@ enum MqttPacketResponseCodes {
     #define INLINE
 #endif /* !NO_INLINE */
 #endif /* !INLINE */
+
+
+/* printf */
+#ifndef WOLFMQTT_CUSTOM_PRINTF
+    #ifndef LINE_END
+        #define LINE_END    "\n"
+    #endif
+    #ifndef PRINTF
+        #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
+    #endif
+
+    #ifndef WOLFMQTT_NO_STDIO
+        #include <stdlib.h>
+        #include <string.h>
+        #include <stdio.h>
+    #else
+        #undef PRINTF
+        #define PRINTF
+    #endif
+#endif
+
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Fixes for stdin capture and signal (ctrl+c) handling. Fix for make check on Unix due to stdin that was causing invalid failure. Added printf "Use TLS" info to example startup message. Moved the support for custom printf/line endings into the mqtt_types.h for use throughout the project.