### PR TITLE
Refactor of the multi-threading code to better handle edge case and state for non-blocking

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -399,7 +399,6 @@ int awsiot_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
-            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -381,7 +381,6 @@ int azureiothub_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
-            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -325,7 +325,6 @@ int fwclient_test(MQTTCtx *mqttCtx)
 
             /* Subscribe Topic */
             XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
-            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = 1;
             mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -326,6 +326,7 @@ int fwpush_test(MQTTCtx *mqttCtx)
     if (mStopRead) {
         rc = MQTT_CODE_SUCCESS;
         PRINTF("MQTT Exiting...");
+        mStopRead = 0;
         goto disconn;
     }
 

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -386,7 +386,6 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 #endif
 
     /* Subscribe Topic */
-    mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
     mqttCtx->subscribe.packet_id = mqtt_get_packetid();
     mqttCtx->subscribe.topic_count =
             sizeof(mqttCtx->topics) / sizeof(MqttTopic);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -109,6 +109,10 @@ typedef struct _MQTTCtx {
     MqttPublish publish;
     MqttDisconnect disconnect;
 
+#ifdef WOLFMQTT_SN
+    SN_Publish publishSN;
+#endif
+
     /* configuration */
     MqttQoS qos;
     const char* app_name;

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -29,7 +29,9 @@
 #include "examples/mqttexample.h"
 
 /* Default MQTT host broker to use, when none is specified in the examples */
+#ifndef DEFAULT_MQTT_HOST
 #define DEFAULT_MQTT_HOST       "iot.eclipse.org" /* broker.hivemq.com */
+#endif
 
 /* Functions used to handle the MqttNet structure creation / destruction */
 int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -243,7 +243,6 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->topics[i].qos = mqttCtx->qos;
 
             /* Subscribe Topic */
-            mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count =
                     sizeof(mqttCtx->topics) / sizeof(MqttTopic);

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -220,28 +220,28 @@ int sn_test(MQTTCtx *mqttCtx)
 
     {
         /* Publish Topic */
-        XMEMSET(&mqttCtx->publish, 0, sizeof(SN_Publish));
-        mqttCtx->publish.retain = 0;
-        mqttCtx->publish.qos = mqttCtx->qos;
-        mqttCtx->publish.duplicate = 0;
-        mqttCtx->publish.topic_type = SN_TOPIC_ID_TYPE_NORMAL;
-        mqttCtx->publish.topic_name = (char*)&topicID;
-        if (mqttCtx->publish.qos > MQTT_QOS_0) {
-            mqttCtx->publish.packet_id = mqtt_get_packetid();
+        XMEMSET(&mqttCtx->publishSN, 0, sizeof(SN_Publish));
+        mqttCtx->publishSN.retain = 0;
+        mqttCtx->publishSN.qos = mqttCtx->qos;
+        mqttCtx->publishSN.duplicate = 0;
+        mqttCtx->publishSN.topic_type = SN_TOPIC_ID_TYPE_NORMAL;
+        mqttCtx->publishSN.topic_name = (char*)&topicID;
+        if (mqttCtx->publishSN.qos > MQTT_QOS_0) {
+            mqttCtx->publishSN.packet_id = mqtt_get_packetid();
         }
         else {
-            mqttCtx->publish.packet_id = 0x00;
+            mqttCtx->publishSN.packet_id = 0x00;
         }
 
-        mqttCtx->publish.buffer = (byte*)TEST_MESSAGE;
-        mqttCtx->publish.total_len = (word16)XSTRLEN(TEST_MESSAGE);
+        mqttCtx->publishSN.buffer = (byte*)TEST_MESSAGE;
+        mqttCtx->publishSN.total_len = (word16)XSTRLEN(TEST_MESSAGE);
 
-        rc = SN_Client_Publish(&mqttCtx->client, &mqttCtx->publish);
+        rc = SN_Client_Publish(&mqttCtx->client, &mqttCtx->publishSN);
 
         PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
-            (word16)*mqttCtx->publish.topic_name,
-                mqttCtx->publish.return_code,
-                mqttCtx->publish.buffer);
+            (word16)*mqttCtx->publishSN.topic_name,
+                mqttCtx->publishSN.return_code,
+                mqttCtx->publishSN.buffer);
         if (rc != MQTT_CODE_SUCCESS) {
             goto disconn;
         }
@@ -273,21 +273,21 @@ int sn_test(MQTTCtx *mqttCtx)
 
                 /* Publish Topic */
                 mqttCtx->stat = WMQ_PUB;
-                XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
-                mqttCtx->publish.retain = 0;
-                mqttCtx->publish.qos = mqttCtx->qos;
-                mqttCtx->publish.duplicate = 0;
-                mqttCtx->publish.topic_type = SN_TOPIC_ID_TYPE_NORMAL;
-                mqttCtx->publish.topic_name = (char*)&topicID;
-                mqttCtx->publish.packet_id = mqtt_get_packetid();
-                mqttCtx->publish.buffer = mqttCtx->rx_buf;
-                mqttCtx->publish.total_len = (word16)rc;
+                XMEMSET(&mqttCtx->publishSN, 0, sizeof(SN_Publish));
+                mqttCtx->publishSN.retain = 0;
+                mqttCtx->publishSN.qos = mqttCtx->qos;
+                mqttCtx->publishSN.duplicate = 0;
+                mqttCtx->publishSN.topic_type = SN_TOPIC_ID_TYPE_NORMAL;
+                mqttCtx->publishSN.topic_name = (char*)&topicID;
+                mqttCtx->publishSN.packet_id = mqtt_get_packetid();
+                mqttCtx->publishSN.buffer = mqttCtx->rx_buf;
+                mqttCtx->publishSN.total_len = (word16)rc;
                 rc = SN_Client_Publish(&mqttCtx->client,
-                       &mqttCtx->publish);
+                       &mqttCtx->publishSN);
                 PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
