### PR TITLE
Fixes for building with Visual Studio

### DIFF
--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -50,11 +50,6 @@
     #endif
 #endif
 
-/* for ctrl handler */
-#ifdef USE_WINDOWS_API
-    #include <windows.h>
-#endif
-
 
 #ifdef ENABLE_AZUREIOTHUB_EXAMPLE
 
@@ -86,7 +81,7 @@ static int mStopRead = 0;
 #define AZURE_TOKEN_EXPIRY_SEC  (60 * 60 * 1) /* 1 hour */
 
 #define AZURE_DEVICE_NAME       AZURE_HOST"/devices/"AZURE_DEVICE_ID
-#define AZURE_USERNAME          AZURE_HOST"/"AZURE_DEVICE_ID 
+#define AZURE_USERNAME          AZURE_HOST"/"AZURE_DEVICE_ID
 #define AZURE_SIG_FMT           "%s\n%ld"
     /* [device name (URL Encoded)]\n[Expiration sec UTC] */
 #define AZURE_PASSWORD_FMT      "SharedAccessSignature sr=%s&sig=%s&se=%ld"
@@ -288,7 +283,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
         case WMQ_INIT:
         {
             mqttCtx->stat = WMQ_INIT;
-            
+
             /* Initialize MqttClient structure */
             rc = MqttClient_Init(&mqttCtx->client, &mqttCtx->net, mqtt_message_cb,
                 mqttCtx->tx_buf, MAX_BUFFER_SIZE, mqttCtx->rx_buf, MAX_BUFFER_SIZE,
@@ -558,6 +553,8 @@ exit:
 /* so overall tests can pull in test function */
 #ifndef NO_MAIN_DRIVER
     #ifdef USE_WINDOWS_API
+        #include <windows.h> /* for ctrl handler */
+
         static BOOL CtrlHandler(DWORD fdwCtrlType)
         {
             if (fdwCtrlType == CTRL_C_EVENT) {

--- a/examples/azure/azureiothub.vcxproj
+++ b/examples/azure/azureiothub.vcxproj
@@ -79,6 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -91,6 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../;../../;../../../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -104,6 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -118,6 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/examples/azure/azureiothub.vcxproj
+++ b/examples/azure/azureiothub.vcxproj
@@ -79,7 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../;../../;../../../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -106,7 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -121,7 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/examples/azure/azureiothub.vcxproj.filters
+++ b/examples/azure/azureiothub.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="..\mqttnet.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mqttexample.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="azureiothub.h">

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -29,18 +29,13 @@
 #if defined(ENABLE_MQTT_TLS)
     #include <wolfssl/options.h>
     #include <wolfssl/version.h>
- 
+
     /* The signature wrapper for this example was added in wolfSSL after 3.7.1 */
     #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX > 0x03007001 \
     	    && defined(HAVE_ECC)
         #undef ENABLE_FIRMWARE_EXAMPLE
         #define ENABLE_FIRMWARE_EXAMPLE
     #endif
-#endif
-
-/* for ctrl handler */
-#ifdef USE_WINDOWS_API
-    #include <windows.h>
 #endif
 
 
@@ -238,7 +233,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
         case WMQ_INIT:
         {
             mqttCtx->stat = WMQ_INIT;
-            
+
             /* Initialize MqttClient structure */
             rc = MqttClient_Init(&mqttCtx->client, &mqttCtx->net,
                 mqtt_message_cb,
@@ -273,7 +268,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
         }
-        
+
         case WMQ_MQTT_CONN:
         {
             mqttCtx->stat = WMQ_MQTT_CONN;
@@ -343,21 +338,21 @@ int fwclient_test(MQTTCtx *mqttCtx)
             for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
                 mqttCtx->topic = &mqttCtx->subscribe.topics[i];
                 PRINTF("  Topic %s, Qos %u, Return Code %u",
-                    mqttCtx->topic->topic_filter, 
-                    mqttCtx->topic->qos, 
+                    mqttCtx->topic->topic_filter,
+                    mqttCtx->topic->qos,
                     mqttCtx->topic->return_code);
             }
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
         }
-            
+
         case WMQ_WAIT_MSG:
         {
             mqttCtx->stat = WMQ_WAIT_MSG;
 
             do {
                 /* Try and read packet */
-                rc = MqttClient_WaitMessage(&mqttCtx->client, 
+                rc = MqttClient_WaitMessage(&mqttCtx->client,
                                                   mqttCtx->cmd_timeout_ms);
 
                 /* check for test mode */
@@ -465,6 +460,8 @@ exit:
 /* so overall tests can pull in test function */
 #if !defined(NO_MAIN_DRIVER) && !defined(MICROCHIP_MPLAB_HARMONY)
     #ifdef USE_WINDOWS_API
+        #include <windows.h> /* for ctrl handler */
+
         static BOOL CtrlHandler(DWORD fdwCtrlType)
         {
             if (fdwCtrlType == CTRL_C_EVENT) {

--- a/examples/firmware/fwclient.vcxproj
+++ b/examples/firmware/fwclient.vcxproj
@@ -79,7 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../;../../;../../../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -106,6 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -120,6 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/examples/firmware/fwclient.vcxproj.filters
+++ b/examples/firmware/fwclient.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="..\mqttnet.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mqttexample.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fwclient.h">

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -29,18 +29,13 @@
 #if defined(ENABLE_MQTT_TLS)
     #include <wolfssl/options.h>
     #include <wolfssl/version.h>
- 
+
     /* The signature wrapper for this example was added in wolfSSL after 3.7.1 */
     #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX > 0x03007001 \
     	    && defined(HAVE_ECC)
         #undef ENABLE_FIRMWARE_EXAMPLE
         #define ENABLE_FIRMWARE_EXAMPLE
     #endif
-#endif
-
-/* for ctrl handler */
-#ifdef USE_WINDOWS_API
-    #include <windows.h>
 #endif
 
 
@@ -477,6 +472,8 @@ exit:
 /* so overall tests can pull in test function */
 #ifndef NO_MAIN_DRIVER
     #ifdef USE_WINDOWS_API
+        #include <windows.h> /* for ctrl handler */
+
         static BOOL CtrlHandler(DWORD fdwCtrlType)
         {
             if (fdwCtrlType == CTRL_C_EVENT) {

--- a/examples/firmware/fwpush.vcxproj
+++ b/examples/firmware/fwpush.vcxproj
@@ -79,7 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../;../../;../../../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -106,6 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -120,6 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/examples/firmware/fwpush.vcxproj.filters
+++ b/examples/firmware/fwpush.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="..\mqttnet.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mqttexample.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fwpush.h">

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -36,7 +36,7 @@
 
 /* Locals */
 static int mStopRead = 0;
- 
+
 /* Configuration */
 #define MAX_BUFFER_SIZE         1024    /* Maximum size for network read/write callbacks */
 #define TEST_MESSAGE            "test"
@@ -417,6 +417,8 @@ exit:
 /* so overall tests can pull in test function */
 #if !defined(NO_MAIN_DRIVER) && !defined(MICROCHIP_MPLAB_HARMONY)
     #ifdef USE_WINDOWS_API
+        #include <windows.h> /* for ctrl handler */
+
         static BOOL CtrlHandler(DWORD fdwCtrlType)
         {
             if (fdwCtrlType == CTRL_C_EVENT) {

--- a/examples/mqttclient/mqttclient.vcxproj
+++ b/examples/mqttclient/mqttclient.vcxproj
@@ -79,6 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -91,6 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../;../../;../../../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -104,6 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -118,6 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/examples/mqttclient/mqttclient.vcxproj.filters
+++ b/examples/mqttclient/mqttclient.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="..\mqttnet.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mqttexample.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mqttclient.h">

--- a/wolfmqtt.vcxproj
+++ b/wolfmqtt.vcxproj
@@ -79,6 +79,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -90,7 +91,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>.;./../wolfssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>BUILDING_WOLFMQTT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BUILDING_WOLFMQTT;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -104,6 +105,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -118,6 +120,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);ENABLE_MQTT_TLS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -121,7 +121,11 @@ enum MqttPacketResponseCodes {
         #define XISALNUM(c)         isalnum((c))
     #endif
     #ifndef XSNPRINTF
-        #define XSNPRINTF           snprintf
+        #ifndef USE_WINDOWS_API
+            #define XSNPRINTF        snprintf
+        #else
+            #define XSNPRINTF        _snprintf
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
. Fixes issue with windows.h include order. Enabled TLS support by default in Visual Studio projects.