### PR TITLE
Fixes to the example Arduino TLS functions

### DIFF
--- a/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
+++ b/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
@@ -86,26 +86,38 @@ static int mqttclient_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store
          store->error, wolfSSL_ERR_error_string(store->error, buffer));
   printf("  Subject's domain name is %s\n", store->domain);
 
-  /* Allowing to continue */
-  /* Should check certificate and return 0 if not okay */
-  printf("  Allowing cert anyways\n");
+  if (store->error != 0) {
+    /* Allowing to continue */
+    /* Should check certificate and return 0 if not okay */
+    printf("  Allowing cert anyways");
+  }
 
   return 1;
 }
 
 static int mqttclient_tls_cb(MqttClient* cli)
 {
-  int rc = SSL_FAILURE;
-  (void)cli; /* Supress un-used argument */
+  int rc = WOLFSSL_FAILURE;
+  
+  cli->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+  if (cli->tls.ctx) {
+    wolfSSL_CTX_set_verify(cli->tls.ctx, SSL_VERIFY_PEER, mqttclient_tls_verify_cb);
 
-  wolfSSL_CTX_set_verify(cli->tls.ctx, SSL_VERIFY_PEER, mqttclient_tls_verify_cb);
+    /* default to success */
+    rc = WOLFSSL_SUCCESS;
 
-  if (mTlsFile) {
-    /* Load CA certificate file */
-    rc = wolfSSL_CTX_load_verify_locations(cli->tls.ctx, mTlsFile, 0);
+    if (mTlsFile) {
+      /* Load CA certificate file */
+      rc = wolfSSL_CTX_load_verify_locations(cli->tls.ctx, mTlsFile, 0);
+    }
   }
   else {
-    rc = SSL_SUCCESS;
+#if 0
+    /* Load CA using buffer */
+    rc = wolfSSL_CTX_load_verify_buffer(cli->tls.ctx, caCertBuf,
+                                        caCertSize, WOLFSSL_FILETYPE_PEM);
+#endif
+    rc = WOLFSSL_SUCCESS;
   }
 
   printf("MQTT TLS Setup (%d)\n", rc);


### PR DESCRIPTION
Fixes to the example Arduino TLS functions to mirror the default example functions `mqtt_tls_cb` and `mqtt_tls_verify_cb` in `mqttexample.c`.