### PR TITLE
Multithread support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ examples/wiot/wiot
 wolfmqtt/options.h
 /IDE/Microchip-Harmony/wolfmqtt_client/firmware/mqtt_client.X/dist/default/
 examples/sn-client/sn-client
+examples/multithread/multithread

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ This example enables the wolfMQTT client to connect to the IBM Watson Internet o
 ### MQTT-SN Example
 The Sensor Network client implements the MQTT-SN protocol for low-bandwidth networks. There are several differences from MQTT, including the ability to use a two byte Topic ID instead the full topic during subscribe and publish. The SN client requires an MQTT-SN gateway. The gateway acts as an intermediary between the SN clients and the broker. This client was tested with the Eclipse Paho MQTT-SN Gateway, which connects by default to the public Eclipse broker, much like our wolfMQTT Client example. The address of the gateway must be configured as the host. The example is located in `/examples/sn-client/`.
 
+### Multithread Example
+This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 
+ 
 ## Specification Support
 
 ### MQTT v3.1.1 Specification Support

--- a/commit-tests.sh
+++ b/commit-tests.sh
@@ -62,4 +62,15 @@ make -j 8 test;
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mqtt5 --enable-propcb' make test failed " && exit 1
 
+
+# make sure multithread is okay
+echo -e "\n\nTesting multithread config...\n\n"
+./configure --enable-mt;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt' failed" && exit 1
+
+make -j 8 test;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt' make test failed " && exit 1
+
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,19 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_DISCONNECT_CB"
 fi
 
+# Multithread support
+AC_ARG_ENABLE([mt],
+    [AS_HELP_STRING([--enable-mt],[Enable multiple thread support (default: disabled)])],
+    [ ENABLED_MULTITHREAD=$enableval ],
+    [ ENABLED_MULTITHREAD=no ]
+    )
 
+if test "x$ENABLED_MULTITHREAD" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_MULTITHREAD"
+fi
+
+AM_CONDITIONAL([BUILD_MULTITHREAD], [test "x$ENABLED_MULTITHREAD" = "xyes"])
 
 # HARDEN FLAGS
 AX_HARDEN_CC_COMPILER_FLAGS
@@ -358,4 +370,5 @@ echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * Non-Blocking:              $ENABLED_NONBLOCK"
 echo "   * STDIN Capture:             $ENABLED_STDINCAP"
 echo "   * TLS:                       $ENABLED_TLS"
+echo "   * Multi-thread:              $ENABLED_MULTITHREAD"
 

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -605,6 +605,8 @@ exit:
 
         /* Cleanup network */
         MqttClientNet_DeInit(&mqttCtx->net);
+
+        MqttClient_DeInit(&mqttCtx->client);
     }
 
     return rc;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -580,6 +580,8 @@ exit:
 
         /* Cleanup network */
         MqttClientNet_DeInit(&mqttCtx->net);
+
+        MqttClient_DeInit(&mqttCtx->client);
     }
 
     return rc;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -481,6 +481,8 @@ exit:
 
         /* Cleanup network */
         MqttClientNet_DeInit(&mqttCtx->net);
+
+        MqttClient_DeInit(&mqttCtx->client);
     }
 
     return rc;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -543,6 +543,8 @@ exit:
 
         /* Cleanup network */
         MqttClientNet_DeInit(&mqttCtx->net);
+
+        MqttClient_DeInit(&mqttCtx->client);
     }
 
     return rc;

--- a/examples/include.am
+++ b/examples/include.am
@@ -9,6 +9,9 @@ noinst_PROGRAMS += examples/mqttclient/mqttclient \
                    examples/azure/azureiothub \
                    examples/aws/awsiot \
                    examples/wiot/wiot
+if BUILD_MULTITHREAD
+noinst_PROGRAMS += examples/multithread/multithread
+endif
 if BUILD_SN
 noinst_PROGRAMS += examples/sn-client/sn-client
 endif
@@ -23,6 +26,9 @@ noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
                    examples/wiot/wiot.h \
                    examples/mqttnet.h \
                    examples/mqttexample.h
+if BUILD_MULTITHREAD
+noinst_HEADERS +=  examples/multithread/multithread.h
+endif
 if BUILD_SN
 noinst_HEADERS +=  examples/sn-client/sn-client.h
 endif
@@ -34,6 +40,14 @@ examples_mqttclient_mqttclient_LDADD        = src/libwolfmqtt.la
 examples_mqttclient_mqttclient_DEPENDENCIES = src/libwolfmqtt.la
 examples_mqttclient_mqttclient_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
+if BUILD_MULTITHREAD
+examples_multithread_multithread_SOURCES      = examples/multithread/multithread.c \
+                                                examples/mqttnet.c \
+                                                examples/mqttexample.c
+examples_multithread_multithread_LDADD        = src/libwolfmqtt.la
+examples_multithread_multithread_DEPENDENCIES = src/libwolfmqtt.la
+examples_multithread_multithread_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
+endif
 
 examples_nbclient_nbclient_SOURCES = examples/nbclient/nbclient.c \
                                                examples/mqttnet.c \
@@ -101,6 +115,9 @@ dist_example_DATA+= examples/mqttnet.c \
                     examples/azure/azureiothub.c \
                     examples/aws/awsiot.c \
                     examples/wiot/wiot.c
+if BUILD_MULTITHREAD
+dist_example_DATA+= examples/multithread/multithread.c
+endif
 if BUILD_SN
 dist_example_DATA+= examples/sn-client/sn-client.c
 endif
@@ -112,6 +129,9 @@ DISTCLEANFILES+=   examples/mqttclient/.libs/mqttclient \
                    examples/azure/.libs/azureiothub \
                    examples/aws/.libs/awsiot \
                    examples/wiot/.libs/wiot
+if BUILD_MULTITHREAD
+DISTCLEANFILES+=   examples/multithread/.libs/multithread
+endif
 if BUILD_SN
 DISTCLEANFILES+=   examples/sn-client/.libs/sn-client
 endif
@@ -125,3 +145,4 @@ EXTRA_DIST+=       examples/mqttuart.c \
                    examples/aws/awsiot.vcxproj \
                    examples/wiot/wiot.vcxproj \
                    examples/sn-client/sn-client.vcxproj
+#                   examples/multithread/multithread.vcxproj

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -572,6 +572,8 @@ exit:
     /* Cleanup network */
     MqttClientNet_DeInit(&mqttCtx->net);
 
+    MqttClient_DeInit(&mqttCtx->client);
+
     return rc;
 }
 

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -30,7 +30,7 @@
 
 
 /* locals */
-static int mPacketIdLast;
+static volatile word16 mPacketIdLast;
 
 /* argument parsing */
 static int myoptind = 0;
@@ -297,9 +297,12 @@ int err_sys(const char* msg)
 
 word16 mqtt_get_packetid(void)
 {
-    mPacketIdLast = (mPacketIdLast >= MAX_PACKET_ID) ?
-        1 : mPacketIdLast + 1;
-    return (word16)mPacketIdLast;
+    /* Check rollover */
+    if (mPacketIdLast >= MAX_PACKET_ID) {
+        mPacketIdLast = 0;
+    }
+
+    return ++mPacketIdLast;
 }
 
 #ifdef WOLFMQTT_NONBLOCK

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -1,6 +1,6 @@
-/* wiot.c
+/* multithread.c
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfMQTT.
  *
@@ -19,12 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-/* This example enables the wolfMQTT client to connect to the IBM Watson
- * Internet of Things (WIOT) Platform. The WIOT Platform has a limited test
- * broker called "Quickstart" that allows non-secure connections to
- * exercise the component.
- */
-
 /* Include the autoconf generated config.h */
 #ifdef HAVE_CONFIG_H
     #include <config.h>
@@ -32,36 +26,27 @@
 
 #include "wolfmqtt/mqtt_client.h"
 
-#include "wiot.h"
-#include "examples/mqttexample.h"
+#include "multithread.h"
 #include "examples/mqttnet.h"
+#ifdef WOLFMQTT_MULTITHREAD
+    #include <pthread.h>
+#endif
 
 /* Locals */
 static int mStopRead = 0;
 
