### PR TITLE
Initialize subscribe stat to  MQTT_MSG_BEGIN

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -399,6 +399,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -381,6 +381,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -325,6 +325,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = 1;
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -367,6 +367,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
     /* Build list of topics */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+
     i = 0;
     mqttCtx->topics[i].topic_filter = mqttCtx->topic_name;
     mqttCtx->topics[i].qos = mqttCtx->qos;
@@ -383,6 +384,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 #endif
 
     /* Subscribe Topic */
+    mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
     mqttCtx->subscribe.packet_id = mqtt_get_packetid();
     mqttCtx->subscribe.topic_count =
             sizeof(mqttCtx->topics) / sizeof(MqttTopic);

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -235,11 +235,13 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
             /* Build list of topics */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+
             i = 0;
             mqttCtx->topics[i].topic_filter = mqttCtx->topic_name;
             mqttCtx->topics[i].qos = mqttCtx->qos;
 
             /* Subscribe Topic */
+            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count =
                     sizeof(mqttCtx->topics) / sizeof(MqttTopic);

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -220,6 +220,7 @@ int wiot_test(MQTTCtx *mqttCtx)
 
     /* Subscribe Topic */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+    mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
     mqttCtx->subscribe.packet_id = mqtt_get_packetid();
     mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
     mqttCtx->subscribe.topics = mqttCtx->topics;


### PR DESCRIPTION
The `MqttSubscribe` structure is initialized to zero, but that obfuscates the required initial value of the `stat` field, which must be `MQTT_MSG_BEGIN`. This update explicitly sets the value of the `stat` field in all the examples.