### PR TITLE
Fix the DH minimum key size

### DIFF
--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -37,8 +37,12 @@
     #include <wolfssl/ssl.h>
     #include <wolfssl/wolfcrypt/types.h>
 
-    #ifndef WOLF_TLS_DHKEY_BITS_MIN
-        #define WOLF_TLS_DHKEY_BITS_MIN 2048
+    #ifndef WOLF_TLS_DHKEY_BITS_MIN /* allow define to be overridden */
+        #ifdef WOLFSSL_MAX_STRENGTH
+            #define WOLF_TLS_DHKEY_BITS_MIN 2048
+        #else
+            #define WOLF_TLS_DHKEY_BITS_MIN 1024
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
Fix the DH minimum key size to default to 1024 and only use 2048 if overridden or if WOLFSSL_MAX_STRENGTH defined. ZenDesk 2962 and 2932.