-/* Configuration */
-#define MAX_BUFFER_SIZE 1024 /* Maximum size for network read/write callbacks */
-
-/* Undefine if using an IBM WIOT Platform account that you created. */
-#define WIOT_USE_QUICKSTART
-
-#define WIOT_DEV_TYPE   "wolfMQTT"
-#define WIOT_DEV_ID     "wolftestid"
-#define WIOT_EVT        "sensor"
-#define WIOT_TOPIC_NAME "iot-2/type/" WIOT_DEV_TYPE "/id/" WIOT_DEV_ID "/evt/" WIOT_EVT "/fmt/json"
-
-#ifdef  WIOT_USE_QUICKSTART
-#define WIOT_ORG_ID     "quickstart" /* The Quickstart broker does not support authentication */
-#define WIOT_CLIENT_ID  "a:" WIOT_ORG_ID ":" WIOT_DEV_ID
-#else
-#define WIOT_ORG_ID     "your org id" /* Replace with your WIOT Organization ID. */
-#define WIOT_USER_NAME  "use-token-auth"
-#define WIOT_PASSWORD   "your device token" /* Replace with your device token */
-#define WIOT_CLIENT_ID  "d:" WIOT_ORG_ID ":" WIOT_DEV_TYPE ":" WIOT_DEV_ID
+#ifdef WOLFMQTT_MULTITHREAD
+static wolfSSL_Mutex demoLock; /* Protect access to mqtt_get_packetid() */
 #endif
 
-#define WIOT_MQTT_HOST  WIOT_ORG_ID ".messaging.internetofthings.ibmcloud.com"
-#define TEST_MESSAGE    "{\"" WIOT_EVT "\":1}"
+/* Configuration */
+
+/* Maximum size for network read/write callbacks. There is also a v5 define that
+   describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+#define MAX_BUFFER_SIZE 1024
+#define TEST_MESSAGE    "test00"
+/* Number of publish tasks. Each will send a unique message to the broker. */
+#define NUM_PUB_TASKS   10
 
 #ifdef WOLFMQTT_DISCONNECT_CB
 /* callback indicates a network error occurred */
@@ -75,13 +60,14 @@ static int mqtt_disconnect_cb(MqttClient* client, int error_code, void* ctx)
 }
 #endif
 
+#ifdef WOLFMQTT_MULTITHREAD
 static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     byte msg_new, byte msg_done)
 {
     byte buf[PRINT_BUFFER_SIZE+1];
     word32 len;
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
-
+    static int num_msgs_recvd;
     (void)mqttCtx;
 
     if (msg_new) {
@@ -97,11 +83,17 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         PRINTF("MQTT Message: Topic %s, Qos %d, Len %u",
             buf, msg->qos, msg->total_len);
 
-        /* for test mode: check if TEST_MESSAGE was received */
+        /* for test mode: count the number of TEST_MESSAGE matches received */
         if (mqttCtx->test_mode) {
             if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
-                XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer, msg->buffer_len) == 0) {
-                mStopRead = 1;
+                /* Only compare the "test" part */
+                XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer,
+                         msg->buffer_len-3) == 0)
+            {
+                num_msgs_recvd++;
+                if (num_msgs_recvd == NUM_PUB_TASKS) {
+                    mStopRead = 1;
+                }
             }
         }
     }
@@ -124,19 +116,60 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     return MQTT_CODE_SUCCESS;
 }
 
-int wiot_test(MQTTCtx *mqttCtx)
+static void client_exit(MQTTCtx *mqttCtx)
 {
-    int rc = MQTT_CODE_SUCCESS, i;
+    /* Free resources */
+    if (mqttCtx->tx_buf) WOLFMQTT_FREE(mqttCtx->tx_buf);
+    if (mqttCtx->rx_buf) WOLFMQTT_FREE(mqttCtx->rx_buf);
 
-    PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos, mqttCtx->use_tls);
+    /* Cleanup network */
+    MqttClientNet_DeInit(&mqttCtx->net);
+
+    MqttClient_DeInit(&mqttCtx->client);
+}
+
+static void client_disconnect(MQTTCtx *mqttCtx)
+{
+    int rc;
+
+    do {
+        /* Disconnect */
+        rc = MqttClient_Disconnect_ex(&mqttCtx->client,
+               &mqttCtx->disconnect);
+
+        PRINTF("MQTT Disconnect: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    } while (rc != MQTT_CODE_SUCCESS);
+
+    rc = MqttClient_NetDisconnect(&mqttCtx->client);
+
+    PRINTF("MQTT Socket Disconnect: %s (%d)",
+        MqttClient_ReturnCodeToString(rc), rc);
+
+    client_exit(mqttCtx);
+}
+
+static int multithread_test_init(MQTTCtx *mqttCtx)
+{
+    int rc = MQTT_CODE_SUCCESS;
+
+    /* Create a demo mutex for making packet id values */
+    rc = wc_InitMutex(&demoLock);
+    if (rc != 0) {
+        client_exit(mqttCtx);
+    }
+
+    PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos,
+            mqttCtx->use_tls);
+
+    PRINTF("Use \"Ctrl+c\" to exit.");
 
     /* Initialize Network */
     rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
-
     PRINTF("MQTT Net Init: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto exit;
+        client_exit(mqttCtx);
     }
 
     /* setup tx/rx buffers */
@@ -153,8 +186,10 @@ int wiot_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT Init: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto exit;
+        client_exit(mqttCtx);
     }
+    /* The client.ctx will be stored in the cert callback ctx during
+       MqttSocket_Connect for use by mqtt_tls_verify_cb */
     mqttCtx->client.ctx = mqttCtx;
 
 #ifdef WOLFMQTT_DISCONNECT_CB
@@ -162,18 +197,19 @@ int wiot_test(MQTTCtx *mqttCtx)
     rc = MqttClient_SetDisconnectCallback(&mqttCtx->client,
         mqtt_disconnect_cb, NULL);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto exit;
+        client_exit(mqttCtx);
     }
 #endif
 
     /* Connect to broker */
-    rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host, mqttCtx->port,
+    rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host,
+           mqttCtx->port,
         DEFAULT_CON_TIMEOUT_MS, mqttCtx->use_tls, mqtt_tls_cb);
 
     PRINTF("MQTT Socket Connect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto exit;
+        client_exit(mqttCtx);
     }
 
     /* Build connect packet */
@@ -193,7 +229,8 @@ int wiot_test(MQTTCtx *mqttCtx)
         mqttCtx->lwt_msg.retain = 0;
         mqttCtx->lwt_msg.topic_name = WOLFMQTT_TOPIC_NAME"lwttopic";
         mqttCtx->lwt_msg.buffer = (byte*)mqttCtx->client_id;
-        mqttCtx->lwt_msg.total_len = (word16)XSTRLEN(mqttCtx->client_id);
+        mqttCtx->lwt_msg.total_len =
+          (word16)XSTRLEN(mqttCtx->client_id);
     }
     /* Optional authentication */
     mqttCtx->connect.username = mqttCtx->username;
@@ -205,7 +242,7 @@ int wiot_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT Connect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
+        client_disconnect(mqttCtx);
     }
 
     /* Validate Connect Ack info */
@@ -216,29 +253,48 @@ int wiot_test(MQTTCtx *mqttCtx)
             1 : 0
     );
 
+    return rc;
+}
+
+static int multithread_test_finish(MQTTCtx *mqttCtx)
+{
+    client_disconnect(mqttCtx);
+    wc_FreeMutex(&demoLock);
+
+    return mqttCtx->return_code;
+}
+
+/* This task subscribes to a topic and waits for messages */
+static void *waitMessage_task(void *param)
+{
+    int rc, i;
+    MQTTCtx *mqttCtx = param;
+
     /* Build list of topics */
-    mqttCtx->topics[0].topic_filter = mqttCtx->topic_name;
-    mqttCtx->topics[0].qos = mqttCtx->qos;
+    XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
+
+    i = 0;
+    mqttCtx->topics[i].topic_filter = mqttCtx->topic_name;
+    mqttCtx->topics[i].qos = mqttCtx->qos;
 
     /* Subscribe Topic */
-    XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
     mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
+
+    /* Get the demo lock */
+    wc_LockMutex(&demoLock);
     mqttCtx->subscribe.packet_id = mqtt_get_packetid();
-    mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
+    wc_UnLockMutex(&demoLock);
+
+    mqttCtx->subscribe.topic_count =
+            sizeof(mqttCtx->topics) / sizeof(MqttTopic);
     mqttCtx->subscribe.topics = mqttCtx->topics;
-#ifdef WIOT_USE_QUICKSTART
-    /* Print web site URL to monitor client activity */
-    PRINTF("\r\nTo view the published sample data visit:");
-    PRINTF("https://" WIOT_ORG_ID ".internetofthings.ibmcloud.com/#/device/" WIOT_DEV_ID "/" WIOT_EVT "/");
-    PRINTF("\r\n");
-#endif
 
     rc = MqttClient_Subscribe(&mqttCtx->client, &mqttCtx->subscribe);
 
     PRINTF("MQTT Subscribe: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
+        client_disconnect(mqttCtx);
     }
 
     /* show subscribe results */
@@ -249,63 +305,18 @@ int wiot_test(MQTTCtx *mqttCtx)
             mqttCtx->topic->qos, mqttCtx->topic->return_code);
     }
 
