### PR TITLE
Fix to better handle TLS callback return code != SSL_SUCCESS.

### DIFF
--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -278,6 +278,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
                 rc = cb(client);
             }
             if (rc != SSL_SUCCESS) {
+                rc = MQTT_CODE_ERROR_TLS_CONNECT;
                 goto exit;
             }
         }


### PR DESCRIPTION
Fix to better handle return code handling for TLS callback to make sure its treated as failure if SSL_SUCCESS is not returned.