### PR TITLE
Fix MQTT-SN decode publish parsing and QoS2 response

### DIFF
--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -222,7 +222,7 @@ int sn_test(MQTTCtx *mqttCtx)
         /* Publish Topic */
         XMEMSET(&mqttCtx->publish, 0, sizeof(SN_Publish));
         mqttCtx->publish.retain = 0;
-        mqttCtx->publish.qos = MQTT_QOS_1;//mqttCtx->qos;
+        mqttCtx->publish.qos = mqttCtx->qos;
         mqttCtx->publish.duplicate = 0;
         mqttCtx->publish.topic_type = SN_TOPIC_ID_TYPE_NORMAL;
         mqttCtx->publish.topic_name = (char*)&topicID;
@@ -238,9 +238,10 @@ int sn_test(MQTTCtx *mqttCtx)
 
         rc = SN_Client_Publish(&mqttCtx->client, &mqttCtx->publish);
 
-        PRINTF("MQTT-SN Publish: topic id = %d, msg = \"%s\", rc = %d",
-            (word16)*mqttCtx->publish.topic_name, mqttCtx->publish.buffer,
-            mqttCtx->publish.return_code);
+        PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
+            (word16)*mqttCtx->publish.topic_name,
+                mqttCtx->publish.return_code,
+                mqttCtx->publish.buffer);
         if (rc != MQTT_CODE_SUCCESS) {
             goto disconn;
         }
@@ -283,9 +284,10 @@ int sn_test(MQTTCtx *mqttCtx)
                 mqttCtx->publish.total_len = (word16)rc;
                 rc = SN_Client_Publish(&mqttCtx->client,
                        &mqttCtx->publish);
-                PRINTF("MQTT-SN Publish: topic id = %d, msg = \"%s\", rc = %d",
-                    (word16)*mqttCtx->publish.topic_name, mqttCtx->publish.buffer,
-                    mqttCtx->publish.return_code);
+                PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
+                    (word16)*mqttCtx->publish.topic_name,
+                        mqttCtx->publish.return_code,
+                        mqttCtx->publish.buffer);
                 if (rc != MQTT_CODE_SUCCESS) {
                     break;
                 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1236,10 +1236,13 @@ static int SN_Client_HandlePayload(MqttClient* client, MqttMessage* msg,
             if (msg->type == SN_MSG_TYPE_PUBREC ||
                 msg->type == SN_MSG_TYPE_PUBREL) {
 
+                byte resp_type = (msg->type == SN_MSG_TYPE_PUBREC) ?
+                        SN_MSG_TYPE_PUBREL : SN_MSG_TYPE_PUBCOMP;
+
                 /* Encode publish response */
                 publish_resp.packet_id = p_publish_resp->packet_id;
                 rc = SN_Encode_PublishResp(client->tx_buf,
-                    client->tx_buf_len, msg->type+1, &publish_resp);
+                    client->tx_buf_len, resp_type, &publish_resp);
                 if (rc <= 0) {
                     return rc;
                 }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2551,14 +2551,16 @@ int SN_Decode_Publish(byte *rx_buf, int rx_buf_len, MqttPublish *publish)
 
     flags = *rx_payload++;
 
-    rx_payload += MqttDecode_Num(rx_payload, (word16*)publish->topic_name);
+    publish->topic_name = (char*)rx_payload;
+    rx_payload += MQTT_DATA_LEN_SIZE;
 
     rx_payload += MqttDecode_Num(rx_payload, &publish->packet_id);
 
     /* Set flags */
     publish->duplicate = flags & SN_PACKET_FLAG_DUPLICATE;
 
-    publish->qos = (MqttQoS)((flags >> SN_PACKET_FLAG_QOS_SHIFT) & SN_PACKET_FLAG_QOS_MASK);
+    publish->qos = (MqttQoS)((flags & SN_PACKET_FLAG_QOS_MASK) >>
+            SN_PACKET_FLAG_QOS_SHIFT);
 
     publish->retain = flags & SN_PACKET_FLAG_RETAIN;
 


### PR DESCRIPTION
Fixes for the following issues in MQTT-SN:
* when a publish message is received, the response to PUBREL (0x10) is not RESERVED (0x11) but PUBCOMP (0x0E)
* topic_name and qos are not correctly set, topic_name_len is not set

Also fixes minor display issue in SN example.