### PR TITLE
Multithreading fixes to use binary semaphores

### DIFF
--- a/examples/include.am
+++ b/examples/include.am
@@ -152,5 +152,5 @@ EXTRA_DIST+=       examples/mqttuart.c \
                    examples/azure/azureiothub.vcxproj \
                    examples/aws/awsiot.vcxproj \
                    examples/wiot/wiot.vcxproj \
-                   examples/sn-client/sn-client.vcxproj
-#                   examples/multithread/multithread.vcxproj
+                   examples/sn-client/sn-client.vcxproj \
+                   examples/multithread/multithread.vcxproj

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -1050,7 +1050,7 @@ int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
     #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
         /* setup the pipe for waking select() */
         if (pipe(sockCtx->pfd) != 0) {
-            PRINTF("Failed to set up pipe for stdin\n");
+            PRINTF("Failed to set up pipe for stdin");
             return -1;
         }
     #endif
@@ -1095,7 +1095,7 @@ int SN_ClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
     #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
         /* setup the pipe for waking select() */
         if (pipe(sockCtx->pfd) != 0) {
-            PRINTF("Failed to set up pipe for stdin\n");
+            PRINTF("Failed to set up pipe for stdin");
             return -1;
         }
     #endif
@@ -1124,7 +1124,7 @@ int MqttClientNet_Wake(MqttNet* net)
         if (sockCtx) {
             /* wake the select() */
             if (write(sockCtx->pfd[1], "\n", 1) < 0) {
-                PRINTF("Failed to wake select.\n");
+                PRINTF("Failed to wake select");
                 return -1;
             }
         }

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -1049,7 +1049,10 @@ int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
     
     #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
         /* setup the pipe for waking select() */
-        pipe(sockCtx->pfd);
+        if (pipe(sockCtx->pfd) != 0) {
+            PRINTF("Failed to set up pipe for stdin\n");
+            return -1;
+        }
     #endif
     }
 
@@ -1091,7 +1094,10 @@ int SN_ClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
 
     #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
         /* setup the pipe for waking select() */
-        pipe(sockCtx->pfd);
+        if (pipe(sockCtx->pfd) != 0) {
+            PRINTF("Failed to set up pipe for stdin\n");
+            return -1;
+        }
     #endif
     }
 
@@ -1117,7 +1123,10 @@ int MqttClientNet_Wake(MqttNet* net)
         SocketContext* sockCtx = (SocketContext*)net->context;
         if (sockCtx) {
             /* wake the select() */
-            write(sockCtx->pfd[1], "\n", 1);
+            if (write(sockCtx->pfd[1], "\n", 1) < 0) {
+                PRINTF("Failed to wake select.\n");
+                return -1;
+            }
         }
     }
 #else

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -168,6 +168,10 @@ typedef struct _SocketContext {
 #ifdef MICROCHIP_MPLAB_HARMONY
     word32 bytes;
 #endif
+#ifdef WOLFMQTT_ENABLE_STDIN_CAP
+    /* "self pipe" -> signal wake sleep() */
+    SOCKET_T pfd[2];
+#endif
     MQTTCtx* mqttCtx;
 } SocketContext;
 
@@ -841,17 +845,16 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
 #ifndef WOLFMQTT_NO_TIMEOUT
     /* Setup timeout and FD's */
     setup_timeout(&tv, timeout_ms);
-    FD_ZERO(&recvfds);
-    FD_SET(sock->fd, &recvfds);
     FD_ZERO(&errfds);
     FD_SET(sock->fd, &errfds);
-
+    FD_ZERO(&recvfds);
+    FD_SET(sock->fd, &recvfds);
     #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+    FD_SET(sock->pfd[0], &recvfds);
     if (!mqttCtx->test_mode) {
         FD_SET(STDIN, &recvfds);
     }
     #endif
-
 #else
     (void)timeout_ms;
 #endif /* !WOLFMQTT_NO_TIMEOUT && !WOLFMQTT_NONBLOCK */
