### PR TITLE
silence scan build false positive warning

### DIFF
--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -226,7 +226,7 @@ static int fw_message_build(const char* fwFile, byte **p_msgBuf, int *p_msgLen)
 
     /* Verify file can be loaded */
     rc = fwfile_load(fwFile, &fwBuf, &fwLen);
-    if (rc < 0 || fwLen == 0) {
+    if (rc < 0 || fwLen == 0 || fwBuf == NULL) {
         PRINTF("Firmware File %s Load Error!", fwFile);
         Usage();
         goto exit;


### PR DESCRIPTION
This is a false positive because wc_SignatureGenerate will return BAD_FUNC_ARG if fwBuf is NULL which will then goto exit avoiding the XMEMCPY being reported. To silence the warning of a potential NULL pointer being passed to XMEMCPY have added a NULL check after loading the file.