### PR TITLE
Fixes and improvements for non-blocking mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,19 @@ else
 fi
 
 
+# Verbose Logging
+AC_ARG_ENABLE([verbose],
+    [AS_HELP_STRING([--enable-verbose],[Enable verbose logging  (default: disabled)])],
+    [ ENABLED_VERBOSE=$enableval ],
+    [ ENABLED_VERBOSE=no ]
+    )
+
+if test "x$ENABLED_VERBOSE" = "xyes"
+then
+    AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFMQTT_DEBUG_CLIENT -DWOLFMQTT_DEBUG_SOCKET"
+fi
+
+
 # TLS Support with wolfSSL
 # Examples, used to disable examples
 AC_ARG_ENABLE([tls],

--- a/configure.ac
+++ b/configure.ac
@@ -93,13 +93,7 @@ fi
 
 
 # Verbose Logging
-AC_ARG_ENABLE([verbose],
-    [AS_HELP_STRING([--enable-verbose],[Enable verbose logging  (default: disabled)])],
-    [ ENABLED_VERBOSE=$enableval ],
-    [ ENABLED_VERBOSE=no ]
-    )
-
-if test "x$ENABLED_VERBOSE" = "xyes"
+if test "x$ax_enable_debug" = "xverbose"
 then
     AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFMQTT_DEBUG_CLIENT -DWOLFMQTT_DEBUG_SOCKET"
 fi

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -342,13 +342,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
 
-            FALL_THROUGH;
-        }
-
-        case WMQ_MQTT_CONN:
-        {
-            mqttCtx->stat = WMQ_MQTT_CONN;
-
+            /* Build connect packet */
             XMEMSET(&mqttCtx->connect, 0, sizeof(MqttConnect));
             mqttCtx->connect.keep_alive_sec = mqttCtx->keep_alive_sec;
             mqttCtx->connect.clean_session = mqttCtx->clean_session;
@@ -370,6 +364,13 @@ int awsiot_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
+
+            FALL_THROUGH;
+        }
+
+        case WMQ_MQTT_CONN:
+        {
+            mqttCtx->stat = WMQ_MQTT_CONN;
 
             /* Send Connect and wait for Connect Ack */
             rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -325,13 +325,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
 
-            FALL_THROUGH;
-        }
-
-        case WMQ_MQTT_CONN:
-        {
-            mqttCtx->stat = WMQ_MQTT_CONN;
-
+            /* Build connect packet */
             XMEMSET(&mqttCtx->connect, 0, sizeof(MqttConnect));
             mqttCtx->connect.keep_alive_sec = mqttCtx->keep_alive_sec;
             mqttCtx->connect.clean_session = mqttCtx->clean_session;
@@ -354,6 +348,13 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             /* Authentication */
             mqttCtx->connect.username = AZURE_USERNAME;
             mqttCtx->connect.password = mqttCtx->buffer.sasToken;
+
+            FALL_THROUGH;
+        }
+
+        case WMQ_MQTT_CONN:
+        {
+            mqttCtx->stat = WMQ_MQTT_CONN;
 
             /* Send Connect and wait for Connect Ack */
             rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -276,13 +276,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
 
-            FALL_THROUGH;
-        }
-
-        case WMQ_MQTT_CONN:
-        {
-            mqttCtx->stat = WMQ_MQTT_CONN;
-
+            /* Build connect packet */
             XMEMSET(&mqttCtx->connect, 0, sizeof(MqttConnect));
             mqttCtx->connect.keep_alive_sec = mqttCtx->keep_alive_sec;
             mqttCtx->connect.clean_session = mqttCtx->clean_session;
@@ -299,6 +293,13 @@ int fwclient_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
+
+            FALL_THROUGH;
+        }
+
+        case WMQ_MQTT_CONN:
+        {
+            mqttCtx->stat = WMQ_MQTT_CONN;
 
             /* Send Connect and wait for Connect Ack */
             rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -351,13 +351,7 @@ int fwpush_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
 
-            FALL_THROUGH;
-        }
-
-        case WMQ_MQTT_CONN:
-        {
-            mqttCtx->stat = WMQ_MQTT_CONN;
-
+            /* Build connect packet */
             XMEMSET(&mqttCtx->connect, 0, sizeof(MqttConnect));
             mqttCtx->connect.keep_alive_sec = mqttCtx->keep_alive_sec;
             mqttCtx->connect.clean_session = mqttCtx->clean_session;
@@ -374,6 +368,13 @@ int fwpush_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
+
+            FALL_THROUGH;
+        }
+
+        case WMQ_MQTT_CONN:
+        {
+            mqttCtx->stat = WMQ_MQTT_CONN;
 
             /* Send Connect and wait for Connect Ack */
             rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -265,6 +265,12 @@ wait_again:
 
             /* Wait for packet */
             rc = MqttPacket_Read(client, client->rx_buf, client->rx_buf_len, timeout_ms);
+        #ifdef WOLFMQTT_NONBLOCK
+            if (rc == MQTT_CODE_CONTINUE) {
+                /* advance state, so we don't reset packet state */
+                msg->stat = MQTT_MSG_WAIT;
+            }
+        #endif
             if (rc <= 0) {
                 return rc;
             }


### PR DESCRIPTION
* Fix for non-blocking issue that causes out of buffer error if not all of packet is received.
* Fix with non-blocking mode sending multiple connect requests for examples.
* Added new `./configure --enable-debug=verbose` option.
* Improved the non-blocking unsubscribe handling in mqttclient example for timeout.