### PR TITLE
Add a call to set the callback context prior to the connect in MqttSo…

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -264,6 +264,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto exit;
             }
+            /* The client.ctx will be stored in the cert callback ctx during
+               MqttSocket_Connect for use by mqtt_tls_verify_cb */
             mqttCtx->client.ctx = mqttCtx;
 
         #ifdef WOLFMQTT_DISCONNECT_CB

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -352,8 +352,19 @@ int mqtt_check_timeout(int rc, word32* start_sec, word32 timeout_sec)
 static int mqtt_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     char buffer[WOLFSSL_MAX_ERROR_SZ];
+    MQTTCtx *mqttCtx = NULL;
+    char appName[PRINT_BUFFER_SIZE] = {0};
 
-    PRINTF("MQTT TLS Verify Callback: PreVerify %d, Error %d (%s)", preverify,
+    if (store->userCtx != NULL) {
+        /* The client.ctx was stored during MqttSocket_Connect. */
+        mqttCtx = (MQTTCtx *)store->userCtx;
+        XSTRNCPY(appName, " for ", PRINT_BUFFER_SIZE-1);
+        XSTRNCAT(appName, mqttCtx->app_name,
+                 PRINT_BUFFER_SIZE-XSTRLEN(appName)-1);
+    }
+
+    PRINTF("MQTT TLS Verify Callback%s: PreVerify %d, Error %d (%s)",
+        appName, preverify,
         store->error, store->error != 0 ?
             wolfSSL_ERR_error_string(store->error, buffer) : "none");
     PRINTF("  Subject's domain name is %s", store->domain);

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -367,6 +367,11 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         #endif
         }
 
+        if (client->ctx != NULL) {
+            /* Store any app data for use by the tls verify callback*/
+            wolfSSL_SetCertCbCtx(client->tls.ssl, client->ctx);
+        }
+
         rc = wolfSSL_connect(client->tls.ssl);
         if (rc != WOLFSSL_SUCCESS) {
             goto exit;


### PR DESCRIPTION
…cket_Connect

Customer requested feature for a method of passing app data to the wolfMQTT TLS verify callback. The client structure "ctx" pointer is set as the callback context during ```MqttSocket_Connect```, which allows the verify callback to access the ```WOLFSSL_X509_STORE_CTX*```->```useCtx```

Added some code in the verify callback example to print the app name.