### PR TITLE
Improvements to the non-blocking connect code

### DIFF
--- a/commit-tests.sh
+++ b/commit-tests.sh
@@ -73,4 +73,15 @@ make -j 8 test;
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt' make test failed " && exit 1
 
+# make sure multithread with non-blocking is okay
+echo -e "\n\nTesting multithread with non-block config...\n\n"
+./configure --enable-mt;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt --enable-nonblock' failed" && exit 1
+
+make -j 8 test;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt --enable-nonblock' make test failed " && exit 1
+
+
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ AC_CHECK_SIZEOF([long long], 8)
 AC_CHECK_SIZEOF([long], 4)
 
 # Check headers/libs
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket signal])
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket signal rand])
 AC_CHECK_LIB([network],[socket])
 
 # DEBUG
@@ -153,7 +153,7 @@ AC_ARG_ENABLE([examples],
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
 
 
-# Error strings 
+# Error strings
 AC_ARG_ENABLE([errorstrings],
     [AS_HELP_STRING([--enable-errorstrings],[Enable error strings  (default: enabled)])],
     [ ENABLED_ERROR_STRINGS=$enableval ],
@@ -371,4 +371,3 @@ echo "   * Non-Blocking:              $ENABLED_NONBLOCK"
 echo "   * STDIN Capture:             $ENABLED_STDINCAP"
 echo "   * TLS:                       $ENABLED_TLS"
 echo "   * Multi-thread:              $ENABLED_MULTITHREAD"
-

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -690,7 +690,7 @@ exit:
 
         /* This example requires wolfSSL 3.9.1 or later with base64encode enabled */
         PRINTF("Example not compiled in!");
-        rc = EXIT_FAILURE;
+        rc = 0; /* return success, so make check passes with TLS disabled */
     #endif
 
         return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -682,6 +682,8 @@ exit:
         do {
             rc = awsiot_test(&mqttCtx);
         } while (rc == MQTT_CODE_CONTINUE);
+
+        mqtt_free_ctx(&mqttCtx);
     #else
         (void)argc;
         (void)argv;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -659,6 +659,8 @@ exit:
         do {
             rc = azureiothub_test(&mqttCtx);
         } while (rc == MQTT_CODE_CONTINUE);
+
+        mqtt_free_ctx(&mqttCtx);
     #else
         (void)argc;
         (void)argv;

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -667,7 +667,7 @@ exit:
 
         /* This example requires wolfSSL 3.9.1 or later with base64encode enabled */
         PRINTF("Example not compiled in!");
-        rc = EXIT_FAILURE;
+        rc = 0; /* return success, so make check passes with TLS disabled */
     #endif
 
         return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -553,6 +553,8 @@ exit:
         do {
             rc = fwclient_test(&mqttCtx);
         } while (rc == MQTT_CODE_CONTINUE);
+
+        mqtt_free_ctx(&mqttCtx);
     #else
         (void)argc;
         (void)argv;

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -561,7 +561,7 @@ exit:
 
         /* This example requires wolfSSL after 3.7.1 for signature wrapper */
         PRINTF("Example not compiled in!");
-        rc = EXIT_FAILURE;
+        rc = 0; /* return success, so make check passes with TLS disabled */
     #endif
 
         return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -658,7 +658,7 @@ exit:
 
         /* This example requires wolfSSL after 3.7.1 for signature wrapper */
         PRINTF("Example not compiled in!");
-        rc = EXIT_FAILURE;
+        rc = 0; /* return success, so make check passes with TLS disabled */
     #endif
 
         return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -320,7 +320,7 @@ int fwpush_test(MQTTCtx *mqttCtx)
     }
 
     /* restore callback data */
-    cbData = mqttCtx->publish.ctx;
+    cbData = (FwpushCBdata*)mqttCtx->publish.ctx;
 
     /* check for stop */
     if (mStopRead) {

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -650,6 +650,8 @@ exit:
         do {
             rc = fwpush_test(&mqttCtx);
         } while (rc == MQTT_CODE_CONTINUE);
+
+        mqtt_free_ctx(&mqttCtx);
     #else
         (void)argc;
         (void)argv;

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -620,6 +620,10 @@ int main(int argc, char** argv)
     /* parse arguments */
     rc = mqtt_parse_args(&mqttCtx, argc, argv);
     if (rc != 0) {
+        if (rc == MY_EX_USAGE) {
+            /* return success, so make check passes with TLS disabled */
+            return 0;
+        }
         return rc;
     }
 

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -470,6 +470,12 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         rc = MqttClient_WaitMessage(&mqttCtx->client,
                                             mqttCtx->cmd_timeout_ms);
 
+    #ifdef WOLFMQTT_NONBLOCK
+        /* Track elapsed time with no activity and trigger timeout */
+        rc = mqtt_check_timeout(rc, &mqttCtx->start_sec,
+            mqttCtx->cmd_timeout_ms/1000);
+    #endif
+
         /* check for test mode */
         if (mStopRead) {
             rc = MQTT_CODE_SUCCESS;
@@ -605,7 +611,6 @@ exit:
 int main(int argc, char** argv)
 {
     int rc;
-#ifndef WOLFMQTT_NONBLOCK
     MQTTCtx mqttCtx;
 
     /* init defaults */
@@ -617,7 +622,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         return rc;
     }
-#endif
+
 #ifdef USE_WINDOWS_API
     if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler,
           TRUE) == FALSE)
@@ -630,17 +635,7 @@ int main(int argc, char** argv)
     }
 #endif
 
-#ifndef WOLFMQTT_NONBLOCK
     rc = mqttclient_test(&mqttCtx);
-#else
-    (void)argc;
-    (void)argv;
-
-    /* This example requires non-blocking mode to be disabled
-       ./configure --disable-nonblock */
-    PRINTF("Example not compiled in!");
-    rc = EXIT_FAILURE;
-#endif
 
 
     return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -637,6 +637,7 @@ int main(int argc, char** argv)
 
     rc = mqttclient_test(&mqttCtx);
 