@@ -872,13 +875,13 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
             rc = select((int)SELECT_FD(sock->fd), &recvfds, NULL, &errfds, &tv);
             if (rc > 0)
             {
-                if (FD_ISSET(sock->fd, &recvfds))
-                {
+                if (FD_ISSET(sock->fd, &recvfds)) {
                     do_read = 1;
                 }
                 /* Check if rx or error */
             #ifdef WOLFMQTT_ENABLE_STDIN_CAP
-                else if (!mqttCtx->test_mode && FD_ISSET(STDIN, &recvfds)) {
+                else if ((!mqttCtx->test_mode && FD_ISSET(STDIN, &recvfds)) || 
+                        FD_ISSET(sock->pfd[0], &recvfds)) {
                     return MQTT_CODE_STDIN_WAKE;
                 }
             #endif
@@ -1038,6 +1041,11 @@ int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
         sockCtx->fd = SOCKET_INVALID;
         sockCtx->stat = SOCK_BEGIN;
         sockCtx->mqttCtx = mqttCtx;
+    
+    #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+        /* setup the pipe for waking select() */
+        pipe(sockCtx->pfd);
+    #endif
     }
 
     return MQTT_CODE_SUCCESS;
@@ -1075,6 +1083,11 @@ int SN_ClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx)
         XMEMSET(multi_ctx, 0, sizeof(MulticastContext));
         multi_ctx->stat = SOCK_BEGIN;
     #endif
+
+    #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+        /* setup the pipe for waking select() */
+        pipe(sockCtx->pfd);
+    #endif
     }
 
     return MQTT_CODE_SUCCESS;
@@ -1089,5 +1102,18 @@ int MqttClientNet_DeInit(MqttNet* net)
         }
         XMEMSET(net, 0, sizeof(MqttNet));
     }
+    return 0;
+}
+
+int MqttClientNet_Wake(MqttNet* net)
+{
+#ifdef WOLFMQTT_ENABLE_STDIN_CAP
+    SocketContext* sockCtx = (SocketContext*)net->context;
+
+    /* wake the select() */
+    write(sockCtx->pfd[1], "\n", 1);
+#else
+    (void)context;
+#endif
     return 0;
 }

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -1108,12 +1108,15 @@ int MqttClientNet_DeInit(MqttNet* net)
 int MqttClientNet_Wake(MqttNet* net)
 {
 #ifdef WOLFMQTT_ENABLE_STDIN_CAP
-    SocketContext* sockCtx = (SocketContext*)net->context;
-
-    /* wake the select() */
-    write(sockCtx->pfd[1], "\n", 1);
+    if (net) {
+        SocketContext* sockCtx = (SocketContext*)net->context;
+        if (sockCtx) {
+            /* wake the select() */
+            write(sockCtx->pfd[1], "\n", 1);
+        }
+    }
 #else
-    (void)context;
+    (void)net;
 #endif
     return 0;
 }

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -40,6 +40,8 @@ int MqttClientNet_DeInit(MqttNet* net);
 int SN_ClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);
 #endif
 
+int MqttClientNet_Wake(MqttNet* net);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -38,14 +38,14 @@ static int mStopRead = 0;
 static int mNumMsgsRecvd;
 
 #ifdef WOLFMQTT_MULTITHREAD
-static wolfSSL_Mutex packetIdLock; /* Protect access to mqtt_get_packetid() */
+static wm_Sem packetIdLock; /* Protect access to mqtt_get_packetid() */
 
 static word16 mqtt_get_packetid_threadsafe(void)
 {
     word16 packet_id;
-    wc_LockMutex(&packetIdLock);
+    wm_SemLock(&packetIdLock);
     packet_id = mqtt_get_packetid();
-    wc_UnLockMutex(&packetIdLock);
+    wm_SemUnlock(&packetIdLock);
     return packet_id;
 }
 #endif
@@ -167,7 +167,7 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
     mNumMsgsRecvd = 0;
 
     /* Create a demo mutex for making packet id values */
