### PR TITLE
Revert verify none change workaround

### DIFF
--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -307,11 +307,7 @@ int mqtt_tls_cb(MqttClient* client)
 
     client->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
     if (client->tls.ctx) {
-    #if 1
-        wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_NONE, mqtt_tls_verify_cb);
-    #else
         wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_PEER, mqtt_tls_verify_cb);
-    #endif
 
 		/* default to success */
         rc = SSL_SUCCESS;


### PR DESCRIPTION
Revert verify none change workaround for issue with wolfSSL 3.11.0 verify callback override (https://github.com/wolfSSL/wolfssl/pull/907).