+    mqtt_free_ctx(&mqttCtx);
 
     return (rc == 0) ? 0 : EXIT_FAILURE;
 }

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -31,6 +31,8 @@
 
 /* locals */
 static volatile word16 mPacketIdLast;
+static const char* kDefTopicName = DEFAULT_TOPIC_NAME;
+static const char* kDefClientId =  DEFAULT_CLIENT_ID;
 
 /* argument parsing */
 static int myoptind = 0;
@@ -40,7 +42,6 @@ static char* myoptarg = NULL;
 	static const char* mTlsCaFile;
 #endif
 
-#define MY_EX_USAGE 2 /* Exit reason code */
 static int mygetopt(int argc, char** argv, const char* optstring)
 {
     static char* next = NULL;
@@ -207,8 +208,8 @@ void mqtt_init_ctx(MQTTCtx* mqttCtx)
     mqttCtx->qos = DEFAULT_MQTT_QOS;
     mqttCtx->clean_session = 1;
     mqttCtx->keep_alive_sec = DEFAULT_KEEP_ALIVE_SEC;
-    mqttCtx->client_id = DEFAULT_CLIENT_ID;
-    mqttCtx->topic_name = DEFAULT_TOPIC_NAME;
+    mqttCtx->client_id = kDefClientId;
+    mqttCtx->topic_name = kDefTopicName;
     mqttCtx->cmd_timeout_ms = DEFAULT_CMD_TIMEOUT_MS;
 #ifdef WOLFMQTT_V5
     mqttCtx->max_packet_size = DEFAULT_MAX_PKT_SZ;
@@ -340,17 +341,17 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
 #ifdef ENABLE_MQTT_TLS
     /* for test mode only */
     /* add random data to end of client_id and topic_name */
-    if (mqttCtx->test_mode && mqttCtx->topic_name == DEFAULT_TOPIC_NAME) {
-        char* topic_name = mqtt_append_random(DEFAULT_TOPIC_NAME,
-            (word32)XSTRLEN(DEFAULT_TOPIC_NAME));
+    if (mqttCtx->test_mode && mqttCtx->topic_name == kDefTopicName) {
+        char* topic_name = mqtt_append_random(kDefTopicName,
+            (word32)XSTRLEN(kDefTopicName));
         if (topic_name) {
             mqttCtx->topic_name = (const char*)topic_name;
             mqttCtx->dynamicTopic = 1;
         }
     }
-    if (mqttCtx->test_mode && mqttCtx->client_id == DEFAULT_CLIENT_ID) {
-        char* client_id = mqtt_append_random(DEFAULT_CLIENT_ID,
-            (word32)XSTRLEN(DEFAULT_CLIENT_ID));
+    if (mqttCtx->test_mode && mqttCtx->client_id == kDefClientId) {
+        char* client_id = mqtt_append_random(kDefClientId,
+            (word32)XSTRLEN(kDefClientId));
         if (client_id) {
             mqttCtx->client_id = (const char*)client_id;
             mqttCtx->dynamicClientId = 1;

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -136,10 +136,10 @@ static char* mqtt_append_random(const char* inStr, word32 inLen)
     if (rc == 0) {
         /* Convert random to hex string */
         int i;
-        for (i=0; i<(int)sizeof(rndHexStr); i+=2) {
+        for (i=0; i<(int)sizeof(rndBytes); i++) {
             byte in = rndBytes[i];
-            rndHexStr[i] =   kHexChar[in >> 4];
-            rndHexStr[i+1] = kHexChar[in & 0xf];
+            rndHexStr[(i*2)] =   kHexChar[in >> 4];
+            rndHexStr[(i*2)+1] = kHexChar[in & 0xf];
         }
     }
     if (rc == 0) {
@@ -340,7 +340,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
 #ifdef ENABLE_MQTT_TLS
     /* for test mode only */
     /* add random data to end of client_id and topic_name */
-    if (mqttCtx->test_mode && mqttCtx->topic_name == DEFAULT_CLIENT_ID) {
+    if (mqttCtx->test_mode && mqttCtx->topic_name == DEFAULT_TOPIC_NAME) {
         char* topic_name = mqtt_append_random(DEFAULT_TOPIC_NAME,
             (word32)XSTRLEN(DEFAULT_TOPIC_NAME));
         if (topic_name) {

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -109,16 +109,24 @@ static int mygetopt(int argc, char** argv, const char* optstring)
 /* used for testing only, requires wolfSSL RNG */
 #ifdef ENABLE_MQTT_TLS
 #include <wolfssl/wolfcrypt/random.h>
+#endif
 
 static int mqtt_get_rand(byte* data, word32 len)
 {
     int ret = -1;
+#ifdef ENABLE_MQTT_TLS
     WC_RNG rng;
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_RNG_GenerateBlock(&rng, data, len);
         wc_FreeRng(&rng);
     }
+#elif defined(HAVE_RAND)
+    word32 i;
+    for (i = 0; i<len; i++) {
+        data[i] = (byte)rand();
+    }
+#endif
     return ret;
 }
 
@@ -159,7 +167,6 @@ static char* mqtt_append_random(const char* inStr, word32 inLen)
     }
     return tmp;
 }
-#endif /* ENABLE_MQTT_TLS */
 
 void mqtt_show_usage(MQTTCtx* mqttCtx)
 {
@@ -338,7 +345,6 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
     }
 #endif
 
-#ifdef ENABLE_MQTT_TLS
     /* for test mode only */
     /* add random data to end of client_id and topic_name */
     if (mqttCtx->test_mode && mqttCtx->topic_name == kDefTopicName) {
@@ -357,7 +363,6 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
             mqttCtx->dynamicClientId = 1;
         }
     }
-#endif
 
     return rc;
 }

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -342,6 +342,7 @@ int mqtt_check_timeout(int rc, word32* start_sec, word32 timeout_sec)
         elapsed_sec -= *start_sec;
         if (elapsed_sec >= timeout_sec) {
             *start_sec = mqtt_get_timer_seconds();
+            PRINTF("Timeout timer %d seconds", timeout_sec);
             return MQTT_CODE_ERROR_TIMEOUT;
         }
     }

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -91,6 +91,8 @@ typedef enum _MQTTCtxState {
 } MQTTCtxState;
 
 /* MQTT Client context */
+/* This is used for the examples as reference */
+/* Use of this structure allow non-blocking context */
 typedef struct _MQTTCtx {
     MQTTCtxState stat;
 
@@ -146,14 +148,18 @@ typedef struct _MQTTCtx {
     byte    subId_not_avail; /* Server property */
     byte    enable_eauth; /* Enhanced authentication */
 #endif
+    unsigned int dynamicTopic:1;
+    unsigned int dynamicClientId:1;
 #ifdef WOLFMQTT_NONBLOCK
-    unsigned int useNonBlockMode:1;
+    unsigned int useNonBlockMode:1; /* set to use non-blocking mode.
+        network callbacks can return MQTT_CODE_CONTINUE to indicate "would block" */
 #endif
 } MQTTCtx;
 
 
 void mqtt_show_usage(MQTTCtx* mqttCtx);
 void mqtt_init_ctx(MQTTCtx* mqttCtx);
+void mqtt_free_ctx(MQTTCtx* mqttCtx);
 int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv);
 int err_sys(const char* msg);
 

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -146,6 +146,9 @@ typedef struct _MQTTCtx {
     byte    subId_not_avail; /* Server property */
     byte    enable_eauth; /* Enhanced authentication */
 #endif
+#ifdef WOLFMQTT_NONBLOCK
+    unsigned int useNonBlockMode:1;
+#endif
 } MQTTCtx;
 
 

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -32,6 +32,10 @@
 	#define exit(rc) return rc
 #endif
 
+#ifndef MY_EX_USAGE
+#define MY_EX_USAGE 2 /* Exit reason code */
+#endif
+
 /* STDIN / FGETS for examples */
 #ifndef WOLFMQTT_NO_STDIO
     /* For Linux/Mac */

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -826,6 +826,8 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     MQTTCtx* mqttCtx = sock->mqttCtx;
 #endif
 
+    (void)mqttCtx;
+
     if (context == NULL || buf == NULL || buf_len <= 0) {
         return MQTT_CODE_ERROR_BAD_ARG;
     }

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -627,28 +627,31 @@ static int NetConnect(void *context, const char* host, word16 port,
         #endif /* !WOLFMQTT_NO_TIMEOUT */
 
         #if !defined(WOLFMQTT_NO_TIMEOUT) && defined(WOLFMQTT_NONBLOCK)
-            /* Set socket as non-blocking */
-            tcp_set_nonblocking(&sock->fd);
+            if (mqttCtx->useNonBlockMode) {
+                /* Set socket as non-blocking */
+                tcp_set_nonblocking(&sock->fd);
+            }
         #endif
 
             /* Start connect */
             rc = SOCK_CONNECT(sock->fd, (struct sockaddr*)&sock->addr, sizeof(sock->addr));
-        #ifndef WOLFMQTT_NO_TIMEOUT
-            /* Wait for connect */
-            if (rc < 0 || select((int)SELECT_FD(sock->fd), NULL, &fdset, NULL, &tv) > 0)
-        #else
-            if (rc < 0)
-        #endif /* !WOLFMQTT_NO_TIMEOUT */
-            {
+            if (rc < 0) {
                 /* Check for error */
                 socklen_t len = sizeof(so_error);
                 getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, &so_error, &len);
-                if (so_error == 0) {
-                    rc = 0; /* Success */
-                }
-            #if !defined(WOLFMQTT_NO_TIMEOUT) && defined(WOLFMQTT_NONBLOCK)
-                else if (so_error == EINPROGRESS) {
+
+                /* set default error case */
+                rc = MQTT_CODE_ERROR_NETWORK;
+            #ifdef WOLFMQTT_NONBLOCK
+                if (errno == EINPROGRESS || so_error == EINPROGRESS) {
+                #ifndef WOLFMQTT_NO_TIMEOUT
+                    /* Wait for connect */
+                    if (select((int)SELECT_FD(sock->fd), NULL, &fdset, NULL, &tv) > 0) {
+                        rc = MQTT_CODE_SUCCESS;
+                    }
+                #else
                     rc = MQTT_CODE_CONTINUE;
+                #endif
                 }
             #endif
             }
@@ -816,10 +819,11 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     SOERROR_T so_error = 0;
     int bytes = 0;
     int flags = 0;
-#if !defined(WOLFMQTT_NO_TIMEOUT) && !defined(WOLFMQTT_NONBLOCK)
+#ifndef WOLFMQTT_NO_TIMEOUT
     fd_set recvfds;
     fd_set errfds;
     struct timeval tv;
+    MQTTCtx* mqttCtx = sock->mqttCtx;
 #endif
 
     if (context == NULL || buf == NULL || buf_len <= 0) {
@@ -833,7 +837,7 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
         flags |= MSG_PEEK;
     }
 
-#if !defined(WOLFMQTT_NO_TIMEOUT) && !defined(WOLFMQTT_NONBLOCK)
+#ifndef WOLFMQTT_NO_TIMEOUT
     /* Setup timeout and FD's */
     setup_timeout(&tv, timeout_ms);
     FD_ZERO(&recvfds);
@@ -851,50 +855,69 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
 
     /* Loop until buf_len has been read, error or timeout */
     while (bytes < buf_len) {
+        int do_read = 0;
 
-    #if !defined(WOLFMQTT_NO_TIMEOUT) && !defined(WOLFMQTT_NONBLOCK)
-        /* Wait for rx data to be available */
-        rc = select((int)SELECT_FD(sock->fd), &recvfds, NULL, &errfds, &tv);
-        if (rc > 0)
-        {
-            /* Check if rx or error */
-            if (FD_ISSET(sock->fd, &recvfds)) {
-    #endif /* !WOLFMQTT_NO_TIMEOUT && !WOLFMQTT_NONBLOCK */
-
-                /* Try and read number of buf_len provided,
-                    minus what's already been read */
-                rc = (int)SOCK_RECV(sock->fd,
-                               &buf[bytes],
-                               buf_len - bytes,
-                               flags);
-                if (rc <= 0) {
-                    rc = -1;
-                    goto exit; /* Error */
-                }
-                else {
-                    bytes += rc; /* Data */
-                }
-
-    #if !defined(WOLFMQTT_NO_TIMEOUT) && !defined(WOLFMQTT_NONBLOCK)
-            }
-        #ifdef WOLFMQTT_ENABLE_STDIN_CAP
-            else if (FD_ISSET(STDIN, &recvfds)) {
-                return MQTT_CODE_STDIN_WAKE;
-            }
-        #endif
-            if (FD_ISSET(sock->fd, &errfds)) {
-                rc = -1;
-                break;
-            }
+    #ifndef WOLFMQTT_NO_TIMEOUT
+        #ifdef WOLFMQTT_NONBLOCK
+        if (mqttCtx->useNonBlockMode) {
+            do_read = 1;
         }
-        else {
-            timeout = 1;
-            break; /* timeout or signal */
+        else
+        #endif
+        {
+            /* Wait for rx data to be available */
+            rc = select((int)SELECT_FD(sock->fd), &recvfds, NULL, &errfds, &tv);
+            if (rc > 0)
+            {
+                if (FD_ISSET(sock->fd, &recvfds))
+                {
+                    do_read = 1;
+                }
+                /* Check if rx or error */
+            #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+                else if (FD_ISSET(STDIN, &recvfds)) {
+                    return MQTT_CODE_STDIN_WAKE;
+                }
+            #endif
+                if (FD_ISSET(sock->fd, &errfds)) {
+                    rc = -1;
+                    break;
+                }
+            }
+            else {
+                timeout = 1;
+                break; /* timeout or signal */
+            }
         }
     #else
-        /* non-blocking should always exit loop */
+        do_read = 1;
+    #endif /* !WOLFMQTT_NO_TIMEOUT */
+
+        if (do_read) {
+            /* Try and read number of buf_len provided,
+                minus what's already been read */
+            rc = (int)SOCK_RECV(sock->fd,
+                           &buf[bytes],
+                           buf_len - bytes,
+                           flags);
+            if (rc <= 0) {
+                rc = -1;
+                goto exit; /* Error */
+            }
+            else {
+                bytes += rc; /* Data */
+            }
+        }
+
+        /* no timeout and non-block should always exit loop */
+    #ifdef WOLFMQTT_NONBLOCK
+        if (mqttCtx->useNonBlockMode) {
+            break;
+        }
+    #endif
+    #ifdef WOLFMQTT_NO_TIMEOUT
         break;
-    #endif /* !WOLFMQTT_NO_TIMEOUT && !WOLFMQTT_NONBLOCK */
+    #endif
     } /* while */
 
 exit:

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -814,6 +814,7 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     int timeout_ms, byte peek)
 {
     SocketContext *sock = (SocketContext*)context;
+    MQTTCtx* mqttCtx = sock->mqttCtx;
     int rc = -1, timeout = 0;
     SOERROR_T so_error = 0;
     int bytes = 0;
@@ -822,7 +823,6 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     fd_set recvfds;
     fd_set errfds;
     struct timeval tv;
-    MQTTCtx* mqttCtx = sock->mqttCtx;
 #endif
 
     (void)mqttCtx;
@@ -847,7 +847,9 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     FD_SET(sock->fd, &errfds);
 
     #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+    if (!mqttCtx->test_mode) {
         FD_SET(STDIN, &recvfds);
+    }
     #endif
 
 #else
@@ -876,7 +878,7 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
                 }
                 /* Check if rx or error */
             #ifdef WOLFMQTT_ENABLE_STDIN_CAP
-                else if (FD_ISSET(STDIN, &recvfds)) {
+                else if (!mqttCtx->test_mode && FD_ISSET(STDIN, &recvfds)) {
                     return MQTT_CODE_STDIN_WAKE;
                 }
             #endif

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -723,8 +723,7 @@ static int SN_NetConnect(void *context, const char* host, word16 port,
     }
 
     if (rc == 0) {
-
-    /* Create the socket */
+        /* Create the socket */
         sock->fd = SOCK_OPEN(sock->addr.sin_family, type, 0);
         if (sock->fd == SOCKET_INVALID) {
             rc = -1;

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -519,7 +519,7 @@ int multithread_test(MQTTCtx *mqttCtx)
 int main(int argc, char** argv)
 {
     int rc;
-#if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+#ifdef WOLFMQTT_MULTITHREAD
     MQTTCtx mqttCtx;
 
     /* init defaults */
@@ -543,7 +543,7 @@ int main(int argc, char** argv)
         PRINTF("Can't catch SIGINT");
     }
 #endif
-#if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+#ifdef WOLFMQTT_MULTITHREAD
     rc = multithread_test(&mqttCtx);
 #else
     (void)argc;

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -545,6 +545,8 @@ int main(int argc, char** argv)
 #endif
 #ifdef WOLFMQTT_MULTITHREAD
     rc = multithread_test(&mqttCtx);
+
+    mqtt_free_ctx(&mqttCtx);
 #else
     (void)argc;
     (void)argv;

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -545,8 +545,6 @@ int main(int argc, char** argv)
 #endif
 #if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
     rc = multithread_test(&mqttCtx);
-
-    return (rc == 0) ? 0 : EXIT_FAILURE;
 #else
     (void)argc;
     (void)argv;
@@ -557,6 +555,7 @@ int main(int argc, char** argv)
     rc = EXIT_FAILURE;
     (void) rc;
 #endif
+    return (rc == 0) ? 0 : EXIT_FAILURE;
 }
 
 #endif /* NO_MAIN_DRIVER */

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -29,7 +29,6 @@
 #include "multithread.h"
 #include "examples/mqttnet.h"
 #ifdef WOLFMQTT_MULTITHREAD
-    #define _GNU_SOURCE
     #include <pthread.h>
     #include <sched.h>
 #endif

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -378,7 +378,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         {
             /* Unsubscribe Topics */
             rc = MqttClient_Unsubscribe(&mqttCtx->client,
-                   &mqttCtx->unsubscribe);
+                &mqttCtx->unsubscribe);
             if (rc == MQTT_CODE_CONTINUE) {
                 /* Track elapsed time with no activity and trigger timeout */
                 return mqtt_check_timeout(rc, &mqttCtx->start_sec,
@@ -503,6 +503,10 @@ exit:
         /* parse arguments */
         rc = mqtt_parse_args(&mqttCtx, argc, argv);
         if (rc != 0) {
+            if (rc == MY_EX_USAGE) {
+                /* return success, so make check passes with TLS disabled */
+                return 0;
+            }
             return rc;
         }
 #endif

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -113,6 +113,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos,
                     mqttCtx->use_tls);
 
+            mqttCtx->useNonBlockMode = 1;
+
             FALL_THROUGH;
         }
 
@@ -535,4 +537,3 @@ exit:
     }
 
 #endif /* NO_MAIN_DRIVER */
-

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -524,13 +524,13 @@ exit:
             rc = mqttclient_test(&mqttCtx);
         } while (rc == MQTT_CODE_CONTINUE);
 #else
-    (void)argc;
-    (void)argv;
+        (void)argc;
+        (void)argv;
 
-    /* This example requires non-blocking mode to be enabled
-       ./configure --enable-nonblock */
-    PRINTF("Example not compiled in!");
-    rc = EXIT_FAILURE;
+        /* This example requires non-blocking mode to be enabled
+           ./configure --enable-nonblock */
+        PRINTF("Example not compiled in!");
+        rc = 0; /* return success, so make check passes with TLS disabled */
 #endif
 
         return (rc == 0) ? 0 : EXIT_FAILURE;

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -401,7 +401,6 @@ exit:
 int main(int argc, char** argv)
 {
     int rc;
-#ifndef WOLFMQTT_NONBLOCK
     MQTTCtx mqttCtx;
 
     /* init defaults */
@@ -420,7 +419,6 @@ int main(int argc, char** argv)
     if (rc != 0) {
         return rc;
     }
-#endif
 
 #ifdef USE_WINDOWS_API
     if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler, TRUE) == FALSE) {
@@ -432,17 +430,11 @@ int main(int argc, char** argv)
     }
 #endif
 
-#ifndef WOLFMQTT_NONBLOCK
-    rc = wiot_test(&mqttCtx);
-#else
-    (void)argc;
-    (void)argv;
+    do {
+        rc = wiot_test(&mqttCtx);
+    } while (rc == MQTT_CODE_CONTINUE);
 
-    /* This example requires non-blocking mode to be disabled
-       ./configure --disable-nonblock */
-    PRINTF("Example not compiled in!");
-    rc = EXIT_FAILURE;
-#endif
+    mqtt_free_ctx(&mqttCtx);
 
     return (rc == 0) ? 0 : EXIT_FAILURE;
 }

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -11,10 +11,10 @@ def_args="-T -C 2000"
 
 ./examples/aws/awsiot $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
 
 ./examples/aws/awsiot $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=1" && exit 1
 
 exit 0

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -17,4 +17,6 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=1" && exit 1
 
+echo -e "\n\nAWS IoT MQTT Client Tests Passed"
+
 exit 0

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/aws/awsiot ] && echo -e "\n\nAWS IoT MQTT Client doesn't exist" && exit 1
 
-def_args="-T -C 1000"
+def_args="-T -C 2000"
 
 # Run with TLS and QoS 0-1
 

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -17,4 +17,6 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=1" && exit 1
 
+echo -e "\n\nAzureIotHub MQTT Client Tests Passed"
+
 exit 0

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -11,10 +11,10 @@ def_args="-T -C 2000"
 
 ./examples/azure/azureiothub $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=0" && exit 1
 
 ./examples/azure/azureiothub $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=1" && exit 1
 
 exit 0

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/azure/azureiothub ] && echo -e "\n\nAzureIotHub MQTT Client doesn't exist" && exit 1
 
-def_args="-T -C 1000"
+def_args="-T -C 2000"
 
 # Run with TLS and QoS 0-1
 

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -33,4 +33,6 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && exit 1
 
+echo -e "\n\nMQTT Client Tests Passed"
+
 exit 0

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/mqttclient/mqttclient ] && echo -e "\n\nMQTT Client doesn't exist" && exit 1
 
