### PR TITLE
fix for disabling oldnames and FALL_THROUGH on GCC < 7

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -196,25 +196,28 @@ static int mqtt_aws_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 /* Use this callback to setup TLS certificates and verify callbacks */
 static int mqtt_aws_tls_cb(MqttClient* client)
 {
-    int rc = SSL_FAILURE;
+    int rc = WOLFSSL_FAILURE;
 
     client->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
     if (client->tls.ctx) {
-        wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_PEER, mqtt_aws_tls_verify_cb);
+        wolfSSL_CTX_set_verify(client->tls.ctx, WOLFSSL_VERIFY_PEER,
+                               mqtt_aws_tls_verify_cb);
 
         /* Load CA certificate buffer */
         rc = wolfSSL_CTX_load_verify_buffer(client->tls.ctx,
-            (const byte*)root_ca, (long)XSTRLEN(root_ca), SSL_FILETYPE_PEM);
+            (const byte*)root_ca, (long)XSTRLEN(root_ca), WOLFSSL_FILETYPE_PEM);
 
         /* Load Client Cert */
-        if (rc == SSL_SUCCESS)
+        if (rc == WOLFSSL_SUCCESS)
             rc = wolfSSL_CTX_use_certificate_buffer(client->tls.ctx,
-                (const byte*)device_cert, (long)XSTRLEN(device_cert), SSL_FILETYPE_PEM);
+                (const byte*)device_cert, (long)XSTRLEN(device_cert),
+                WOLFSSL_FILETYPE_PEM);
 
         /* Load Private Key */
