### PR TITLE
Add support for DH and setting the default minimum key bits

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -466,7 +466,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
                     /* Get data from STDIO */
                     XMEMSET(mqttCtx->rx_buf, 0, MAX_BUFFER_SIZE);
                     if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE - 1, stdin) != NULL) {
-                        rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
+                        /* rc = (int)XSTRLEN((char*)mqttCtx->rx_buf); */
 
                         /* Publish Topic */
                         XSNPRINTF(mqttCtx->buffer.pubMsg, sizeof(mqttCtx->buffer.pubMsg),

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -297,7 +297,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         wolfSSL_CTX_SetMinDhKey_Sz(client->tls.ctx, WOLF_TLS_DHKEY_BITS_MIN);
     #endif
 
-        /* Seutp the async IO callbacks */
+        /* Setup the async IO callbacks */
         wolfSSL_SetIORecv(client->tls.ctx, MqttSocket_TlsSocketReceive);
         wolfSSL_SetIOSend(client->tls.ctx, MqttSocket_TlsSocketSend);
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -293,6 +293,10 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
             wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_NONE, 0);
         }
 
+    #ifndef NO_DH
+        wolfSSL_CTX_SetMinDhKey_Sz(client->tls.ctx, WOLF_TLS_DHKEY_BITS_MIN);
+    #endif
+
         /* Seutp the async IO callbacks */
         wolfSSL_SetIORecv(client->tls.ctx, MqttSocket_TlsSocketReceive);
         wolfSSL_SetIOSend(client->tls.ctx, MqttSocket_TlsSocketSend);

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -36,6 +36,10 @@
     #include <wolfssl/options.h>
     #include <wolfssl/ssl.h>
     #include <wolfssl/wolfcrypt/types.h>
+
+    #ifndef WOLF_TLS_DHKEY_BITS_MIN
+        #define WOLF_TLS_DHKEY_BITS_MIN 2048
+    #endif
 #endif
 
 /* Default Port Numbers */


### PR DESCRIPTION
Adds an overridable define `WOLF_TLS_DHKEY_BITS_MIN` that defaults to 2048-bit. Fix warning with rc not used in awsiot.c. Fixed spelling error.