-    /* Publish Topic */
-    XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
-    mqttCtx->publish.retain = 0;
-    mqttCtx->publish.qos = mqttCtx->qos;
-    mqttCtx->publish.duplicate = 0;
-    mqttCtx->publish.topic_name = mqttCtx->topic_name;
-    mqttCtx->publish.packet_id = mqtt_get_packetid();
-    mqttCtx->publish.buffer = (byte*)TEST_MESSAGE;
-    mqttCtx->publish.total_len = (word16)XSTRLEN(TEST_MESSAGE);
-
-    rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-
-    PRINTF("MQTT Publish: Topic %s, %s (%d)",
-        mqttCtx->publish.topic_name, MqttClient_ReturnCodeToString(rc), rc);
-    if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
-    }
-
     /* Read Loop */
     PRINTF("MQTT Waiting for message...");
 
     do {
         /* Try and read packet */
-        rc = MqttClient_WaitMessage(&mqttCtx->client,
-                                            mqttCtx->cmd_timeout_ms);
+        rc = MqttClient_WaitMessage(&mqttCtx->client, mqttCtx->cmd_timeout_ms);
 
         /* check for test mode */
         if (mStopRead) {
-            rc = MQTT_CODE_SUCCESS;
             PRINTF("MQTT Exiting...");
             break;
         }
-
-        /* check return code */
-    #ifdef WOLFMQTT_ENABLE_STDIN_CAP
-        else if (rc == MQTT_CODE_STDIN_WAKE) {
-            XMEMSET(mqttCtx->rx_buf, 0, MAX_BUFFER_SIZE);
-            if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE - 1, stdin) != NULL) {
-                rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
-
-                /* Publish Topic */
-                mqttCtx->stat = WMQ_PUB;
-                XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
-                mqttCtx->publish.retain = 0;
-                mqttCtx->publish.qos = mqttCtx->qos;
-                mqttCtx->publish.duplicate = 0;
-                mqttCtx->publish.topic_name = mqttCtx->topic_name;
-                mqttCtx->publish.packet_id = mqtt_get_packetid();
-                mqttCtx->publish.buffer = mqttCtx->rx_buf;
-                mqttCtx->publish.total_len = (word16)rc;
-                rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
-                    MqttClient_ReturnCodeToString(rc), rc);
-            }
-        }
-    #endif
         else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
             /* Keep Alive */
             PRINTF("Keep-alive timeout, sending ping");
@@ -323,56 +334,98 @@ int wiot_test(MQTTCtx *mqttCtx)
                 MqttClient_ReturnCodeToString(rc), rc);
             break;
         }
-    } while (1);
+    } while(!mStopRead);
 
-    /* Check for error */
-    if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
-    }
 
     /* Unsubscribe Topics */
     XMEMSET(&mqttCtx->unsubscribe, 0, sizeof(MqttUnsubscribe));
+
+    /* Get the demo lock */
+    wc_LockMutex(&demoLock);
     mqttCtx->unsubscribe.packet_id = mqtt_get_packetid();
+    wc_UnLockMutex(&demoLock);
+
     mqttCtx->unsubscribe.topic_count =
         sizeof(mqttCtx->topics) / sizeof(MqttTopic);
     mqttCtx->unsubscribe.topics = mqttCtx->topics;
 
     /* Unsubscribe Topics */
-    rc = MqttClient_Unsubscribe(&mqttCtx->client, &mqttCtx->unsubscribe);
+    rc = MqttClient_Unsubscribe(&mqttCtx->client,
+           &mqttCtx->unsubscribe);
 
     PRINTF("MQTT Unsubscribe: %s (%d)",
-            MqttClient_ReturnCodeToString(rc), rc);
-    if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
-    }
+        MqttClient_ReturnCodeToString(rc), rc);
+
     mqttCtx->return_code = rc;
 
-disconn:
-    /* Disconnect */
-    rc = MqttClient_Disconnect(&mqttCtx->client);
-
-    PRINTF("MQTT Disconnect: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
-
-    rc = MqttClient_NetDisconnect(&mqttCtx->client);
-
-    PRINTF("MQTT Socket Disconnect: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
-
-exit:
-
-    /* Free resources */
-    if (mqttCtx->tx_buf) WOLFMQTT_FREE(mqttCtx->tx_buf);
-    if (mqttCtx->rx_buf) WOLFMQTT_FREE(mqttCtx->rx_buf);
-
-    /* Cleanup network */
-    MqttClientNet_DeInit(&mqttCtx->net);
-
-    MqttClient_DeInit(&mqttCtx->client);
-
-    return rc;
+    pthread_exit(NULL);
 }
 
+/* This task publishes a message to the broker. The task will be created
+   NUM_PUB_TASKS times, sending a unique message each time. */
+static void *publish_task(void *param)
+{
+    int rc;
+    char buf[7];
+    MQTTCtx *mqttCtx = param;
+    MqttPublish publish;
+
+    /* Publish Topic */
+    XMEMSET(&publish, 0, sizeof(MqttPublish));
+    publish.retain = 0;
+    publish.qos = mqttCtx->qos;
+    publish.duplicate = 0;
+    publish.topic_name = mqttCtx->topic_name;
+
+    /* Get the demo lock */
+    wc_LockMutex(&demoLock);
+    publish.packet_id = mqtt_get_packetid();
+    wc_UnLockMutex(&demoLock);
+
+    XSTRNCPY(buf, TEST_MESSAGE, sizeof(buf));
+    buf[4] = '0' + ((publish.packet_id / 10) % 10);
+    buf[5] = '0' + (publish.packet_id % 10);
+    publish.buffer = (byte*)buf;
+    publish.total_len = (word16)XSTRLEN(buf);
+
+    rc = MqttClient_Publish(&mqttCtx->client, &publish);
+
+    PRINTF("MQTT Publish: Topic %s, %s (%d)",
+        publish.topic_name,
+        MqttClient_ReturnCodeToString(rc), rc);
+
+    pthread_exit(NULL);
+}
+
+int multithread_test(MQTTCtx *mqttCtx)
+{
+    int rc = 0;
+    int i;
+    pthread_t waitMessage_thread;
+    pthread_t publish_thread[NUM_PUB_TASKS];
+
+    rc = multithread_test_init(mqttCtx);
+
+    if (rc == 0) {
+        /* Create the thread that waits for messages */
+        pthread_create(&waitMessage_thread, NULL, waitMessage_task, mqttCtx);
+
+        for (i = 0; i < NUM_PUB_TASKS; i++) {
+            /* Create threads that publish unique messages */
+            pthread_create(&publish_thread[i], NULL, publish_task, mqttCtx);
+        }
+
+        pthread_join(waitMessage_thread, NULL);
+
+        for (i = 0; i < NUM_PUB_TASKS; i++) {
+            pthread_join(publish_thread[i], NULL);
+        }
+
+        rc = multithread_test_finish(mqttCtx);
+    }
+    return rc;
+}
+#endif
 
 /* so overall tests can pull in test function */
 #if !defined(NO_MAIN_DRIVER) && !defined(MICROCHIP_MPLAB_HARMONY)
@@ -402,29 +455,23 @@ exit:
 int main(int argc, char** argv)
 {
     int rc;
-#ifndef WOLFMQTT_NONBLOCK
+#if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
     MQTTCtx mqttCtx;
 
     /* init defaults */
     mqtt_init_ctx(&mqttCtx);
-    mqttCtx.app_name = "wiotclient";
-    mqttCtx.host = WIOT_MQTT_HOST;
-    mqttCtx.client_id = WIOT_CLIENT_ID;
-    mqttCtx.topic_name = WIOT_TOPIC_NAME;
-#ifndef WIOT_USE_QUICKSTART
-    mqttCtx.use_tls = 1;
-    mqttCtx.username = WIOT_USER_NAME;
-    mqttCtx.password = WIOT_PASSWORD;
-#endif
+    mqttCtx.app_name = "wolfMQTT multithread client";
+
     /* parse arguments */
     rc = mqtt_parse_args(&mqttCtx, argc, argv);
     if (rc != 0) {
         return rc;
     }
 #endif
-
 #ifdef USE_WINDOWS_API
-    if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler, TRUE) == FALSE) {
+    if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler,
+          TRUE) == FALSE)
+    {
         PRINTF("Error setting Ctrl Handler! Error %d", (int)GetLastError());
     }
 #elif HAVE_SIGNAL
@@ -432,20 +479,20 @@ int main(int argc, char** argv)
         PRINTF("Can't catch SIGINT");
     }
 #endif
+#if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+    rc = multithread_test(&mqttCtx);
 
