### PR TITLE
Improvements to the message callback to support a custom context

### DIFF
--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -104,12 +104,12 @@ typedef struct _MqttClient {
     MqttPkRead   packet;
     MqttSk       read;
     MqttSk       write;
-    word16       packet_id;
 
     MqttMsgCb    msg_cb;
-    MqttMessage  msg;   /* temp incomming message */
+    MqttMessage  msg;   /* temp incomming message
+                         * Used for MqttClient_Ping and MqttClient_WaitType */
 
-    void*        ctx;
+    void*        ctx;   /* user supplied context for publish callbacks */
 } MqttClient;
 
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -73,6 +73,8 @@ typedef struct _MqttMessage {
     byte        buffer_new;   /* flag to indicate new message */
     word32      buffer_len;   /* Buffer length */
     word32      buffer_pos;   /* Buffer position */
+
+    void*       ctx;          /* user supplied context for publish callbacks */
 } MqttMessage;
 
 
@@ -238,6 +240,7 @@ typedef struct _MqttConnectAck {
 
 /* Connect */
 typedef struct _MqttConnect {
+    MqttMsgStat stat;
     word16      keep_alive_sec;
     byte        clean_session;
     const char *client_id;
@@ -278,6 +281,7 @@ typedef struct _MqttPublishResp {
 /* SUBSCRIBE PACKET */
 /* Packet Id followed by contiguous list of topics w/Qos to subscribe to. */
 typedef struct _MqttSubscribe {
+    MqttMsgStat stat;
     word16      packet_id;
     int         topic_count;
     MqttTopic  *topics;


### PR DESCRIPTION
* Improvements to the message callback to support a custom context per message. If the temporary client message is used, then the message context uses the default client context.
* Changed the source for state on connect, subscribe and unsubscribe to use the provided pointer instead of the shared temp client message.
* Removed unused `MqttClient` member for `packet_id` (old code).