-def_args="-T -C 1000"
+def_args="-T -C 2000"
 
 # Run with and without TLS and QoS 0-2
 

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -11,26 +11,26 @@ def_args="-T -C 2000"
 
 ./examples/mqttclient/mqttclient $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && exit 1
 
 ./examples/mqttclient/mqttclient $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=1" && exit 1
 
 ./examples/mqttclient/mqttclient $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=2" && exit 1
 
 ./examples/mqttclient/mqttclient $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && exit 1
 
 ./examples/mqttclient/mqttclient $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && exit 1
 
 ./examples/mqttclient/mqttclient $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && exit 1
 
 exit 0

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -13,17 +13,17 @@ fileout=./README.md.trs
 # Start firmware push
 ./examples/firmware/fwpush $def_args -r -f $filein $1
 server_result=$?
-[ $server_result -lt 0 ] && echo -e "\n\nMQTT Example fwpush failed!" && exit 1
+[ $server_result -ne 0 ] && echo -e "\n\nMQTT Example fwpush failed!" && exit 1
 
 # Start firmware client
 ./examples/firmware/fwclient $def_args -f $fileout $1
 client_result=$?
-[ $client_result -lt 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && exit 1
+[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && exit 1
 
 # Compare files
 md5sum -b $filein $fileout
 compare_result=$?
-[ $client_result -lt 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && exit 1
+[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && exit 1
 
 # Delete file
 rm $fileout

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -28,6 +28,6 @@ compare_result=$?
 # Delete file
 rm $fileout
 
-echo MQTT Firmware Example Test Success!
+echo -e "\n\nFirmware Example MQTT Client Tests Passed"
 
 exit 0

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/multithread/multithread ] && echo -e "\n\nMultithread Client doesn't exist" && exit 1
 
-def_args="-T -C 1000"
+def_args="-T -C 2000"
 
 # Run with and without TLS and QoS 0-2
 

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/multithread/multithread ] && echo -e "\n\nMultithread Client doesn't exist" && exit 1
 
-def_args="-T -C 2000"
+def_args="-T -C 5000"
 
 # Run with and without TLS and QoS 0-2
 
@@ -32,5 +32,7 @@ RESULT=$?
 ./examples/multithread/multithread $def_args -t -q 2 $1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && exit 1
+
+echo -e "\n\nMultithread MQTT Client Tests Passed"
 
 exit 0

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -11,26 +11,26 @@ def_args="-T -C 2000"
 
 ./examples/multithread/multithread $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && exit 1
 
 ./examples/multithread/multithread $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=1" && exit 1
 
 ./examples/multithread/multithread $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && exit 1
 
 ./examples/multithread/multithread $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && exit 1
 
 ./examples/multithread/multithread $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && exit 1
 
 ./examples/multithread/multithread $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && exit 1
 
 exit 0

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -35,4 +35,6 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && exit 1
 
+echo -e "\n\nNon-blocking MQTT Client Tests Passed"
+
 exit 0

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -5,7 +5,9 @@
 # Check for application
 [ ! -x ./examples/nbclient/nbclient ] && echo -e "\n\nNon-blocking Client doesn't exist" && exit 1
 
-def_args="-T -C 1000"
+# Use minimum of 2 seconds
+# The check timout will sometimes incorrectly trigger if 1 second is used
+def_args="-T -C 2000"
 
 # Run with and without TLS and QoS 0-2
 

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -13,26 +13,26 @@ def_args="-T -C 2000"
 
 ./examples/nbclient/nbclient $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=0" && exit 1
 
 ./examples/nbclient/nbclient $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=1" && exit 1
 
 ./examples/nbclient/nbclient $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=2" && exit 1
 
 ./examples/nbclient/nbclient $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && exit 1
 
 ./examples/nbclient/nbclient $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && exit 1
 
 ./examples/nbclient/nbclient $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && exit 1
 
 exit 0

--- a/scripts/wiot.test
+++ b/scripts/wiot.test
@@ -5,7 +5,7 @@
 # Check for application
 [ ! -x ./examples/wiot/wiot ] && echo -e "\n\nWatson IoT MQTT Client doesn't exist" && exit 1
 
-def_args="-T"
+def_args="-T -C 2000"
 
 # Run
 

--- a/scripts/wiot.test
+++ b/scripts/wiot.test
@@ -13,4 +13,6 @@ def_args="-T -C 2000"
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nWatson IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
 
+echo -e "\n\nWatson IoT MQTT Client Tests Passed"
+
 exit 0

--- a/scripts/wiot.test
+++ b/scripts/wiot.test
@@ -11,6 +11,6 @@ def_args="-T -C 2000"
 
 ./examples/wiot/wiot $def_args $1
 RESULT=$?
-[ $RESULT -lt 0 ] && echo -e "\n\nWatson IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nWatson IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
 
 exit 0

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -201,7 +201,7 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
 
     /* Decode header */
     header = (MqttPacket*)rx_buf;
-    packet_type = MQTT_PACKET_TYPE_GET(header->type_flags);
+    packet_type = (MqttPacketType)MQTT_PACKET_TYPE_GET(header->type_flags);
     if (ppacket_type) {
         *ppacket_type = packet_type;
     }
@@ -524,11 +524,12 @@ static int MqttClient_HandlePacket(MqttClient* client,
 
             /* Encode publish response */
             publish_resp.packet_id = packet_id;
+            packet_type = (MqttPacketType)((int)packet_type+1); /* next ack */
             rc = MqttEncode_PublishResp(client->tx_buf, client->tx_buf_len,
-                packet_type+1, &publish_resp);
+                packet_type, &publish_resp);
         #ifdef WOLFMQTT_DEBUG_CLIENT
             PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
-                rc, MqttPacket_TypeDesc(packet_type+1), packet_type+1, packet_id,
+                rc, MqttPacket_TypeDesc(packet_type), packet_type, packet_id,
                 packet_qos);
         #endif
             if (rc <= 0) {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -434,7 +434,7 @@ static int MqttClient_HandlePacket(MqttClient* client,
             MqttPublish *publish = (MqttPublish*)packet_obj;
             MqttPacketType resp_type;
 
-            if (publish->stat == MQTT_MSG_READ) {
+            if (publish->stat == MQTT_MSG_BEGIN || publish->stat == MQTT_MSG_READ) {
                 rc = MqttClient_DecodePacket(client, client->rx_buf,
                     client->packet.buf_len, packet_obj, &packet_type,
                     &packet_qos, &packet_id);
@@ -471,6 +471,11 @@ static int MqttClient_HandlePacket(MqttClient* client,
             /* Encode publish response */
             rc = MqttEncode_PublishResp(client->tx_buf, client->tx_buf_len,
                 resp_type, &publish->resp);
+        #ifdef WOLFMQTT_DEBUG_CLIENT
+            PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+                rc, MqttPacket_TypeDesc(resp_type), resp_type, packet_id,
+                packet_qos);
+        #endif
             if (rc <= 0) {
             #ifdef WOLFMQTT_MULTITHREAD
                 wc_UnLockMutex(&client->lockSend);
@@ -518,8 +523,14 @@ static int MqttClient_HandlePacket(MqttClient* client,
         #endif
 
             /* Encode publish response */
+            publish_resp.packet_id = packet_id;
             rc = MqttEncode_PublishResp(client->tx_buf, client->tx_buf_len,
                 packet_type+1, &publish_resp);
+        #ifdef WOLFMQTT_DEBUG_CLIENT
+            PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+                rc, MqttPacket_TypeDesc(packet_type+1), packet_type+1, packet_id,
+                packet_qos);
+        #endif
             if (rc <= 0) {
             #ifdef WOLFMQTT_MULTITHREAD
                 wc_UnLockMutex(&client->lockSend);
@@ -716,20 +727,30 @@ wait_again:
         case MQTT_MSG_READ:
         case MQTT_MSG_READ_PAYLOAD:
         {
+            MqttPacketType use_packet_type;
+            void* use_packet_obj;
+
         #ifdef WOLFMQTT_MULTITHREAD
             readLocked = 1; /* if in this state read is locked */
         #endif
 
+            /* read payload state only happens for publish messages */
             if (*mms_stat == MQTT_MSG_READ_PAYLOAD) {
-                /* read payload state only happens for publish messages */
                 packet_type = MQTT_PACKET_TYPE_PUBLISH;
             }
 
             /* Determine if we received data for this request */
             if ((wait_type == MQTT_PACKET_TYPE_ANY || wait_type == packet_type) &&
-               (wait_packet_id == 0 || wait_packet_id == packet_id)) {
+               (wait_packet_id == 0 || wait_packet_id == packet_id))
+            {
+                use_packet_obj = packet_obj;
                 waitMatchFound = 1;
             }
+            else {
+                /* use generic packet object */
+                use_packet_obj = &client->msg;
+            }
+            use_packet_type = packet_type;
 
         #ifdef WOLFMQTT_MULTITHREAD
             /* Check to see if we have a pending response for this packet */
@@ -740,26 +761,20 @@ wait_again:
                                                                    &pendResp)) {
                     /* we found packet match this incoming read packet */
                     pendResp->packetProcessing = 1;
+                    use_packet_obj = pendResp->packet_obj;
+                    use_packet_type = pendResp->packet_type;
+                    waitMatchFound = 0; /* req from another thread... not a match */
                 }
                 wc_UnLockMutex(&client->lockClient);
             }
             else {
                 break; /* error */
             }
-
-            if (pendResp) {
-                rc = MqttClient_HandlePacket(client, pendResp->packet_type,
-                    pendResp->packet_obj, timeout_ms);
-                waitMatchFound = 0; /* req from another thread... not a match */
-            }
-            else
         #endif /* WOLFMQTT_MULTITHREAD */
-            /* always try and "handle" packet */
-            /* we need to call this for the publish QoS responses */
-            {
-                rc = MqttClient_HandlePacket(client, packet_type,
-                    packet_obj, timeout_ms);
-            }
+
+            /* Perform packet handling for publish callback and QoS */
+            rc = MqttClient_HandlePacket(client, use_packet_type,
+                use_packet_obj, timeout_ms);
 
         #ifdef WOLFMQTT_NONBLOCK
             if (rc == MQTT_CODE_CONTINUE) {
@@ -942,6 +957,11 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 
         /* Encode the connect packet */
         rc = MqttEncode_Connect(client->tx_buf, client->tx_buf_len, mc_connect);
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+            rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_CONNECT),
+            MQTT_PACKET_TYPE_CONNECT, 0, 0);
+    #endif
         if (rc <= 0) {
             #ifdef WOLFMQTT_MULTITHREAD
                 wc_UnLockMutex(&client->lockSend);
@@ -1290,6 +1310,12 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
             /* Encode the publish packet */
             rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len,
                     publish, pubCb ? 1 : 0);
+        #ifdef WOLFMQTT_DEBUG_CLIENT
+            PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+                rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_PUBLISH),
+                MQTT_PACKET_TYPE_PUBLISH, publish->packet_id,
+                publish->qos);
+        #endif
             if (rc <= 0) {
             #ifdef WOLFMQTT_MULTITHREAD
                 wc_UnLockMutex(&client->lockSend);
@@ -1462,6 +1488,11 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
         /* Encode the subscribe packet */
         rc = MqttEncode_Subscribe(client->tx_buf, client->tx_buf_len,
                 subscribe);
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+            rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_SUBSCRIBE),
+            MQTT_PACKET_TYPE_SUBSCRIBE, subscribe->packet_id, 0);
+    #endif
         if (rc <= 0) {
         #ifdef WOLFMQTT_MULTITHREAD
             wc_UnLockMutex(&client->lockSend);
@@ -1555,6 +1586,11 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
         /* Encode the subscribe packet */
         rc = MqttEncode_Unsubscribe(client->tx_buf, client->tx_buf_len,
             unsubscribe);
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+            rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_UNSUBSCRIBE),
+            MQTT_PACKET_TYPE_UNSUBSCRIBE, unsubscribe->packet_id, 0);
+    #endif
         if (rc <= 0) {
         #ifdef WOLFMQTT_MULTITHREAD
             wc_UnLockMutex(&client->lockSend);
@@ -1645,6 +1681,11 @@ int MqttClient_Ping_ex(MqttClient *client, MqttPing* ping)
 
         /* Encode the subscribe packet */
         rc = MqttEncode_Ping(client->tx_buf, client->tx_buf_len, ping);
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+            rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_PING_REQ),
+            MQTT_PACKET_TYPE_PING_REQ, 0, 0);
+    #endif
         if (rc <= 0) {
         #ifdef WOLFMQTT_MULTITHREAD
             wc_UnLockMutex(&client->lockSend);
@@ -1737,6 +1778,11 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *disconnect)
 
     /* Encode the disconnect packet */
     rc = MqttEncode_Disconnect(client->tx_buf, client->tx_buf_len, disconnect);