-#ifndef WOLFMQTT_NONBLOCK
-    rc = wiot_test(&mqttCtx);
+    return (rc == 0) ? 0 : EXIT_FAILURE;
 #else
     (void)argc;
     (void)argv;
 
-    /* This example requires non-blocking mode to be disabled
-       ./configure --disable-nonblock */
+    /* This example requires multithread mode to be enabled
+       ./configure --enable-mt */
     PRINTF("Example not compiled in!");
     rc = EXIT_FAILURE;
+    (void) rc;
 #endif
-
-    return (rc == 0) ? 0 : EXIT_FAILURE;
 }
 
 #endif /* NO_MAIN_DRIVER */

--- a/examples/multithread/multithread.h
+++ b/examples/multithread/multithread.h
@@ -1,0 +1,32 @@
+/* multithread.h
+ *
+ * Copyright (C) 2006-2019 wolfSSL Inc.
+ *
+ * This file is part of wolfMQTT.
+ *
+ * wolfMQTT is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfMQTT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFMQTT_MULTITHREAD_H
+#define WOLFMQTT_MULTITHREAD_H
+
+#include "examples/mqttexample.h"
+
+
+/* Exposed functions */
+int multithread_test(MQTTCtx *mqttCtx);
+
+
+#endif /* WOLFMQTT_MULTITHREAD_H */

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -450,6 +450,8 @@ exit:
 
         /* Cleanup network */
         MqttClientNet_DeInit(&mqttCtx->net);
+
+        MqttClient_DeInit(&mqttCtx->client);
     }
 
     return rc;

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -365,6 +365,8 @@ exit:
     /* Cleanup network */
     MqttClientNet_DeInit(&mqttCtx->net);
 
+    MqttClient_DeInit(&mqttCtx->client);
+
     return rc;
 }
 

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -9,4 +9,8 @@ dist_noinst_SCRIPTS += scripts/client.test \
                        scripts/awsiot.test \
                        scripts/wiot.test \
                        scripts/nbclient.test
+if BUILD_MULTITHREAD
+dist_noinst_SCRIPTS += scripts/multithread.test
+endif
+
 endif

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# MQTT Client test
+
+# Check for application
+[ ! -x ./examples/multithread/multithread ] && echo -e "\n\nMultithread Client doesn't exist" && exit 1
+
+def_args="-T -C 1000"
+
+# Run with and without TLS and QoS 0-2
+
+./examples/multithread/multithread $def_args -q 0 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && exit 1
+
+./examples/multithread/multithread $def_args -q 1 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=1" && exit 1
+
+./examples/multithread/multithread $def_args -q 2 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && exit 1
+
+./examples/multithread/multithread $def_args -t -q 0 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && exit 1
+
+./examples/multithread/multithread $def_args -t -q 1 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && exit 1
+
+./examples/multithread/multithread $def_args -t -q 2 $1
+RESULT=$?
+[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && exit 1
+
+exit 0

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -33,6 +33,93 @@
 #endif
 
 /* Private functions */
+#ifdef WOLFMQTT_MULTITHREAD
+static void MqttClient_RespList_Add(MqttClient *client, word16 packet_id,
+        MqttPacketType packet_type, MqttPendResp *newResp)
+{
+    /* Initialize new response */
+    XMEMSET(newResp, 0, sizeof(MqttPendResp));
+
+    newResp->packet_id = packet_id;
+    newResp->packet_type = packet_type;
+
+    if (client->lastPendResp == NULL) {
+        /* This is the only list item */
+        client->firstPendResp = newResp;
+        client->lastPendResp = newResp;
+    }
+    else {
+        /* Append to end of list */
+        newResp->prev = client->lastPendResp;
+        client->lastPendResp->next = newResp;
+        client->lastPendResp = newResp;
+    }
+}
+
+/* Returns 0 on success; -1 on failure */
+static int MqttClient_RespList_Remove(MqttClient *client, word16 packet_id)
+{
+    int rc = 0;
+    MqttPendResp *rmvResp = (client != NULL) ? client->firstPendResp : NULL;
+
+    /* Find the response entry */
+    while (rmvResp != NULL) {
+        if (rmvResp->packet_id == packet_id) {
+            break;
+        }
+        rmvResp = rmvResp->next;
+    }
+    if (rmvResp == NULL) {
+        /* Error - Packet ID not found */
+        rc = -1;
+    }
+    else {
+        /* Fix up the first and last pointers */
+        if (client->firstPendResp == rmvResp) {
+            client->firstPendResp = rmvResp->next;
+        }
+        if (client->lastPendResp == rmvResp) {
+            client->lastPendResp = rmvResp->prev;
+        }
+
+        /* Remove the entry from the list */
+        if (rmvResp->next != NULL) {
+            rmvResp->next->prev = rmvResp->prev;
+        }
+        if (rmvResp->prev != NULL) {
+            rmvResp->prev->next = rmvResp->next;
+        }
+    }
+
+    return rc;
+}
+
+/* Returns packet_done value (0 or 1) */
+static int MqttClient_RespList_Check(MqttClient *client, byte type,
+        word16 packet_id, MqttPendResp **retResp)
+{
+    int rc = WOLFMQTT_NOT_DONE;
+    MqttPendResp *tmpResp = (client != NULL) ? client->firstPendResp : NULL;
+
+    /* Find the response entry */
+    while (tmpResp != NULL) {
+        if (((tmpResp->packet_id == packet_id) || (packet_id == 0)) &&
+            ((tmpResp->packet_type == type) ||
+             (type == MQTT_PACKET_TYPE_ANY))) {
+            rc = tmpResp->packetDone;
+            break;
+        }
+        tmpResp = tmpResp->next;
+    }
+
+    if (retResp != NULL) {
+        *retResp = tmpResp;
+    }
+
+    return rc;
+}
+#endif
+
 static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
     int timeout_ms, void* p_decode, word16* packet_id)
 {
@@ -172,10 +259,21 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
                     MQTT_PACKET_TYPE_PUBLISH_REC;
                 publish_resp.packet_id = msg->packet_id;
 
+            #ifdef WOLFMQTT_MULTITHREAD
+                /* Lock send socket mutex */
+                rc = wc_LockMutex(&client->lockSend);
+                if (rc == BAD_MUTEX_E) {
+                    return rc;
+                }
+            #endif
+
                 /* Encode publish response */
                 rc = MqttEncode_PublishResp(client->tx_buf,
                                     client->tx_buf_len, type, &publish_resp);
                 if (rc <= 0) {
+                #ifdef WOLFMQTT_MULTITHREAD
+                    wc_UnLockMutex(&client->lockSend);
+                #endif
                     return rc;
                 }
                 client->packet.buf_len = rc;
@@ -184,6 +282,10 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
                 msg->stat = MQTT_MSG_BEGIN;
                 rc = MqttPacket_Write(client, client->tx_buf,
                                                     client->packet.buf_len);
+
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
             }
             break;
         }
@@ -195,6 +297,9 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
             MqttPublishResp publish_resp, *p_publish_resp = &publish_resp;
             if (p_decode) {
                 p_publish_resp = (MqttPublishResp*)p_decode;
+            }
+            else {
+                XMEMSET(p_publish_resp, 0, sizeof(MqttPublishResp));
             }
 #ifdef WOLFMQTT_V5
             p_publish_resp->props = NULL;
@@ -222,12 +327,23 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
             /* If Qos then send response */
             if (msg->type == MQTT_PACKET_TYPE_PUBLISH_REC ||
                 msg->type == MQTT_PACKET_TYPE_PUBLISH_REL) {
+                publish_resp.packet_id = p_publish_resp->packet_id;
+
+            #ifdef WOLFMQTT_MULTITHREAD
+                /* Lock send socket mutex */
+                rc = wc_LockMutex(&client->lockSend);
+                if (rc == BAD_MUTEX_E) {
+                    return rc;
+                }
+            #endif
 
                 /* Encode publish response */
-                publish_resp.packet_id = p_publish_resp->packet_id;
                 rc = MqttEncode_PublishResp(client->tx_buf,
                     client->tx_buf_len, msg->type+1, &publish_resp);
                 if (rc <= 0) {
+                #ifdef WOLFMQTT_MULTITHREAD
+                    wc_UnLockMutex(&client->lockSend);
+                #endif
                     return rc;
                 }
                 client->packet.buf_len = rc;
@@ -236,6 +352,9 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
                 msg->stat = MQTT_MSG_BEGIN;
                 rc = MqttPacket_Write(client, client->tx_buf,
                         client->packet.buf_len);
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
             }
             break;
         }
