### PR TITLE
Add MQTT context information to socket callback examples

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -290,7 +290,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_NET_INIT;
 
             /* Initialize Network */
-            rc = MqttClientNet_Init(&mqttCtx->net);
+            rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -262,7 +262,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_NET_INIT;
 
             /* Initialize Network */
-            rc = MqttClientNet_Init(&mqttCtx->net);
+            rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -219,7 +219,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_NET_INIT;
 
             /* Initialize Network */
-            rc = MqttClientNet_Init(&mqttCtx->net);
+            rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -328,7 +328,7 @@ int fwpush_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_NET_INIT;
 
             /* Initialize Network */
-            rc = MqttClientNet_Init(&mqttCtx->net);
+            rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -219,7 +219,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->use_tls);
 
     /* Initialize Network */
-    rc = MqttClientNet_Init(&mqttCtx->net);
+    rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
     PRINTF("MQTT Net Init: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -26,15 +26,16 @@
     extern "C" {
 #endif
 
+#include "examples/mqttexample.h"
 
 /* Default MQTT host broker to use, when none is specified in the examples */
 #define DEFAULT_MQTT_HOST       "iot.eclipse.org" /* broker.hivemq.com */
 
 /* Functions used to handle the MqttNet structure creation / destruction */
-int MqttClientNet_Init(MqttNet* net);
+int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);
 int MqttClientNet_DeInit(MqttNet* net);
 #ifdef WOLFMQTT_SN
-int SN_ClientNet_Init(MqttNet* net);
+int SN_ClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);
 #endif
 
 #ifdef __cplusplus

--- a/examples/mqttuart.c
+++ b/examples/mqttuart.c
@@ -84,7 +84,7 @@ static int NetDisconnect(void *context)
 }
 
 /* Public Functions */
-int MqttClientNet_Init(MqttNet* net)
+int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
 {
     if (net) {
         XMEMSET(net, 0, sizeof(MqttNet));
@@ -94,6 +94,7 @@ int MqttClientNet_Init(MqttNet* net)
         net->disconnect = NetDisconnect;
         net->context = WOLFMQTT_MALLOC(sizeof(UartContext));
     }
+    (void)mqttCtx;
     return 0;
 }
 

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -119,7 +119,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_NET_INIT;
 
             /* Initialize Network */
-            rc = MqttClientNet_Init(&mqttCtx->net);
+            rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -99,7 +99,7 @@ int sn_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT-SN Client: QoS %d", mqttCtx->qos);
 
     /* Initialize Network */
-    rc = SN_ClientNet_Init(&mqttCtx->net);
+    rc = SN_ClientNet_Init(&mqttCtx->net, mqttCtx);
     PRINTF("MQTT-SN Net Init: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -129,7 +129,7 @@ int wiot_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos, mqttCtx->use_tls);
 
     /* Initialize Network */
-    rc = MqttClientNet_Init(&mqttCtx->net);
+    rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
 
     PRINTF("MQTT Net Init: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);


### PR DESCRIPTION
Adds `MQTTCtx` to the network context, so example socket callback functions include it. These API changes are outside of the wolfMQTT library proper and only apply to the examples.

Fixes #100.