-        if (rc == SSL_SUCCESS)
+        if (rc == WOLFSSL_SUCCESS)
             rc = wolfSSL_CTX_use_PrivateKey_buffer(client->tls.ctx,
-                (const byte*)device_priv_key, (long)XSTRLEN(device_priv_key), SSL_FILETYPE_PEM);
+                (const byte*)device_priv_key, (long)XSTRLEN(device_priv_key),
+                WOLFSSL_FILETYPE_PEM);
     }
 
     PRINTF("MQTT TLS Setup (%d)", rc);

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -168,14 +168,14 @@ static int SasTokenCreate(char* sasToken, int sasTokenLen)
 {
     int rc;
     const char* encodedKey = AZURE_KEY;
-    byte decodedKey[SHA256_DIGEST_SIZE+1];
+    byte decodedKey[WC_SHA256_DIGEST_SIZE+1];
     word32 decodedKeyLen = (word32)sizeof(decodedKey);
     char deviceName[150]; /* uri */
     char sigData[200]; /* max uri + expiration */
-    byte sig[SHA256_DIGEST_SIZE];
-    byte base64Sig[SHA256_DIGEST_SIZE*2];
+    byte sig[WC_SHA256_DIGEST_SIZE];
+    byte base64Sig[WC_SHA256_DIGEST_SIZE*2];
     word32 base64SigLen = (word32)sizeof(base64Sig);
-    byte encodedSig[SHA256_DIGEST_SIZE*4];
+    byte encodedSig[WC_SHA256_DIGEST_SIZE*4];
     long lTime;
     Hmac hmac;
 
@@ -205,7 +205,7 @@ static int SasTokenCreate(char* sasToken, int sasTokenLen)
     XSNPRINTF(sigData, sizeof(sigData), AZURE_SIG_FMT, deviceName, lTime);
 
     /* HMAC-SHA256 Hash sigData using decoded key */
-    rc = wc_HmacSetKey(&hmac, SHA256, decodedKey, decodedKeyLen);
+    rc = wc_HmacSetKey(&hmac, WC_SHA256, decodedKey, decodedKeyLen);
     if (rc < 0) {
         PRINTF("SasTokenCreate: Hmac setkey failed! %d", rc);
         return rc;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -149,7 +149,7 @@ static int fw_message_build(MQTTCtx *mqttCtx, const char* fwFile,
     word32 keyLen = 0, sigLen = 0;
     FirmwareHeader *header;
     ecc_key eccKey;
-    RNG rng;
+    WC_RNG rng;
 
     wc_InitRng(&rng);
 

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -348,14 +348,15 @@ static int mqtt_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 /* Use this callback to setup TLS certificates and verify callbacks */
 int mqtt_tls_cb(MqttClient* client)
 {
-    int rc = SSL_FAILURE;
+    int rc = WOLFSSL_FAILURE;
 
     client->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
     if (client->tls.ctx) {
-        wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_PEER, mqtt_tls_verify_cb);
+        wolfSSL_CTX_set_verify(client->tls.ctx, WOLFSSL_VERIFY_PEER,
+                               mqtt_tls_verify_cb);
 
 		/* default to success */
-        rc = SSL_SUCCESS;
+        rc = WOLFSSL_SUCCESS;
 
 	#if !defined(NO_CERT)
     #if !defined(NO_FILESYSTEM)
@@ -365,7 +366,8 @@ int mqtt_tls_cb(MqttClient* client)
 	    }
 
         /* If using a client certificate it can be loaded using: */
-        /* rc = wolfSSL_CTX_use_certificate_file(client->tls.ctx, clientCertFile, SSL_FILETYPE_PEM);*/
+        /* rc = wolfSSL_CTX_use_certificate_file(client->tls.ctx,
+         *                              clientCertFile, WOLFSSL_FILETYPE_PEM);*/
     #else
 	    if (mTlsCaFile) {
 	    #if 0
@@ -383,12 +385,14 @@ int mqtt_tls_cb(MqttClient* client)
 	        fclose(file);
 
 	    	/* Load CA certificate buffer */
-	        rc = wolfSSL_CTX_load_verify_buffer(client->tls.ctx, caCertBuf, caCertSize, SSL_FILETYPE_PEM);
+	        rc = wolfSSL_CTX_load_verify_buffer(client->tls.ctx, caCertBuf,
+                                              caCertSize, WOLFSSL_FILETYPE_PEM);
 	    #endif
 	    }
 
         /* If using a client certificate it can be loaded using: */
-        /* rc = wolfSSL_CTX_use_certificate_buffer(client->tls.ctx, clientCertBuf, clientCertSize, SSL_FILETYPE_PEM);*/
+        /* rc = wolfSSL_CTX_use_certificate_buffer(client->tls.ctx,
+         *               clientCertBuf, clientCertSize, WOLFSSL_FILETYPE_PEM);*/
     #endif /* !NO_FILESYSTEM */
     #endif /* !NO_CERT */
     }

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -202,7 +202,7 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
         if (rc < 0) {
         #ifdef WOLFMQTT_DEBUG_SOCKET
             int error = wolfSSL_get_error(client->tls.ssl, 0);
-            if (error != SSL_ERROR_WANT_READ) {
+            if (error != WOLFSSL_ERROR_WANT_READ) {
                 PRINTF("MqttSocket_Read: SSL Error=%d", error);
             }
         #endif
@@ -312,11 +312,11 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
 
             /* Issue callback to allow setup of the wolfSSL_CTX and cert
                verification settings */
-            rc = SSL_SUCCESS;
+            rc = WOLFSSL_SUCCESS;
             if (cb) {
                 rc = cb(client);
             }
-            if (rc != SSL_SUCCESS) {
+            if (rc != WOLFSSL_SUCCESS) {
                 rc = MQTT_CODE_ERROR_TLS_CONNECT;
                 goto exit;
             }
@@ -330,7 +330,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
                 rc = -1;
                 goto exit;
             }
-            wolfSSL_CTX_set_verify(client->tls.ctx, SSL_VERIFY_NONE, 0);
+            wolfSSL_CTX_set_verify(client->tls.ctx, WOLFSSL_VERIFY_NONE, 0);
         }
 
     #ifndef NO_DH
@@ -357,7 +357,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         }
 
         rc = wolfSSL_connect(client->tls.ssl);
-        if (rc != SSL_SUCCESS) {
+        if (rc != WOLFSSL_SUCCESS) {
             goto exit;
         }
 
@@ -374,8 +374,8 @@ exit:
         int errnum = 0;
         if (client->tls.ssl) {
             errnum = wolfSSL_get_error(client->tls.ssl, 0);
-            if ((errnum == SSL_ERROR_WANT_READ) ||
-                (errnum == SSL_ERROR_WANT_WRITE)) {
+            if ((errnum == WOLFSSL_ERROR_WANT_READ) ||
+                (errnum == WOLFSSL_ERROR_WANT_WRITE)) {
                 return MQTT_CODE_CONTINUE;
             }
         #ifndef WOLFMQTT_NO_STDIO

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -185,14 +185,14 @@ enum MqttPacketResponseCodes {
 #endif
 
 /* GCC 7 has new switch() fall-through detection */
-#ifndef FALL_THROUGH
-    #if defined(__GNUC__)
-        #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
-            #define FALL_THROUGH __attribute__ ((fallthrough));
-        #endif
+/* default to FALL_THROUGH stub */
+#define FALL_THROUGH
+
+#if defined(__GNUC__)
+    #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
+        #undef  FALL_THROUGH
+        #define FALL_THROUGH __attribute__ ((fallthrough));
     #endif
-#else
-    #define FALL_THROUGH
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR:

1)  Fixes wolfMQTT build when compiled against wolfSSL with "--disable-oldnames" defined.

2)  Fixes FALL_THROUGH, where __GNUC__ is defined, but is less than version 7.