@@ -246,6 +365,9 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
             MqttSubscribeAck *p_subscribe_ack = &subscribe_ack;
             if (p_decode) {
                 p_subscribe_ack = (MqttSubscribeAck*)p_decode;
+            }
+            else {
+                XMEMSET(p_subscribe_ack, 0, sizeof(MqttSubscribeAck));
             }
 #ifdef WOLFMQTT_V5
             p_subscribe_ack->props = NULL;
@@ -279,6 +401,9 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
 
             if (p_decode) {
                 p_unsubscribe_ack = (MqttUnsubscribeAck*)p_decode;
+            }
+            else {
+                XMEMSET(p_unsubscribe_ack, 0, sizeof(MqttUnsubscribeAck));
             }
 #ifdef WOLFMQTT_V5
             p_unsubscribe_ack->props = NULL;
@@ -314,6 +439,7 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
         {
             MqttAuth auth, *p_auth = &auth;
 
+            XMEMSET(p_auth, 0, sizeof(MqttAuth));
             p_auth->props = NULL;
             /* Decode authorization */
             rc = MqttDecode_Auth(client->rx_buf, client->packet.buf_len,
@@ -338,6 +464,7 @@ static int MqttClient_HandlePayload(MqttClient* client, MqttMessage* msg,
         {
             MqttDisconnect disc, *p_disc = &disc;
 
+            XMEMSET(p_disc, 0, sizeof(MqttDisconnect));
             p_disc->props = NULL;
 
             /* Decode disconnect */
@@ -378,16 +505,15 @@ static int MqttClient_WaitType(MqttClient *client, MqttMessage* msg,
     int rc;
     word16 packet_id = 0;
 
-wait_again:
-
-
 #ifdef WOLFMQTT_MULTITHREAD
     /* Lock recv socket mutex */
     rc = wc_LockMutex(&client->lockRecv);
     if (rc == BAD_MUTEX_E) {
-        /* TODO: Handle error */
+        return rc;
     }
 #endif
+
+    wait_again:
 
     switch (msg->stat)
     {
@@ -406,24 +532,56 @@ wait_again:
             MqttPacket* header;
 
         #ifdef WOLFMQTT_MULTITHREAD
-            /* TODO
-                1. Lock client and check to see if matching packet type and id have already been completed
-                2. If done then unlock client and socket and return
-                3. If not then unlock client and perform socket read
-            */
+            /* Lock client */
+            rc = wc_LockMutex(&client->lockClient);
+            if (rc == 0) {
+                /* Check to see if matching packet type and id have already
+                   been completed */
+                rc = MqttClient_RespList_Check(client, wait_type,
+                        wait_packet_id, NULL);
+
+                wc_UnLockMutex(&client->lockClient);
+            }
+            else {
+                /* Error locking client */
+                return rc;
+            }
+
+        #ifndef WOLFMQTT_NONBLOCK
+            if (rc == WOLFMQTT_NOT_DONE)
+            /* If not done then perform socket read */
+        #endif
         #endif
 
-            /* Wait for packet */
-            rc = MqttPacket_Read(client, client->rx_buf, client->rx_buf_len,
-                    timeout_ms);
-        #ifdef WOLFMQTT_NONBLOCK
-            if (rc == MQTT_CODE_CONTINUE && client->read.pos > 0) {
-                /* advance state, so we don't reset packet state */
-                msg->stat = MQTT_MSG_WAIT;
+            {
+                /* Wait for packet */
+                rc = MqttPacket_Read(client, client->rx_buf, client->rx_buf_len,
+                        timeout_ms);
+            #ifdef WOLFMQTT_NONBLOCK
+                if (rc == MQTT_CODE_CONTINUE && client->read.pos > 0) {
+                    /* advance state, so we don't reset packet state */
+                    msg->stat = MQTT_MSG_WAIT;
+                }
+            #endif
+            }
+        #if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+            else {
+                /* If done then return */
+                rc = 0;
             }
         #endif
             if (rc <= 0) {
             #ifdef WOLFMQTT_MULTITHREAD
+                if (wc_LockMutex(&client->lockClient) == 0) {
+                    /* Release response entry */
+                    (void)MqttClient_RespList_Remove(client, wait_packet_id);
+                    wc_UnLockMutex(&client->lockClient);
+                }
+                else {
+                    /* Error locking client */
+                    rc = BAD_MUTEX_E;
+                }
+                /* Unlock socket */
                 wc_UnLockMutex(&client->lockRecv);
             #endif
                 return rc;
@@ -459,12 +617,31 @@ wait_again:
             #endif
                 return rc;
             }
+#ifndef WOLFMQTT_MULTITHREAD
             rc = MQTT_CODE_SUCCESS;
+#else
+            /* Lock the client */
+            rc = wc_LockMutex(&client->lockClient);
+            if (rc == 0) {
+                MqttPendResp *tmpResp;
 
-#ifdef WOLFMQTT_MULTITHREAD
-            /* Lock the client
-            /* Check to see if we have a matching packet id and type
-            /* If we do then populate response and mark done, unlock client and unlock socket and wait again */
+                /* Check to see if we have a matching packet id and type */
+                rc = MqttClient_RespList_Check(client, wait_type,
+                        wait_packet_id, &tmpResp);
+                if (rc >= 0) {
+                    if (tmpResp != NULL) {
+                        /* If we do then populate response and mark done */
+                        tmpResp->packetDone = WOLFMQTT_DONE;
+                    }
+                    /* Unlock client and unlock socket and wait again */
+                    wc_UnLockMutex(&client->lockClient);
+                }
+            }
+            else {
+                /* Error locking client */
+                wc_UnLockMutex(&client->lockRecv);
+                return rc;
+            }
             /* if we don't then process as normal below */
 #endif
 
@@ -473,13 +650,19 @@ wait_again:
                 if (wait_type == msg->type) {
                     if (wait_packet_id == 0 || wait_packet_id == packet_id) {
                         /* We found the packet type and id */
+                    #ifdef WOLFMQTT_MULTITHREAD
+                        rc = wc_LockMutex(&client->lockClient);
+                        if (rc == 0) {
+                            /* Release response entry and unlock socket*/
+                            (void)MqttClient_RespList_Remove(client,
+                                    wait_packet_id);
+                            wc_UnLockMutex(&client->lockClient);
+                        }
+                    #endif
                         break;
                     }
                 }
 
-            #ifdef WOLFMQTT_MULTITHREAD
-                wc_UnLockMutex(&client->lockRecv);
-            #endif
                 msg->stat = MQTT_MSG_BEGIN;
                 goto wait_again;
             }
@@ -507,6 +690,7 @@ wait_again:
 
     return rc;
 }
+
 
 /* Public Functions */
 int MqttClient_Init(MqttClient *client, MqttNet* net,
@@ -538,28 +722,40 @@ int MqttClient_Init(MqttClient *client, MqttNet* net,
     client->max_qos = MQTT_QOS_2;
     client->retain_avail = 1;
 #endif
+
 #ifdef WOLFMQTT_MULTITHREAD
-    /* TODO: Add erorr checking */
-    wc_InitMutex(&client->lockSend);
-    wc_InitMutex(&client->lockRecv);
-    wc_InitMutex(&client->lockClient);
+    rc = wc_InitMutex(&client->lockSend);
+    if (rc == 0) {
+        rc = wc_InitMutex(&client->lockRecv);
+    }
+    if (rc == 0) {
+        rc = wc_InitMutex(&client->lockClient);
+    }
 #endif
 
-    /* Init socket */
-    rc = MqttSocket_Init(client, net);
+    if (rc == 0) {
+        /* Init socket */
+        rc = MqttSocket_Init(client, net);
+    }
+
+    if (rc != 0) {
+        /* Cleanup if init failed */
+        MqttClient_DeInit(client);
+    }
 
     return rc;
 }
 
-#if 0
-/* TODO: Add MqttClient_Cleanup */
+void MqttClient_DeInit(MqttClient *client)
+{
+    if (client != NULL) {
 #ifdef WOLFMQTT_MULTITHREAD
-    wc_FreeMutex(&client->lockSend);
-    wc_FreeMutex(&client->lockRecv);
-    wc_FreeMutex(&client->lockClient);
+        (void)wc_FreeMutex(&client->lockSend);
+        (void)wc_FreeMutex(&client->lockRecv);
+        (void)wc_FreeMutex(&client->lockClient);
 #endif
-#endif
-
+    }
+}
 
 #ifdef WOLFMQTT_DISCONNECT_CB
 int MqttClient_SetDisconnectCallback(MqttClient *client,
@@ -599,16 +795,44 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *connect)
     }
 
     if (connect->stat == MQTT_MSG_BEGIN) {
+    #ifdef WOLFMQTT_MULTITHREAD
+        /* Lock client */
+        rc = wc_LockMutex(&client->lockClient);
+        if (rc == 0) {
+            /* Add the pendResp */
+            MqttClient_RespList_Add(client, 0,
+                    MQTT_PACKET_TYPE_CONNECT_ACK, &connect->pendResp);
+
+            /* Unlock Client */
+            wc_UnLockMutex(&client->lockClient);
+        }
+        else {
+            /* Error locking client */
+            return rc;
+        }
+
+        /* Lock send socket mutex */
+        rc = wc_LockMutex(&client->lockSend);
+        if (rc == BAD_MUTEX_E) {
+            return rc;
+        }
+    #endif
 
         /* Encode the connect packet */
         rc = MqttEncode_Connect(client->tx_buf, client->tx_buf_len, connect);
         if (rc <= 0) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
             return rc;
         }
         len = rc;
 
         /* Send connect packet */
         rc = MqttPacket_Write(client, client->tx_buf, len);
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
         if (rc != len) {
             return rc;
         }
@@ -653,11 +877,10 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *connect)
 
         /* Send the AUTH packet */
         rc = MqttClient_Auth(client, p_auth);
+        MqttClient_PropsFree(p_auth->props);
         if (rc != len) {
             return rc;
         }
-
-        MqttClient_PropsFree(p_auth->props);
     }
 #endif
 
@@ -691,10 +914,42 @@ int MqttClient_Publish(MqttClient *client, MqttPublish *publish)
     {
         case MQTT_MSG_BEGIN:
         {
+        #ifdef WOLFMQTT_MULTITHREAD
+
+            if (publish->qos > MQTT_QOS_0) {
+                type = (publish->qos == MQTT_QOS_1) ?
+                        MQTT_PACKET_TYPE_PUBLISH_ACK :
+                        MQTT_PACKET_TYPE_PUBLISH_COMP;
+
+                /* Lock client */
+                rc = wc_LockMutex(&client->lockClient);
+                if (rc == 0) {
+                    /* Add the publish->pendResp */
+                    MqttClient_RespList_Add(client, publish->packet_id, type,
+                            &publish->pendResp);
+
+                    /* Unlock Client */
+                    wc_UnLockMutex(&client->lockClient);
+                }
+                else {
+                    /* Error locking client */
+                    return rc;
+                }
+            }
+
+            /* Lock send socket mutex */
+            rc = wc_LockMutex(&client->lockSend);
+            if (rc == BAD_MUTEX_E) {
+                return rc;
+            }
+        #endif
             /* Encode the publish packet */
             rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len,
                     publish, 0);
             if (rc <= 0) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
                 return rc;
             }
 
@@ -705,27 +960,6 @@ int MqttClient_Publish(MqttClient *client, MqttPublish *publish)
             if (publish->buffer_len == 0) {
                 publish->buffer_len = publish->total_len;
             }
-
-        #ifdef WOLFMQTT_MULTITHREAD
-            /* Lock send socket mutex */
-            rc = wc_LockMutex(&client->lockSend);
-            if (rc == BAD_MUTEX_E) {
-                /* TODO: Handle error */
-            }
-
-            if (publish->qos > MQTT_QOS_0) {
-                type = (publish->qos == MQTT_QOS_1) ?
-                        MQTT_PACKET_TYPE_PUBLISH_ACK :
-                        MQTT_PACKET_TYPE_PUBLISH_COMP;
-
-                /* TODO:
-                1. Lock client
-                2. Add the publish->pendResp populated with type, publish->packet_id, timestamp, etc.. to client->firstPendResp...
-                3. Unlock Client
-                */
-            }
-
-        #endif
 
             FALL_THROUGH;
         }
@@ -755,9 +989,6 @@ int MqttClient_Publish(MqttClient *client, MqttPublish *publish)
                 /* Check if we are done sending publish message */
                 if (publish->intBuf_pos >= publish->buffer_len) {
                     rc = MQTT_CODE_SUCCESS;
-                #ifdef WOLFMQTT_MULTITHREAD
-                    wc_UnLockMutex(&client->lockSend);
-                #endif
                     break;
                 }
 
@@ -786,15 +1017,16 @@ int MqttClient_Publish(MqttClient *client, MqttPublish *publish)
                 }
                 return MQTT_CODE_CONTINUE;
             }
