### PR TITLE
Adds support for keep-alive ping when using non-blocking mode

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -457,6 +457,12 @@ int awsiot_test(MQTTCtx *mqttCtx)
                     break;
                 }
 
+            #ifdef WOLFMQTT_NONBLOCK
+                /* Track elapsed time with no activity and trigger timeout */
+                rc = mqtt_check_timeout(rc, &mqttCtx->start_sec,
+                    mqttCtx->cmd_timeout_ms/1000);
+            #endif
+
                 /* check return code */
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
@@ -490,6 +496,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
+                    PRINTF("Keep-alive timeout, sending ping");
+
                     rc = MqttClient_Ping(&mqttCtx->client);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -440,6 +440,12 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                     break;
                 }
 
+            #ifdef WOLFMQTT_NONBLOCK
+                /* Track elapsed time with no activity and trigger timeout */
+                rc = mqtt_check_timeout(rc, &mqttCtx->start_sec,
+                    mqttCtx->cmd_timeout_ms/1000);
+            #endif
+
                 /* check return code */
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
@@ -470,6 +476,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
+                    PRINTF("Keep-alive timeout, sending ping");
+
                     rc = MqttClient_Ping(&mqttCtx->client);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -362,12 +362,20 @@ int fwclient_test(MQTTCtx *mqttCtx)
                     break;
                 }
 
+            #ifdef WOLFMQTT_NONBLOCK
+                /* Track elapsed time with no activity and trigger timeout */
+                rc = mqtt_check_timeout(rc, &mqttCtx->start_sec,
+                    mqttCtx->cmd_timeout_ms/1000);
+            #endif
+
                 /* check return code */
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
+                    PRINTF("Keep-alive timeout, sending ping");
+
                     rc = MqttClient_Ping(&mqttCtx->client);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -278,6 +278,12 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                     break;
                 }
 
+            #ifdef WOLFMQTT_NONBLOCK
+                /* Track elapsed time with no activity and trigger timeout */
+                rc = mqtt_check_timeout(rc, &mqttCtx->start_sec,
+                    mqttCtx->cmd_timeout_ms/1000);
+            #endif
+
                 /* check return code */
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
@@ -307,6 +313,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Keep Alive */
+                    PRINTF("Keep-alive timeout, sending ping");
+
                     rc = MqttClient_Ping(&mqttCtx->client);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -108,6 +108,9 @@ typedef struct MQTTCtx {
     byte test_mode;
     const char* pub_file;
     int retain;
+#if defined(WOLFMQTT_NONBLOCK)
+    word32 start_sec; /* used for keep-alive */
+#endif
 #if defined(ENABLE_AZUREIOTHUB_EXAMPLE) || defined(ENABLE_AWSIOT_EXAMPLE)
     union {
     #ifdef ENABLE_AZUREIOTHUB_EXAMPLE
@@ -140,6 +143,10 @@ int err_sys(const char* msg);
 
 int mqtt_tls_cb(MqttClient* client);
 word16 mqtt_get_packetid(void);
+
+#ifdef WOLFMQTT_NONBLOCK
+int mqtt_check_timeout(int rc, word32* start_sec, word32 timeout_sec);
+#endif
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Checks for timeout with no activity using command timeout (-C arg). New `mqtt_check_timeout` function in `mqttexample.c`. Support for Posix time and Microchip Harmony. Added printf message for keep-alive.