+#ifdef WOLFMQTT_DEBUG_CLIENT
+    PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+        rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_DISCONNECT),
+        MQTT_PACKET_TYPE_DISCONNECT, 0, 0);
+#endif
     if (rc <= 0) {
     #ifdef WOLFMQTT_MULTITHREAD
         wc_UnLockMutex(&client->lockSend);
@@ -1780,6 +1826,11 @@ int MqttClient_Auth(MqttClient *client, MqttAuth* auth)
 
         /* Encode the authentication packet */
         rc = MqttEncode_Auth(client->tx_buf, client->tx_buf_len, auth);
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
+            rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_AUTH),
+            MQTT_PACKET_TYPE_AUTH, auth->packet_id, auth->packet_qos);
+    #endif
         if (rc <= 0) {
         #ifdef WOLFMQTT_MULTITHREAD
             wc_UnLockMutex(&client->lockSend);
@@ -2687,4 +2738,3 @@ int SN_Client_WaitMessage(MqttClient *client, int timeout_ms)
 }
 
 #endif /* defined WOLFMQTT_SN */
-

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1830,7 +1830,7 @@ int MqttClient_Auth(MqttClient *client, MqttAuth* auth)
     #ifdef WOLFMQTT_DEBUG_CLIENT
         PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
             rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_AUTH),