+
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
+
             /* if not expecting a reply, the reset state and exit */
             if (publish->qos == MQTT_QOS_0) {
                 publish->stat = MQTT_MSG_BEGIN;
                 break;
             }
-
-        #ifdef WOLFMQTT_MULTITHREAD
-            wc_UnLockMutex(&client->lockSend);
-        #endif
 
             FALL_THROUGH;
         }
@@ -831,12 +1063,6 @@ int MqttClient_Publish(MqttClient *client, MqttPublish *publish)
             break;
     } /* switch (publish->stat) */
 
-#ifdef WOLFMQTT_MULTITHREAD
-    if (rc != MQTT_CODE_SUCCESS) {
-        wc_UnLockMutex(&client->lockSend);
-    }
-#endif
-
     return rc;
 }
 
@@ -844,6 +1070,7 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
                             MqttPublishCb pubCb)
 {
     int rc = MQTT_CODE_SUCCESS;
+    MqttPacketType type;
 
     /* Validate required arguments */
     if (client == NULL || publish == NULL || pubCb == NULL) {
@@ -863,10 +1090,43 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
     {
         case MQTT_MSG_BEGIN:
         {
+
+        #ifdef WOLFMQTT_MULTITHREAD
+            if (publish->qos > MQTT_QOS_0) {
+                type = (publish->qos == MQTT_QOS_1) ?
+                        MQTT_PACKET_TYPE_PUBLISH_ACK :
+                        MQTT_PACKET_TYPE_PUBLISH_COMP;
+
+                /* Lock client */
+                rc = wc_LockMutex(&client->lockClient);
+                if (rc == 0) {
+                    /* Add the publish->pendResp */
+                    MqttClient_RespList_Add(client, publish->packet_id, type,
+                            &publish->pendResp);
+
+                    /* Unlock Client */
+                    wc_UnLockMutex(&client->lockClient);
+                }
+                else {
+                    /* Error locking client */
+                    return rc;
+                }
+            }
+
+            /* Lock send socket mutex */
+            rc = wc_LockMutex(&client->lockSend);
+            if (rc == BAD_MUTEX_E) {
+                return rc;
+            }
+        #endif
+
             /* Encode the publish packet */
             rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len,
                     publish, 1);
             if (rc <= 0) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
                 return rc;
             }
 
@@ -876,6 +1136,9 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
             rc = MqttPacket_Write(client, client->tx_buf,
                     client->write.len);
             if (rc < 0) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                wc_UnLockMutex(&client->lockSend);
+            #endif
                 return rc;
             }
             publish->buffer_pos = 0;
@@ -890,6 +1153,9 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
             do {
                 /* Use the callback to get payload */
                 if ((client->write.len = pubCb(publish)) < 0) {
+                #ifdef WOLFMQTT_MULTITHREAD
+                    wc_UnLockMutex(&client->lockSend);
+                #endif
                     return MQTT_CODE_ERROR_CALLBACK;
                 }
 
@@ -910,6 +1176,9 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
                     rc = MqttPacket_Write(client, client->tx_buf,
                             client->write.len);
                     if (rc < 0) {
+                    #ifdef WOLFMQTT_MULTITHREAD
+                        wc_UnLockMutex(&client->lockSend);
+                    #endif
                         return rc;
                     }
 
@@ -922,6 +1191,10 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
                 publish->intBuf_pos = 0;
 
             } while (publish->buffer_pos < publish->total_len);
+
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
 
             /* if not expecting a reply, the reset state and exit */
             if (publish->qos == MQTT_QOS_0) {
@@ -942,7 +1215,7 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
             /* Handle QoS */
             if (publish->qos > MQTT_QOS_0) {
                 /* Determine packet type to wait for */
-                MqttPacketType type = (publish->qos == MQTT_QOS_1) ?
+                type = (publish->qos == MQTT_QOS_1) ?
                     MQTT_PACKET_TYPE_PUBLISH_ACK :
                     MQTT_PACKET_TYPE_PUBLISH_COMP;
 
@@ -985,15 +1258,48 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
     XMEMSET(&subscribe_ack, 0, sizeof(MqttSubscribeAck));
 
     if (subscribe->stat == MQTT_MSG_BEGIN) {
+    #ifdef WOLFMQTT_MULTITHREAD
+        /* Lock client */
+        rc = wc_LockMutex(&client->lockClient);
+        if (rc == 0) {
+            /* Add the pendResp */
+            MqttClient_RespList_Add(client, subscribe->packet_id,
+                    MQTT_PACKET_TYPE_SUBSCRIBE_ACK, &subscribe->pendResp);
+
+            /* Unlock Client */
+            wc_UnLockMutex(&client->lockClient);
+        }
+        else {
+            /* Error locking client */
+            return rc;
+        }
+
+        /* Lock send socket mutex */
+        rc = wc_LockMutex(&client->lockSend);
+        if (rc == BAD_MUTEX_E) {
+            return rc;
+        }
+    #endif
+
         /* Encode the subscribe packet */
         rc = MqttEncode_Subscribe(client->tx_buf, client->tx_buf_len,
                 subscribe);
-        if (rc <= 0) { return rc; }
+        if (rc <= 0) {
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
+            return rc;
+        }
         len = rc;
 
         /* Send subscribe packet */
         rc = MqttPacket_Write(client, client->tx_buf, len);
-        if (rc != len) { return rc; }
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
+        if (rc != len) {
+            return rc;
+        }
 
         subscribe->stat = MQTT_MSG_WAIT;
     }
@@ -1027,15 +1333,48 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
     XMEMSET(&unsubscribe_ack, 0, sizeof(MqttUnsubscribeAck));
 
     if (unsubscribe->stat == MQTT_MSG_BEGIN) {
+    #ifdef WOLFMQTT_MULTITHREAD
+        /* Lock client */
+        rc = wc_LockMutex(&client->lockClient);
+        if (rc == 0) {
+            /* Add the pendResp */
+            MqttClient_RespList_Add(client, unsubscribe->packet_id,
+                    MQTT_PACKET_TYPE_UNSUBSCRIBE_ACK, &unsubscribe->pendResp);
+
+            /* Unlock Client */
+            wc_UnLockMutex(&client->lockClient);
+        }
+        else {
+            /* Error locking client */
+            return rc;
+        }
+
+        /* Lock send socket mutex */
+        rc = wc_LockMutex(&client->lockSend);
+        if (rc == BAD_MUTEX_E) {
+            return rc;
+        }
+    #endif
+
         /* Encode the subscribe packet */
         rc = MqttEncode_Unsubscribe(client->tx_buf, client->tx_buf_len,
             unsubscribe);
-        if (rc <= 0) { return rc; }
+        if (rc <= 0) {
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
+            return rc;
+        }
         len = rc;
 
         /* Send unsubscribe packet */
         rc = MqttPacket_Write(client, client->tx_buf, len);
-        if (rc != len) { return rc; }
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
+        if (rc != len) {
+            return rc;
+        }
 
         unsubscribe->stat = MQTT_MSG_WAIT;
     }
@@ -1065,14 +1404,47 @@ int MqttClient_Ping(MqttClient *client)
     }
 
     if (client->msg.stat == MQTT_MSG_BEGIN) {
+    #ifdef WOLFMQTT_MULTITHREAD
+        /* Lock client */
+        rc = wc_LockMutex(&client->lockClient);
+        if (rc == 0) {
+            /* Add the pendResp */
+            MqttClient_RespList_Add(client, 0,
+                    MQTT_PACKET_TYPE_PING_RESP, &client->msg.pendResp);
+
+            /* Unlock Client */
+            wc_UnLockMutex(&client->lockClient);
+        }
+        else {
+            /* Error locking client */
+            return rc;
+        }
+
+        /* Lock send socket mutex */
+        rc = wc_LockMutex(&client->lockSend);
+        if (rc == BAD_MUTEX_E) {
+            return rc;
+        }
+    #endif
+
         /* Encode the subscribe packet */
         rc = MqttEncode_Ping(client->tx_buf, client->tx_buf_len);
-        if (rc <= 0) { return rc; }
+        if (rc <= 0) {
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
+            return rc;
+        }
         len = rc;
 
         /* Send ping req packet */
         rc = MqttPacket_Write(client, client->tx_buf, len);
-        if (rc != len) { return rc; }
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
+        if (rc != len) {
+            return rc;
+        }
 
         client->msg.stat = MQTT_MSG_WAIT;
     }
@@ -1098,13 +1470,29 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *disconnect)
         return MQTT_CODE_ERROR_BAD_ARG;
     }
 
