### PR TITLE
Added option to disable the timeouts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,18 @@ then
 fi
 
 
+# Timeout support
+AC_ARG_ENABLE([timeout],
+    [  --enable-timeout         Enable timeout support  (default: enabled)],
+    [ ENABLED_TIMEOUT=$enableval ],
+    [ ENABLED_TIMEOUT=yes ]
+    )
+
+if test "x$ENABLED_TIMEOUT" = "xno"
+then
+    AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFMQTT_NO_TIMEOUT"
+fi
+
 # Examples
 AC_ARG_ENABLE([examples],
     [  --enable-examples       Enable Examples  (default: enabled)],

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -369,7 +369,7 @@ static int NetRead(void *context, byte* buf, int buf_len,
     SocketContext *sock = (SocketContext*)context;
     int rc = -1, timeout = 0;
     SOERROR_T so_error = 0;
-#ifndef WOLFMQTT_NO_TIMEOUT
+#if !defined(WOLFMQTT_NO_TIMEOUT) && !defined(WOLFMQTT_NONBLOCK)
     fd_set recvfds;
     fd_set errfds;
     struct timeval tv;

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -181,7 +181,7 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len, int tim
 int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
 {
     int rc;
-    
+
     /* Validate arguments */
     if (client == NULL || client->net == NULL || client->net->read == NULL ||
         buf == NULL || buf_len <= 0) {
@@ -216,7 +216,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
         client->read.pos += rc;
     } while (client->read.pos < buf_len);
 #endif /* WOLFMQTT_NONBLOCK */
-        
+
     /* handle return code */
     if (rc > 0) {
         /* return length read and reset position */
@@ -237,7 +237,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         client->net->connect == NULL) {
         return MQTT_CODE_ERROR_BAD_ARG;
     }
-    
+
     if ((client->flags & MQTT_CLIENT_FLAG_IS_CONNECTED) == 0) {
         /* Validate port */
         if (port == 0) {
@@ -255,10 +255,14 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
 #ifdef ENABLE_MQTT_TLS
     if (use_tls) {
         if (client->tls.ctx == NULL) {
+        #ifdef DEBUG_WOLFSSL
+            wolfSSL_Debugging_ON();
+        #endif
+
             /* Setup the WolfSSL library */
             wolfSSL_Init();
-            
-            /* Issue callback to allow setup of the wolfSSL_CTX and cert 
+
+            /* Issue callback to allow setup of the wolfSSL_CTX and cert
                verification settings */
             rc = SSL_SUCCESS;
             if (cb) {


### PR DESCRIPTION
Added option to disable the timeouts (select) using --disable-timeout (or WOLFMQTT_NO_TIMEOUT). Cleanup around the socket connect reference code. Added call to enable debug printouts if DEBUG_WOLFSSL is defined.