-            MQTT_PACKET_TYPE_AUTH, auth->packet_id, auth->packet_qos);
+            MQTT_PACKET_TYPE_AUTH, 0, 0);
     #endif
         if (rc <= 0) {
         #ifdef WOLFMQTT_MULTITHREAD

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -388,7 +388,11 @@ typedef struct _MqttConnectAck {
 /* Connect structure */
 struct _MqttMessage;
 typedef struct _MqttConnect {
-    MqttMsgStat stat; /* must be first member at top */
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 
     word16      keep_alive_sec;
     byte        clean_session;
@@ -411,9 +415,6 @@ typedef struct _MqttConnect {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
-#ifdef WOLFMQTT_MULTITHREAD
-    MqttPendResp pendResp;
-#endif
 } MqttConnect;
 
 
@@ -429,23 +430,27 @@ typedef struct _MqttConnect {
     QoS2 protocol exchange */
 /* Expect response packet with type = MQTT_PACKET_TYPE_PUBLISH_COMP */
 typedef struct _MqttPublishResp {
-    MqttMsgStat stat; /* must be first member at top */
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 
     word16      packet_id;
 #ifdef WOLFMQTT_V5
     byte reason_code;
     MqttProp* props;
 #endif
-#ifdef WOLFMQTT_MULTITHREAD
-    MqttPendResp pendResp;
-#endif
 } MqttPublishResp;
 
 /* PUBLISH */
 /* PacketId sent only if QoS > 0 */
 typedef struct _MqttMessage {
-    MqttMsgStat stat; /* must be first member at top */
-
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
     word16      packet_id;
     byte        type;
     MqttQoS     qos;
@@ -476,9 +481,6 @@ typedef struct _MqttMessage {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
-#ifdef WOLFMQTT_MULTITHREAD
-    MqttPendResp pendResp;
-#endif
 } MqttMessage;
 typedef MqttMessage MqttPublish; /* Publish is message */
 
@@ -505,7 +507,11 @@ typedef struct _MqttSubscribeAck {
 /* SUBSCRIBE */
 /* Packet Id followed by contiguous list of topics w/Qos to subscribe to. */
 typedef struct _MqttSubscribe {
-    MqttMsgStat stat; /* must be first member at top */
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 
     word16      packet_id;
     int         topic_count;
@@ -515,9 +521,6 @@ typedef struct _MqttSubscribe {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
-#endif
-#ifdef WOLFMQTT_MULTITHREAD
-    MqttPendResp pendResp;
 #endif
 } MqttSubscribe;
 
@@ -537,7 +540,11 @@ typedef struct _MqttUnsubscribeAck {
 /* UNSUBSCRIBE */
 /* Packet Id followed by contiguous list of topics to unsubscribe from. */
 typedef struct _MqttUnsubscribe {
-    MqttMsgStat stat; /* must be first member at top */
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
+#ifdef WOLFMQTT_MULTITHREAD
+    MqttPendResp pendResp;
+#endif
 
     word16      packet_id;
     int         topic_count;
@@ -548,17 +555,14 @@ typedef struct _MqttUnsubscribe {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
-#ifdef WOLFMQTT_MULTITHREAD
-    MqttPendResp pendResp;
-#endif
 } MqttUnsubscribe;
 
 
 /* PING / PING RESPONSE */
 /* Fixed header "MqttPacket" only. No variable header or payload */
 typedef struct _MqttPing {
-    MqttMsgStat stat; /* must be first member at top */
-
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
 #ifdef WOLFMQTT_MULTITHREAD
     MqttPendResp pendResp;
 #endif
@@ -579,13 +583,14 @@ typedef struct _MqttDisconnect {
 #ifdef WOLFMQTT_V5
 /* AUTH */
 typedef struct _MqttAuth {
-    MqttMsgStat stat; /* must be first member at top */
-
-    byte        reason_code;
-    MqttProp*   props;
+    /* stat and pendResp must be first members at top */
+    MqttMsgStat stat;
 #ifdef WOLFMQTT_MULTITHREAD
     MqttPendResp pendResp;
 #endif
+
+    byte        reason_code;
+    MqttProp*   props;
 } MqttAuth;
 #endif
 

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -238,7 +238,13 @@ enum MqttPacketResponseCodes {
         #define LINE_END    "\n"
     #endif
     #ifndef PRINTF
-        #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
+        #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_DEBUG_THREAD)
+            #define _GNU_SOURCE
+            #include <pthread.h>
+            #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), pthread_self(), ##__VA_ARGS__)
+        #else
+            #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
+        #endif
     #endif
 
     #ifndef WOLFMQTT_NO_STDIO

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -239,7 +239,6 @@ enum MqttPacketResponseCodes {
     #endif
     #ifndef PRINTF
         #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_DEBUG_THREAD)
-            #define _GNU_SOURCE
             #include <pthread.h>
             #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), pthread_self(), ##__VA_ARGS__)
         #else


### PR DESCRIPTION
Fixes for non-blocking and multi-threading edge cases.
* Fix for multi-threading case where packet_obj of wrong type could be used.
* Fix to add random client_id and topic as hex string when example uses "-T" option.
* Enabled the mqttclient, multithreaded and wiot examples with `--enable-nonblock` enabled.
* Added message when `mqtt_check_timeout` triggers timeout.
* Fix for test scripts to check non-zero return code.
* Added extra timeout for test scripts because 1 second is too small to give enough time in all cases (1.9-2.0 seconds is seen as a 1 second change).
* Added thread logging option `WOLFMQTT_DEBUG_THREAD`