-    rc = wc_InitMutex(&packetIdLock);
+    rc = wm_SemInit(&packetIdLock);
     if (rc != 0) {
         client_exit(mqttCtx);
     }
@@ -274,7 +274,7 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
 static int multithread_test_finish(MQTTCtx *mqttCtx)
 {
     client_disconnect(mqttCtx);
-    wc_FreeMutex(&packetIdLock);
+    wm_SemFree(&packetIdLock);
 
     return mqttCtx->return_code;
 }

--- a/examples/multithread/multithread.vcxproj
+++ b/examples/multithread/multithread.vcxproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7D62F9C5-1416-4E8F-8931-103701C23D8D}</ProjectGuid>
+    <RootNamespace>mqttclient</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS; _MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\;..\..\..\wolfssl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;$(SolutionDir)wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\;..\..\..\wolfssl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS; _MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Ws2_32.lib;$(SolutionDir)wolfssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS; _MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS; _MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mqttexample.c" />
+    <ClCompile Include="..\mqttnet.c" />
+    <ClCompile Include="multithread.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mqttexample.h" />
+    <ClInclude Include="..\mqttnet.h" />
+    <ClInclude Include="multithread.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\wolfmqtt.vcxproj">
+      <Project>{d42405ee-238f-4560-8b49-e70948ec9100}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -26,13 +26,13 @@
 
 #include "wolfmqtt/mqtt_client.h"
 
-#ifdef WOLFMQTT_SN
-
 #include "sn-client.h"
 #include "examples/mqttnet.h"
 
 /* Locals */
 static int mStopRead = 0;
+
+#ifdef WOLFMQTT_SN
 
 /* Configuration */
 /* Maximum size for network read/write callbacks. */

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -82,10 +82,11 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
     /* FreeRTOS binary semaphore */
     int wm_SemInit(wm_Sem *s) {
         *s = xSemaphoreCreateBinary();
+        xSemaphoreGive(*s);
         return 0;
     }
     int wm_SemFree(wm_Sem *s) {
-        sem_destroy(*s);
+        vSemaphoreDelete(*s);
         *s = NULL;
         return 0;
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -98,6 +98,26 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
         xSemaphoreGive(*s);
         return 0;
     }
+#elif defined(USE_WINDOWS_API)
+    /* Windows semaphore object */
+    int wm_SemInit(wm_Sem *s) {
+        *s = CreateSemaphore( NULL, 0, 1, NULL);
+        return 0;
+    }
+    int wm_SemFree(wm_Sem *s) {
+        CloseHandle(*s);
+        *s = NULL;
+        return 0;
+    }
+    int wm_SemLock(wm_Sem *s) {
+        WaitForSingleObject(*s, 0);
+        return 0;
+    }
+    int wm_SemUnlock(wm_Sem *s) {
+        ReleaseSemaphore(*s, 1, NULL);
+        return 0;
+    }
+
 #endif
 
 /* These RespList functions assume caller has locked client->lockClient mutex */

