### PR TITLE
Fixed the #define ENABLE_MQTT_TLS issue for libraries, other error fixes

### DIFF
--- a/IDE/ARDUINO/README.md
+++ b/IDE/ARDUINO/README.md
@@ -20,6 +20,8 @@ IDE/ARDUINO directory:
         `IDE/ARDUNIO/wolfMQTT` folder.
     - In `Sketch -> Include Library` choose wolfMQTT.
 
+To enable TLS support, uncomment `#define ENABLE_MQTT_TLS` in
+    `IDE/ARDUNIO/wolfMQTT/wolfmqtt/mqtt_types.h`.
 Note: If using wolfSSL TLS then you'll need to do this for wolfSSL as well.
 See `<wolfssl-root>/IDE/ARDUINO/README.md` for instructions.
 

--- a/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
+++ b/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
@@ -1,15 +1,5 @@
-/* Uncomment this to enable TLS support */
-/* Make sure and include the wolfSSL library */
-//#define ENABLE_MQTT_TLS
-
-#ifdef ENABLE_MQTT_TLS
-#ifdef HAVE_CONFIG
-  #include <config.h>
-#endif
 #include <wolfssl.h>
 #include <wolfssl/ssl.h>
-#endif
-
 #include <wolfMQTT.h>
 #include <Ethernet.h>
 
@@ -232,6 +222,7 @@ void loop() {
   rc = MqttClient_NetConnect(&client, mHost, mPort,
                              DEFAULT_CON_TIMEOUT_MS, use_tls,
 #ifdef ENABLE_MQTT_TLS
+
                              mqttclient_tls_cb
 #else
                              NULL

--- a/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
+++ b/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
@@ -1,5 +1,3 @@
-#include <wolfssl.h>
-#include <wolfssl/ssl.h>
 #include <wolfMQTT.h>
 #include <Ethernet.h>
 
@@ -222,7 +220,6 @@ void loop() {
   rc = MqttClient_NetConnect(&client, mHost, mPort,
                              DEFAULT_CON_TIMEOUT_MS, use_tls,
 #ifdef ENABLE_MQTT_TLS
-
                              mqttclient_tls_cb
 #else
                              NULL

--- a/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
+++ b/IDE/ARDUINO/wolfmqtt_client/wolfmqtt_client.ino
@@ -3,7 +3,9 @@
 //#define ENABLE_MQTT_TLS
 
 #ifdef ENABLE_MQTT_TLS
-#include <config.h>
+#ifdef HAVE_CONFIG
+  #include <config.h>
+#endif
 #include <wolfssl.h>
 #include <wolfssl/ssl.h>
 #endif
@@ -86,26 +88,38 @@ static int mqttclient_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store
          store->error, wolfSSL_ERR_error_string(store->error, buffer));
   printf("  Subject's domain name is %s\n", store->domain);
 
-  /* Allowing to continue */
-  /* Should check certificate and return 0 if not okay */
-  printf("  Allowing cert anyways\n");
+  if (store->error != 0) {
+    /* Allowing to continue */
+    /* Should check certificate and return 0 if not okay */
+    printf("  Allowing cert anyways");
+  }
 
   return 1;
 }
 
 static int mqttclient_tls_cb(MqttClient* cli)
 {
-  int rc = SSL_FAILURE;
-  (void)cli; /* Supress un-used argument */
+  int rc = WOLFSSL_FAILURE;
+  
+  cli->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+  if (cli->tls.ctx) {
+    wolfSSL_CTX_set_verify(cli->tls.ctx, SSL_VERIFY_PEER, mqttclient_tls_verify_cb);
 
-  wolfSSL_CTX_set_verify(cli->tls.ctx, SSL_VERIFY_PEER, mqttclient_tls_verify_cb);
+    /* default to success */
+    rc = WOLFSSL_SUCCESS;
 
-  if (mTlsFile) {
-    /* Load CA certificate file */
-    rc = wolfSSL_CTX_load_verify_locations(cli->tls.ctx, mTlsFile, 0);
+    if (mTlsFile) {
+      /* Load CA certificate file */
+      rc = wolfSSL_CTX_load_verify_locations(cli->tls.ctx, mTlsFile, 0);
+    }
   }
   else {
-    rc = SSL_SUCCESS;
+#if 0
+    /* Load CA using buffer */
+    rc = wolfSSL_CTX_load_verify_buffer(cli->tls.ctx, caCertBuf,
+                                        caCertSize, WOLFSSL_FILETYPE_PEM);
+#endif
+    rc = WOLFSSL_SUCCESS;
   }
 
   printf("MQTT TLS Setup (%d)\n", rc);

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -27,6 +27,10 @@
 #ifndef WOLFMQTT_TYPES_H
 #define WOLFMQTT_TYPES_H
 
+#ifdef ARDUINO
+    #define ENABLE_MQTT_TLS
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -27,8 +27,10 @@
 #ifndef WOLFMQTT_TYPES_H
 #define WOLFMQTT_TYPES_H
 
+/* Uncomment this to enable TLS support */
+/* Make sure and include the wolfSSL library */
 #ifdef ARDUINO
-    #define ENABLE_MQTT_TLS
+    //#define ENABLE_MQTT_TLS
 #endif
 
 #ifdef __cplusplus

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -27,10 +27,16 @@
 #ifndef WOLFMQTT_TYPES_H
 #define WOLFMQTT_TYPES_H
 
+/* configuration for Arduino */
+#ifdef ARDUINO
 /* Uncomment this to enable TLS support */
 /* Make sure and include the wolfSSL library */
-#ifdef ARDUINO
     //#define ENABLE_MQTT_TLS
+
+    /* make sure arduino can see the wolfssl library directory */
+    #ifdef ENABLE_MQTT_TLS
+        #include <wolfssl.h>
+    #endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Now has issue with defining ENABLE_MQTT_TLS in the libraries regardless if it is defined by the user in the sketch.  The WolfSSL library is not included in the sketch when ENABLE_MQTT_TLS is not defined, the libraries throw an error because they try and include files from it