### PR TITLE
Fix for Harmony NetConnect function incorrectly checking EWOULDBLOCK

### DIFF
--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -397,7 +397,7 @@ exit:
 
     /* check for error */
     if (rc != 0) {
-        if (errno == EINPROGRESS || errno = EWOULDBLOCK) {
+        if (errno == EINPROGRESS || errno == EWOULDBLOCK) {
             return MQTT_CODE_CONTINUE;
         }
 


### PR DESCRIPTION
Fixes issue #88.