--- a/wolfmqtt.sln
+++ b/wolfmqtt.sln
@@ -24,6 +24,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "nbclient", "examples\nbclie
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sn-client", "examples\sn-client\sn-client.vcxproj", "{CBA36D33-BBC1-458B-BDB5-E8A4FEBE6A8C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "multithread", "examples\multithread\multithread.vcxproj", "{7D62F9C5-1416-4E8F-8931-103701C23D8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -104,6 +106,14 @@ Global
 		{CBA36D33-BBC1-458B-BDB5-E8A4FEBE6A8C}.Release|x64.Build.0 = Release|x64
 		{CBA36D33-BBC1-458B-BDB5-E8A4FEBE6A8C}.Release|x86.ActiveCfg = Release|Win32
 		{CBA36D33-BBC1-458B-BDB5-E8A4FEBE6A8C}.Release|x86.Build.0 = Release|Win32
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Debug|x64.ActiveCfg = Debug|x64
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Debug|x64.Build.0 = Debug|x64
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Debug|x86.ActiveCfg = Debug|Win32
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Debug|x86.Build.0 = Debug|Win32
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Release|x64.ActiveCfg = Release|x64
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Release|x64.Build.0 = Release|x64
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Release|x86.ActiveCfg = Release|Win32
+		{7D62F9C5-1416-4E8F-8931-103701C23D8D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -157,9 +157,9 @@ typedef struct _MqttClient {
     void          *property_ctx;
 #endif
 #ifdef WOLFMQTT_MULTITHREAD
-    wolfSSL_Mutex lockSend;
-    wolfSSL_Mutex lockRecv;
-    wolfSSL_Mutex lockClient;
+    wm_Sem lockSend;
+    wm_Sem lockRecv;
+    wm_Sem lockClient;
     struct _MqttPendResp* firstPendResp;
     struct _MqttPendResp* lastPendResp;
 #endif

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -103,6 +103,13 @@
         
         #include <semphr.h>
         typedef SemaphoreHandle_t wm_Sem;
+
+    #elif defined(USE_WINDOWS_API)
+        /* Windows semaphore object */
+        #include <winsock2.h> /* winsock2.h needs included before windows.h */
+        #include <ws2tcpip.h>
+        #include <windows.h>
+        typedef HANDLE wm_Sem;
     
     #elif defined(WOLFMQTT_USER_THREADING)
         /* User provides API's and wm_Sem type */
@@ -260,8 +267,12 @@ enum MqttPacketResponseCodes {
     #endif
     #ifndef PRINTF
         #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_DEBUG_THREAD)
-            #include <pthread.h>
-            #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), pthread_self(), ##__VA_ARGS__)
+            #ifdef USE_WINDOWS_API
+                #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), GetCurrentThreadId(), ##__VA_ARGS__)
+            #else
+                #include <pthread.h>
+                #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), pthread_self(), ##__VA_ARGS__)
+            #endif
         #else
             #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
         #endif

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -91,7 +91,7 @@
         #include <dispatch/dispatch.h>
         typedef dispatch_semaphore_t wm_Sem;
 
-    #elif defined(__FreeBSD__) || defined(__linux__))
+    #elif defined(__FreeBSD__) || defined(__linux__)
         /* Posix Style Semaphore */
         #define WOLFMQTT_POSIX_SEMAPHORES
         #include <semaphore.h>
@@ -261,7 +261,7 @@ enum MqttPacketResponseCodes {
     #ifndef PRINTF
         #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_DEBUG_THREAD)
             #include <pthread.h>
-            #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), (unsigned long)(void*)pthread_self(), ##__VA_ARGS__)
+            #define PRINTF(_f_, ...)  printf( ("%lx: "_f_ LINE_END), pthread_self(), ##__VA_ARGS__)
         #else
             #define PRINTF(_f_, ...)  printf( (_f_ LINE_END), ##__VA_ARGS__)
         #endif

--- a/wolfmqtt/vs_settings.h
+++ b/wolfmqtt/vs_settings.h
@@ -35,6 +35,10 @@
 #undef  WOLFMQTT_DISCONNECT_CB
 #define WOLFMQTT_DISCONNECT_CB
 
+/* Multi-threading */
+#undef  WOLFMQTT_MULTITHREAD
+#define WOLFMQTT_MULTITHREAD
+
 /* Debugging */
 #undef  DEBUG_WOLFMQTT
 #define DEBUG_WOLFMQTT
@@ -44,6 +48,9 @@
 
 #undef  WOLFMQTT_DEBUG_SOCKET
 #define WOLFMQTT_DEBUG_SOCKET
+
+#undef  WOLFMQTT_DEBUG_THREAD
+#define WOLFMQTT_DEBUG_THREAD
 
 /* Disable error strings */
 #undef  WOLFMQTT_NO_ERROR_STRINGS


### PR DESCRIPTION
* Refactor of the thread locking to use binary semaphore, which resolves issue with thread synchronization.
* Added Windows multi-threading support and Visual stdio project.
* Resolved issue with Ctrl+c and multthread example.