+#ifdef WOLFMQTT_MULTITHREAD
+    /* Lock send socket mutex */
+    rc = wc_LockMutex(&client->lockSend);
+    if (rc == BAD_MUTEX_E) {
+        return rc;
+    }
+#endif
+
     /* Encode the disconnect packet */
     rc = MqttEncode_Disconnect(client->tx_buf, client->tx_buf_len, disconnect);
-    if (rc <= 0) { return rc; }
+    if (rc <= 0) {
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
+        return rc;
+    }
     len = rc;
 
     /* Send disconnect packet */
     rc = MqttPacket_Write(client, client->tx_buf, len);
+#ifdef WOLFMQTT_MULTITHREAD
+    wc_UnLockMutex(&client->lockSend);
+#endif
     if (rc != len) { return rc; }
 
     /* No response for MQTT disconnect packet */
@@ -1123,13 +1511,45 @@ int MqttClient_Auth(MqttClient *client, MqttAuth* auth)
     }
 
     if (client->msg.stat == MQTT_MSG_BEGIN) {
+
+    #ifdef WOLFMQTT_MULTITHREAD
+        /* Lock client */
+        rc = wc_LockMutex(&client->lockClient);
+        if (rc == 0) {
+            /* Add the pendResp */
+            MqttClient_RespList_Add(client, 0,
+                    MQTT_PACKET_TYPE_AUTH, &client->msg.pendResp);
+
+            /* Unlock Client */
+            wc_UnLockMutex(&client->lockClient);
+        }
+        else {
+            /* Error locking client */
+            return rc;
+        }
+
+        /* Lock send socket mutex */
+        rc = wc_LockMutex(&client->lockSend);
+        if (rc == BAD_MUTEX_E) {
+            return rc;
+        }
+    #endif
+
         /* Encode the authentication packet */
         rc = MqttEncode_Auth(client->tx_buf, client->tx_buf_len, auth);
-        if (rc <= 0) { return rc; }
+        if (rc <= 0) {
+        #ifdef WOLFMQTT_MULTITHREAD
+            wc_UnLockMutex(&client->lockSend);
+        #endif
+            return rc;
+        }
         len = rc;
 
         /* Send authentication packet */
         rc = MqttPacket_Write(client, client->tx_buf, len);
+    #ifdef WOLFMQTT_MULTITHREAD
+        wc_UnLockMutex(&client->lockSend);
+    #endif
         if (rc != len) { return rc; }
 
         client->msg.stat = MQTT_MSG_WAIT;
@@ -1825,7 +2245,7 @@ int SN_Client_Unsubscribe(MqttClient *client, SN_Unsubscribe *unsubscribe)
     }
 
     /* Clear local structure */
-    XMEMSET(&unsubscribe_ack, 0, sizeof(SN_MqttUnsubscribeAck));
+    XMEMSET(&unsubscribe_ack, 0, sizeof(SN_UnsubscribeAck));
 
     if (unsubscribe->stat == MQTT_MSG_BEGIN) {
         /* Encode the subscribe packet */

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -325,7 +325,6 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
     }
 #endif
 
