### PR TITLE
Fix for issue with msg->stat in non-blocking and network return code cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,22 @@ AC_ARG_ENABLE([examples],
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
 
 
+# STDIN / FGETS for examples
+AC_ARG_ENABLE([stdincap],
+    [  --enable-stdincap       Enable examplesSTDIN capture  (default: enabled)],
+    [ ENABLED_STDINCAP=$enableval ],
+    [ ENABLED_STDINCAP=yes ]
+    )
+
+if test "x$ENABLED_STDINCAP" = "xno"
+then
+    AM_CPPFLAGS="$AM_CPPFLAGS -DNO_STDIN_CAPTURE"
+fi
+
+AM_CONDITIONAL([BUILD_STDINCAP], [test "x$ENABLED_STDINCAP" = "xyes"])
+
+
+
 # HARDEN FLAGS
 AX_HARDEN_CC_COMPILER_FLAGS
 
@@ -168,4 +184,5 @@ echo "   * LIB Flags:                 $LIB"
 echo "   * TLS:                       $ENABLED_TLS"
 echo "   * Non-Blocking:              $ENABLED_NONBLOCK"
 echo "   * Examples:                  $ENABLED_EXAMPLES"
+echo "   * STDIN Capture:             $ENABLED_STDINCAP"
 

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -460,9 +460,10 @@ int awsiot_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
+            #ifdef ENABLE_STDIN_CAPTURE
                 else if (rc == MQTT_CODE_STDIN_WAKE) {
                     /* Get data from STDIO */
-                    if (fgets((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
+                    if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
                         rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
 
                         /* Publish Topic */
@@ -484,6 +485,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
                 }
+            #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
                     rc = MqttClient_Ping(&mqttCtx->client);

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -440,7 +440,6 @@ int awsiot_test(MQTTCtx *mqttCtx)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-            MqttClientNet_CheckForCommand_Enable(&mqttCtx->net);
         }
 
         case WMQ_WAIT_MSG:
@@ -461,11 +460,11 @@ int awsiot_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
-                else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
-                    /* Check to see if command data (stdin) is available */
-                    rc = MqttClientNet_CheckForCommand(&mqttCtx->net,
-                        mqttCtx->rx_buf, MAX_BUFFER_SIZE);
-                    if (rc > 0) {
+                else if (rc == MQTT_CODE_STDIN_WAKE) {
+                    /* Get data from STDIO */
+                    if (fgets((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
+                        rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
+
                         /* Publish Topic */
                         XSNPRINTF(mqttCtx->buffer.pubMsg, sizeof(mqttCtx->buffer.pubMsg),
                             "{\"state\":{\"reported\":{\"msg\":\"%s\"}}}",
@@ -484,17 +483,17 @@ int awsiot_test(MQTTCtx *mqttCtx)
                             mqttCtx->publish.topic_name,
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
+                }
+                else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
-                    else {
-                        rc = MqttClient_Ping(&mqttCtx->client);
-                        if (rc == MQTT_CODE_CONTINUE) {
-                            return rc;
-                        }
-                        else if (rc != MQTT_CODE_SUCCESS) {
-                            PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
-                                MqttClient_ReturnCodeToString(rc), rc);
-                            break;
-                        }
+                    rc = MqttClient_Ping(&mqttCtx->client);
+                    if (rc == MQTT_CODE_CONTINUE) {
+                        return rc;
+                    }
+                    else if (rc != MQTT_CODE_SUCCESS) {
+                        PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
+                            MqttClient_ReturnCodeToString(rc), rc);
+                        break;
                     }
                 }
                 else if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -443,9 +443,10 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
+            #ifdef ENABLE_STDIN_CAPTURE
                 else if (rc == MQTT_CODE_STDIN_WAKE) {
                     /* Get data from STDIO */
-                    if (fgets((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
+                    if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
                         rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
 
                         /* Publish Topic */
@@ -464,6 +465,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
                 }
+            #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
                     rc = MqttClient_Ping(&mqttCtx->client);

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -423,7 +423,6 @@ int azureiothub_test(MQTTCtx *mqttCtx)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-            MqttClientNet_CheckForCommand_Enable(&mqttCtx->net);
         }
 
         case WMQ_WAIT_MSG:
@@ -444,11 +443,11 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
-                else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
-                    /* Check to see if command data (stdin) is available */
-                    rc = MqttClientNet_CheckForCommand(&mqttCtx->net,
-                        mqttCtx->rx_buf, MAX_BUFFER_SIZE);
-                    if (rc > 0) {
+                else if (rc == MQTT_CODE_STDIN_WAKE) {
+                    /* Get data from STDIO */
+                    if (fgets((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
+                        rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
+
                         /* Publish Topic */
                         mqttCtx->stat = WMQ_PUB;
                         XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
@@ -464,17 +463,17 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                             mqttCtx->publish.topic_name,
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
+                }
+                else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
-                    else {
-                        rc = MqttClient_Ping(&mqttCtx->client);
-                        if (rc == MQTT_CODE_CONTINUE) {
-                            return rc;
-                        }
-                        else if (rc != MQTT_CODE_SUCCESS) {
-                            PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
-                                MqttClient_ReturnCodeToString(rc), rc);
-                            break;
-                        }
+                    rc = MqttClient_Ping(&mqttCtx->client);
+                    if (rc == MQTT_CODE_CONTINUE) {
+                        return rc;
+                    }
+                    else if (rc != MQTT_CODE_SUCCESS) {
+                        PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
+                            MqttClient_ReturnCodeToString(rc), rc);
+                        break;
                     }
                 }
                 else if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -281,8 +281,9 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
+            #ifdef ENABLE_STDIN_CAPTURE
                 else if (rc == MQTT_CODE_STDIN_WAKE) {
-                    if (fgets((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
+                    if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE, stdin) != NULL) {
                         rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
 
                         /* Publish Topic */
@@ -301,6 +302,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
                 }
+            #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
                     rc = MqttClient_Ping(&mqttCtx->client);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -32,6 +32,13 @@
 	#define exit(rc) return rc
 #endif
 
+#ifdef ENABLE_STDIN_CAPTURE
+    #ifndef XFGETS
+        #define XFGETS     fgets
+    #endif
+#endif
+
+
 /* Default Configurations */
 #define DEFAULT_CMD_TIMEOUT_MS  30000
 #define DEFAULT_CON_TIMEOUT_MS  5000

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -99,10 +99,6 @@
     #include <errno.h>
     #include <fcntl.h>
     #include <signal.h>
-
-    /* Wake on stdin activity */
-    #define ENABLE_STDIN_CAPTURE
-    #define STDIN   0
 #endif
 
 /* Setup defaults */

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -35,9 +35,6 @@
 int MqttClientNet_Init(MqttNet* net);
 int MqttClientNet_DeInit(MqttNet* net);
 
-/* Standard In / Command handling */
-int MqttClientNet_CheckForCommand_Enable(MqttNet* net);
-int MqttClientNet_CheckForCommand(MqttNet* net, byte* buffer, word32 length);
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -30,6 +30,19 @@
 /* Default MQTT host broker to use, when none is specified in the examples */
 #define DEFAULT_MQTT_HOST       "iot.eclipse.org" /* broker.hivemq.com */
 
+/* For Linux */
+#if !defined(FREERTOS) && !defined(USE_WINDOWS_API) && \
+    !defined(FREESCALE_MQX) && !defined(FREESCALE_KSDK_MQX) && \
+    !defined(MICROCHIP_MPLAB_HARMONY)
+    /* Linux */
+
+    #if !defined(NO_STDIN_CAPTURE) && !defined(ENABLE_STDIN_CAPTURE)
+        /* Wake on stdin activity */
+        #define ENABLE_STDIN_CAPTURE
+        #define STDIN   0
+    #endif
+#endif
+
 
 /* Functions used to handle the MqttNet structure creation / destruction */
 int MqttClientNet_Init(MqttNet* net);

--- a/examples/mqttuart.c
+++ b/examples/mqttuart.c
@@ -58,7 +58,7 @@ static int NetWrite(void *context, const byte* buf, int buf_len,
 {
     UartContext *uartCtx = (UartContext*)context;
     (void)uartCtx;
-    
+
     /* TODO: Implement write call to your UART HW */
 
     return 0;
@@ -105,15 +105,6 @@ int MqttClientNet_DeInit(MqttNet* net)
         }
         XMEMSET(net, 0, sizeof(MqttNet));
     }
-    return 0;
-}
-
-int MqttClientNet_CheckForCommand(MqttNet* net, byte* buffer, word32 length)
-{
-    (void)net;
-    (void)buffer;
-    (void)length;
-
     return 0;
 }
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -83,7 +83,7 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
                     }
                     msg->buffer_new = 0;
                 }
-                
+
                 /* Read payload */
                 if (!msg_done) {
                     int msg_len;
@@ -259,16 +259,13 @@ wait_again:
         {
             MqttPacket* header;
 
-            msg->stat = MQTT_MSG_WAIT;
-
             /* Wait for packet */
             rc = MqttPacket_Read(client, client->rx_buf, client->rx_buf_len, timeout_ms);
             if (rc <= 0) {
-                if (rc != MQTT_CODE_CONTINUE) {
-                    msg->stat = MQTT_MSG_BEGIN;
-                }
                 return rc;
             }
+
+            msg->stat = MQTT_MSG_WAIT;
             client->packet.buf_len = rc;
 
             /* Determine packet type */
@@ -370,7 +367,7 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *connect)
     if (client == NULL || connect == NULL) {
         return MQTT_CODE_ERROR_BAD_ARG;
     }
-    
+
     if (client->msg.stat == MQTT_MSG_BEGIN) {
 
         /* Encode the connect packet */
@@ -506,7 +503,7 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
     if (client == NULL || subscribe == NULL) {
         return MQTT_CODE_ERROR_BAD_ARG;
     }
-    
+
     if (client->msg.stat == MQTT_MSG_BEGIN) {
         /* Encode the subscribe packet */
         rc = MqttEncode_Subscribe(client->tx_buf, client->tx_buf_len, subscribe);
@@ -644,6 +641,8 @@ const char* MqttClient_ReturnCodeToString(int return_code)
             return "Success";
         case MQTT_CODE_CONTINUE:
             return "Continue"; /* would block */
+        case MQTT_CODE_STDIN_WAKE:
+            return "STDIN Wake";
         case MQTT_CODE_ERROR_BAD_ARG:
             return "Error (Bad argument)";
         case MQTT_CODE_ERROR_OUT_OF_BUFFER:

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -71,6 +71,7 @@ typedef struct _MqttNet {
     MqttNetReadCb       read;
     MqttNetWriteCb      write;
     MqttNetDisconnectCb disconnect;
+    int                 sockRc;
 } MqttNet;
 
 

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -93,6 +93,7 @@ enum MqttPacketResponseCodes {
     MQTT_CODE_ERROR_STAT = -10,
 
     MQTT_CODE_CONTINUE = -101,
+    MQTT_CODE_STDIN_WAKE = -102,
 };
 
 


### PR DESCRIPTION
Fix for issue with msg->stat in non-blocking. Enhancement to pass network callback return codes through context back when using TLS. Cleanup to use STDIN_WAKE return code for examples using stdin to send publish messages (works on normal blocking mode only). Eliminates the need for “MqttClientNet_CheckForCommand_Enable” and “MqttClientNet_CheckForCommand” functions in net example.