-                    (word16)*mqttCtx->publish.topic_name,
-                        mqttCtx->publish.return_code,
-                        mqttCtx->publish.buffer);
+                    (word16)*mqttCtx->publishSN.topic_name,
+                        mqttCtx->publishSN.return_code,
+                        mqttCtx->publishSN.buffer);
                 if (rc != MQTT_CODE_SUCCESS) {
                     break;
                 }
@@ -323,7 +323,7 @@ int sn_test(MQTTCtx *mqttCtx)
         SN_Unsubscribe unsubscribe;
 
         /* Build list of topics */
-        XMEMSET(&unsubscribe, 0, sizeof(SN_Subscribe));
+        XMEMSET(&unsubscribe, 0, sizeof(SN_Unsubscribe));
 
         unsubscribe.topicNameId = mqttCtx->topic_name;
 

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -222,7 +222,6 @@ int wiot_test(MQTTCtx *mqttCtx)
 
     /* Subscribe Topic */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
-    mqttCtx->subscribe.stat = MQTT_MSG_BEGIN;
     mqttCtx->subscribe.packet_id = mqtt_get_packetid();
     mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
     mqttCtx->subscribe.topics = mqttCtx->topics;

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -93,7 +93,6 @@
         WOLFSSL_API int wc_FreeMutex(wolfSSL_Mutex*);
         WOLFSSL_API int wc_LockMutex(wolfSSL_Mutex*);
         WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex*);
-        #define BAD_MUTEX_E -106
         */
 #endif
 


### PR DESCRIPTION
* Fixes for multi-thread handling of ack's when processing.
* Refactor to use `stat` from own struct, not shared `msg->stat`.
* Eliminated use of `client->msg` except for `MqttClient_WaitMessage`.
* Fixes to restore "state" after performing MqttClient operation.
* Refactor of publish read and write payload.
* Improvements to multithread example.
* Refactor of the SN code to support new object type and unique state for future multi-thread support.
* Added build option `TEST_NONBLOCK` to force testing non-blocking edge cases.
* Fix for fwpush getting stuck in stop loop on Ctrl+c exit.

ZD 5551