### PR TITLE
Improved the disconnect network error callback example

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -45,11 +45,13 @@ char gClientId[MAX_CLIENT_ID_LEN] = {0};
 #endif
 
 #ifdef WOLFMQTT_DISCONNECT_CB
+/* callback indicates a network error occurred */
 static int mqtt_disconnect_cb(MqttClient* client, int error_code, void* ctx)
 {
     (void)client;
     (void)ctx;
-    PRINTF("Disconnect (error %d)", error_code);
+    PRINTF("Network Error Callback: %s (error %d)",
+        MqttClient_ReturnCodeToString(error_code), error_code);
     return 0;
 }
 #endif

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -41,11 +41,13 @@ static int mStopRead = 0;
 #define TEST_MESSAGE    "test"
 
 #ifdef WOLFMQTT_DISCONNECT_CB
+/* callback indicates a network error occurred */
 static int mqtt_disconnect_cb(MqttClient* client, int error_code, void* ctx)
 {
     (void)client;
     (void)ctx;
-    PRINTF("Disconnect (error %d)", error_code);
+    PRINTF("Network Error Callback: %s (error %d)",
+        MqttClient_ReturnCodeToString(error_code), error_code);
     return 0;
 }
 #endif

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -64,11 +64,13 @@ static int mStopRead = 0;
 #define TEST_MESSAGE    "{\"" WIOT_EVT "\":1}"
 
 #ifdef WOLFMQTT_DISCONNECT_CB
+/* callback indicates a network error occurred */
 static int mqtt_disconnect_cb(MqttClient* client, int error_code, void* ctx)
 {
     (void)client;
     (void)ctx;
-    PRINTF("Disconnect (error %d)", error_code);
+    PRINTF("Network Error Callback: %s (error %d)",
+        MqttClient_ReturnCodeToString(error_code), error_code);
     return 0;
 }
 #endif


### PR DESCRIPTION
Now shows error code and doesn't assume disconnect (can be any network error including timeout).