-
     if ((client->flags & MQTT_CLIENT_FLAG_IS_CONNECTED) == 0) {
         /* Validate port */
         if (port == 0) {

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -115,30 +115,8 @@ typedef struct _MqttSk {
 #endif
 
 #ifdef WOLFMQTT_MULTITHREAD
-    #include <wolfssl/wolfcrypt/wc_port.h>
-    /*
-    wolfSSL_Mutex
-    WOLFSSL_API int wc_InitMutex(wolfSSL_Mutex*);
-    WOLFSSL_API int wc_FreeMutex(wolfSSL_Mutex*);
-    WOLFSSL_API int wc_LockMutex(wolfSSL_Mutex*);
-    WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex*);
-    */
-
-    /* Pending Response Structure */
-    typedef struct MqttPendResp {
-        word16         packet_id;
-        MqttPacketType packet_type;
-        void*          packet_resp;
-        time_t         timestamp;
-
-        /* bits */
-        word16         packetDone:1;
-        word16         gotError:1;
-
-        /* double linked list */
-        struct MqttPendResp* next;
-        struct MqttPendResp* prev;
-    } MqttPendResp;
+    #define WOLFMQTT_NOT_DONE   0
+    #define WOLFMQTT_DONE       1
 #endif
 
 
@@ -186,8 +164,8 @@ typedef struct _MqttClient {
     wolfSSL_Mutex lockSend;
     wolfSSL_Mutex lockRecv;
     wolfSSL_Mutex lockClient;
-    struct MqttPendResp* firstPendResp;
-    struct MqttPendResp* lastPendResp;
+    struct _MqttPendResp* firstPendResp;
+    struct _MqttPendResp* lastPendResp;
 #endif
 } MqttClient;
 
@@ -217,8 +195,11 @@ WOLFMQTT_API int MqttClient_Init(
     byte *rx_buf, int rx_buf_len,
     int cmd_timeout_ms);
 
-/* TODO: Add MqttClient_Cleanup */
-
+/*! \brief      Cleans up resources allocated to the MqttClient structure
+ *  \param      client      Pointer to MqttClient structure
+ *  \return     none
+ */
+WOLFMQTT_API void MqttClient_DeInit(MqttClient *client);
 
 #ifdef WOLFMQTT_DISCONNECT_CB
 /*! \brief      Sets a disconnect callback with custom context

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -214,6 +214,9 @@ typedef struct _MqttMessage {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
+#ifdef WOLFMQTTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 } MqttMessage;
 
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -173,53 +173,6 @@ typedef enum _MqttQoS {
 } MqttQoS;
 
 
-/* Generic Message */
-typedef enum _MqttMsgStat {
-    MQTT_MSG_BEGIN,
-#ifdef WOLFMQTT_V5
-    MQTT_MSG_AUTH,
-#endif
-    MQTT_MSG_WAIT,
-    MQTT_MSG_WRITE,
-    MQTT_MSG_READ,
-    MQTT_MSG_READ_PAYLOAD,
-} MqttMsgStat;
-
-typedef struct _MqttMessage {
-    MqttMsgStat stat;
-    word16      packet_id;
-    byte        type;
-    MqttQoS     qos;
-    byte        retain;
-    byte        duplicate;
-#ifdef WOLFMQTT_SN
-    byte        topic_type;
-    byte        return_code;
-#endif
-    const char *topic_name;   /* Pointer is valid only when
-                                 msg_new set in callback */
-    word16      topic_name_len;
-    word32      total_len;    /* Payload total length */
-    byte       *buffer;       /* Payload buffer */
-    word32      buffer_len;   /* Payload buffer length */
-    word32      buffer_pos;   /* Payload buffer position */
-
-    /* Used internally for TX/RX buffers */
-    byte        buffer_new;   /* flag to indicate new message */
-    word32      intBuf_len;   /* Buffer length */
-    word32      intBuf_pos;   /* Buffer position */
-
-    void*       ctx;          /* user supplied context for publish callbacks */
-
-#ifdef WOLFMQTT_V5
-    MqttProp* props;
-#endif
-#ifdef WOLFMQTTT_MULTITHREAD
-    MqttPendResp pendResp;
-#endif
-} MqttMessage;
-
-
 /* Topic */
 typedef struct _MqttTopic {
     const char* topic_filter;
@@ -309,6 +262,70 @@ typedef struct _MqttPacket {
     /* Must be non-zero value */
 } WOLFMQTT_PACK MqttPacket;
 #define MQTT_PACKET_MAX_SIZE        (int)sizeof(MqttPacket)
+
+
+/* Generic Message */
+typedef enum _MqttMsgStat {
+    MQTT_MSG_BEGIN,
+#ifdef WOLFMQTT_V5
+    MQTT_MSG_AUTH,
+#endif
+    MQTT_MSG_WAIT,
+    MQTT_MSG_WRITE,
+    MQTT_MSG_READ,
+    MQTT_MSG_READ_PAYLOAD,
+} MqttMsgStat;
+
+#ifdef WOLFMQTT_MULTITHREAD
+/* Pending Response Structure */
+typedef struct _MqttPendResp {
+    word16         packet_id;
+    MqttPacketType packet_type;
+    void*          packet_resp;
+
+    /* bits */
+    word16         packetDone:1;
+    word16         gotError:1;
+
+    /* double linked list */
+    struct _MqttPendResp* next;
+    struct _MqttPendResp* prev;
+} MqttPendResp;
+#endif
+
+typedef struct _MqttMessage {
+    MqttMsgStat stat;
+    word16      packet_id;
+    byte        type;
+    MqttQoS     qos;
+    byte        retain;
+    byte        duplicate;
+#ifdef WOLFMQTT_SN
+    byte        topic_type;
+    byte        return_code;
+#endif
+    const char *topic_name;   /* Pointer is valid only when
+                                 msg_new set in callback */
+    word16      topic_name_len;
+    word32      total_len;    /* Payload total length */
+    byte       *buffer;       /* Payload buffer */
+    word32      buffer_len;   /* Payload buffer length */
+    word32      buffer_pos;   /* Payload buffer position */
+
+    /* Used internally for TX/RX buffers */
+    byte        buffer_new;   /* flag to indicate new message */
+    word32      intBuf_len;   /* Buffer length */
+    word32      intBuf_pos;   /* Buffer position */
+
+    void*       ctx;          /* user supplied context for publish callbacks */
+
+#ifdef WOLFMQTT_V5
+    MqttProp* props;
+#endif
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
+} MqttMessage;
 
 
 /* CONNECT PACKET */
@@ -420,6 +437,9 @@ typedef struct _MqttConnect {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 } MqttConnect;
 
 
@@ -445,6 +465,9 @@ typedef struct _MqttPublishResp {
     byte reason_code;
     MqttProp* props;
 #endif
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 } MqttPublishResp;
 
 /* SUBSCRIBE PACKET */
@@ -457,6 +480,9 @@ typedef struct _MqttSubscribe {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+#endif
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
 #endif
 } MqttSubscribe;
 

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -33,13 +33,6 @@
 
 #include "wolfmqtt/mqtt_types.h"
 #ifdef ENABLE_MQTT_TLS
-    #if !defined(WOLFSSL_USER_SETTINGS) && !defined(USE_WINDOWS_API)
-        #include <wolfssl/options.h>
-    #endif
-	#include <wolfssl/wolfcrypt/settings.h>
-    #include <wolfssl/ssl.h>
-    #include <wolfssl/wolfcrypt/types.h>
-
     #ifndef WOLF_TLS_DHKEY_BITS_MIN /* allow define to be overridden */
         #ifdef WOLFSSL_MAX_STRENGTH
             #define WOLF_TLS_DHKEY_BITS_MIN 2048

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -45,6 +45,41 @@
 
 #include "wolfmqtt/visibility.h"
 
+#ifdef ENABLE_MQTT_TLS
+    #if !defined(WOLFSSL_USER_SETTINGS) && !defined(USE_WINDOWS_API)
+        #include <wolfssl/options.h>
+    #endif
+    #include <wolfssl/wolfcrypt/settings.h>
+    #include <wolfssl/ssl.h>
+    #include <wolfssl/wolfcrypt/types.h>
+
+    #ifdef WOLFMQTT_MULTITHREAD
+        #include <wolfssl/wolfcrypt/wc_port.h>
+        #include <wolfssl/wolfcrypt/error-crypt.h>
+    #endif
+
+    #ifndef WOLF_TLS_DHKEY_BITS_MIN /* allow define to be overridden */
+        #ifdef WOLFSSL_MAX_STRENGTH
+            #define WOLF_TLS_DHKEY_BITS_MIN 2048
+        #else
+            #define WOLF_TLS_DHKEY_BITS_MIN 1024
+        #endif
+    #endif
+#endif
+
+#if !defined(ENABLE_MQTT_TLS) && defined(WOLFMQTT_MULTITHREAD)
+#warning "User must supply mutex components if wolfSSL is not included."
+    /*
+    User must supply these...
+        wolfSSL_Mutex
+        WOLFSSL_API int wc_InitMutex(wolfSSL_Mutex*);
+        WOLFSSL_API int wc_FreeMutex(wolfSSL_Mutex*);
+        WOLFSSL_API int wc_LockMutex(wolfSSL_Mutex*);
+        WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex*);
+        #define BAD_MUTEX_E -106
+        */
+#endif
+
 /* configuration for Harmony */
 #ifdef MICROCHIP_MPLAB_HARMONY
     #define NO_EXIT
@@ -219,6 +254,7 @@ enum MqttPacketResponseCodes {
 
 /* GCC 7 has new switch() fall-through detection */
 /* default to FALL_THROUGH stub */
+#ifndef FALL_THROUGH
 #define FALL_THROUGH
 
 #if defined(__GNUC__)
@@ -226,6 +262,7 @@ enum MqttPacketResponseCodes {
         #undef  FALL_THROUGH
         #define FALL_THROUGH __attribute__ ((fallthrough));
     #endif
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Adding support for mulithreading in the wolfMQTT library. This feature allows the application to run threads that call wolfMQTT API, and internally access to the network sockets and structures are protected using mutexes. This option is enabled in the configuration using `--enable-mt`. There is a new example that demonstrates the feature using pthreads in `examples/multithread/`.

Fixes #60