### PR TITLE
Fix fwpush using filename option

### DIFF
--- a/examples/firmware/fwpush.h
+++ b/examples/firmware/fwpush.h
@@ -32,6 +32,7 @@
 typedef struct FwpushCBdata_s {
     const char *filename;
     byte *data;
+    FILE *fp;
 }FwpushCBdata;
 
 /* Exposed functions */

--- a/examples/firmware/fwpush.h
+++ b/examples/firmware/fwpush.h
@@ -27,6 +27,12 @@
 #define FIRMWARE_PUSH_CLIENT_ID "WolfMQTTFwPush"
 #define FIRMWARE_PUSH_DEF_FILE  "README.md"
 
+/* Structure to pass into the publish callback
+ * using the publish->ctx pointer */
+typedef struct FwpushCBdata_s {
+    const char *filename;
+    byte *data;
+}FwpushCBdata;
 
 /* Exposed functions */
 int fwpush_test(MQTTCtx *mqttCtx);


### PR DESCRIPTION
There was an issue when using the `-f <filename>` option with the fwpush example. The CB was hard-coded to use the `FIRMWARE_PUSH_DEF_FILE`.