### PR TITLE
Removed big endian #error.

### DIFF
--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -50,13 +50,6 @@
     #include "system_definitions.h"
 #endif
 
-
-/* Endianess check */
-#if defined(__BIG_ENDIAN__) || defined(BIG_ENDIAN_ORDER)
-    #error Big Endian is not yet supported. Please contact us if \
-        you are interested in this feature.
-#endif
-
 #ifdef _WIN32
     #define USE_WINDOWS_API
 


### PR DESCRIPTION
After further testing on a big endian (PPC) system and feedback from a customer it turns out big endian is already supported fine and this precautionary check can be removed. Resolves issue #13.