### PR TITLE
Fix for non-blocking to resolve keep alive ping

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -266,7 +266,7 @@ wait_again:
             /* Wait for packet */
             rc = MqttPacket_Read(client, client->rx_buf, client->rx_buf_len, timeout_ms);
         #ifdef WOLFMQTT_NONBLOCK
-            if (rc == MQTT_CODE_CONTINUE) {
+            if (rc == MQTT_CODE_CONTINUE && client->read.pos > 0) {
                 /* advance state, so we don't reset packet state */
                 msg->stat = MQTT_MSG_WAIT;
             }


### PR DESCRIPTION
* Fix for non-blocking to resolve keep alive ping. Only advance state if we've already recevied some data.

To reproduce issue build with non-blocking (`./configure --enable-nonblock --enable-debug=verbose`) and after 30 idle seconds you'll see the timeout message `Keep-alive timeout, sending ping`, but no packet is sent.