### PR TITLE
Make MqttSocket_TlsSocket callbacks public

### DIFF
--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -38,9 +38,9 @@
 #endif
 
 
-/* Private Functions */
+/* Public Functions */
 #ifdef ENABLE_MQTT_TLS
-static int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
+int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
     void *ptr)
 {
     int rc;
@@ -63,7 +63,7 @@ static int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
     return rc;
 }
 
-static int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
+int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
     void *ptr)
 {
     int rc;
@@ -86,8 +86,6 @@ static int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
 }
 #endif
 
-
-/* Public Functions */
 int MqttSocket_Init(MqttClient *client, MqttNet *net)
 {
     int rc = MQTT_CODE_ERROR_BAD_ARG;

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -110,6 +110,10 @@ WOLFMQTT_LOCAL int MqttSocket_Connect(struct _MqttClient *client,
         MqttTlsCb cb);
 WOLFMQTT_LOCAL int MqttSocket_Disconnect(struct _MqttClient *client);
 
+#ifdef ENABLE_MQTT_TLS
+int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz, void *ptr);
+int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz, void *ptr);
+#endif
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
The TLS callback that enables the client to set up certificates, etc. can also be used to initialize the ssl structure. But in order for this to work, the calls to setup the async IO callbacks in `MqttSocket_Connect()` would have to occur in the application's TLS callback. This in turn requires that the async IO callbacks, `MqttSocket_TlsSocketReceive()` and `MqttSocket_TlsSocketSend()` be accessible as public functions.