### PR TITLE
feature for disable-errorstrings and change macro name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,19 @@ AC_ARG_ENABLE([examples],
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
 
 
+# Error strings 
+AC_ARG_ENABLE([errorstrings],
+    [  --enable-errorstrings       Enable Error Strings  (default: enabled)],
+    [ ENABLED_ERROR_STRINGS=$enableval ],
+    [ ENABLED_ERROR_STRINGS=yes ]
+    )
+
+if test "x$ENABLED_ERROR_STRINGS" = "xno"
+then
+    AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFMQTT_NO_ERROR_STRINGS"
+fi
+
+
 # STDIN / FGETS for examples
 AC_ARG_ENABLE([stdincap],
     [  --enable-stdincap       Enable examplesSTDIN capture  (default: enabled)],
@@ -198,4 +211,5 @@ echo "   * TLS:                       $ENABLED_TLS"
 echo "   * Non-Blocking:              $ENABLED_NONBLOCK"
 echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * STDIN Capture:             $ENABLED_STDINCAP"
+echo "   * Error Strings:             $ENABLED_ERROR_STRINGS"
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -633,6 +633,7 @@ int MqttClient_NetDisconnect(MqttClient *client)
     return MqttSocket_Disconnect(client);
 }
 
+#ifndef WOLFMQTT_NO_ERROR_STRINGS
 const char* MqttClient_ReturnCodeToString(int return_code)
 {
     switch(return_code) {
@@ -665,4 +666,5 @@ const char* MqttClient_ReturnCodeToString(int return_code)
     }
     return "Unknown";
 }
+#endif /* !WOLFMQTT_NO_ERROR_STRINGS */
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -370,7 +370,7 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
 exit:
     /* Handle error case */
     if (rc) {
-    #ifndef WOLFMQTT_NO_STDIO
+    #ifdef WOLFMQTT_DEBUG_SOCKET
     	const char* errstr = NULL;
     #endif
         int errnum = 0;
@@ -380,15 +380,15 @@ exit:
                 (errnum == WOLFSSL_ERROR_WANT_WRITE)) {
                 return MQTT_CODE_CONTINUE;
             }
-        #ifndef WOLFMQTT_NO_STDIO
+        #ifdef WOLFMQTT_DEBUG_SOCKET
             errstr = wolfSSL_ERR_reason_error_string(errnum);
         #endif
         }
 
-    #ifndef WOLFMQTT_NO_STDIO
+    #ifdef WOLFMQTT_DEBUG_SOCKET
         PRINTF("MqttSocket_TlsConnect Error %d: Num %d, %s",
             rc, errnum, errstr);
-    #endif /* WOLFMQTT_NO_STDIO */
+    #endif /* WOLFMQTT_DEBUG_SOCKET */
 
         /* Make sure we cleanup on error */
         MqttSocket_Disconnect(client);

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -256,13 +256,17 @@ WOLFMQTT_API int MqttClient_NetConnect(
 WOLFMQTT_API int MqttClient_NetDisconnect(
     MqttClient *client);
 
+#ifndef WOLFMQTT_NO_ERROR_STRINGS
 /*! \brief      Performs lookup of the WOLFMQTT_API return values
  *  \param      return_code The return value from a WOLFMQTT_API function
  *  \return     String representation of the return code
  */
 WOLFMQTT_API const char* MqttClient_ReturnCodeToString(
     int return_code);
-
+#else
+    #define MqttClient_ReturnCodeToString(x) \
+                                        "no support for error strings built in"
+#endif /* WOLFMQTT_NO_ERROR_STRINGS */
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Note that these commits were created with --no-verify flag. I could run the ./pre-commit.sh though on the code.