### PR TITLE
Make protocol level a run time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ The MQTT firmware update is located in `/examples/firmware/`. This example has t
 
 ### Azure IoT Hub Example
 We setup a wolfMQTT IoT Hub on the Azure server for testing. We added a device called `demoDevice`, which you can connect and publish to. The example demonstrates creation of a SasToken, which is used as the password for the MQTT connect packet. It also shows the topic names for publishing events and listening to `devicebound` messages. This example only works with `ENABLE_MQTT_TLS` set and the wolfSSL library present because it requires Base64 Encode/Decode and HMAC-SHA256. Note: The wolfSSL library must be built with `./configure --enable-base64encode` or `#define WOLFSSL_BASE64_ENCODE`. The `wc_GetTime` API was added in 3.9.1 and if not present you'll need to implement your own version of this to get current UTC seconds or update your wolfSSL library.
+**NOTE** The Azure broker only supports MQTT v3.1.1
 
 ### AWS IoT Example
 We setup an AWS IoT endpoint and testing device certificate for testing. The AWS server uses TLS client certificate for authentication. The example is located in `/examples/aws/`. The example subscribes to `$aws/things/"AWSIOT_DEVICE_ID"/shadow/update/delta` and publishes to `$aws/things/"AWSIOT_DEVICE_ID"/shadow/update`.
+**NOTE** The AWS broker only supports MQTT v3.1.1
 
 ### Watson IoT Example
 This example enables the wolfMQTT client to connect to the IBM Watson Internet of Things (WIOT) Platform. The WIOT Platform has a limited test broker called "Quickstart" that allows non-secure connections to exercise the component. The example is located in `/examples/wiot/`. Works with MQTT v5 support enabled.

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -325,6 +325,12 @@ int awsiot_test(MQTTCtx *mqttCtx)
             }
             mqttCtx->client.ctx = mqttCtx;
 
+        #ifdef WOLFMQTT_V5
+            /* AWS broker only supports v3.1.1 client */
+            mqttCtx->client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+        #endif
+
+
             FALL_THROUGH;
         }
 

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -308,6 +308,11 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             }
             mqttCtx->client.ctx = mqttCtx;
 
+        #ifdef WOLFMQTT_V5
+            /* AWS broker only supports v3.1.1 client */
+            mqttCtx->client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+        #endif
+
             FALL_THROUGH;
         }
 
@@ -487,6 +492,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                         mqttCtx->publish.packet_id = mqtt_get_packetid();
                         mqttCtx->publish.buffer = mqttCtx->rx_buf;
                         mqttCtx->publish.total_len = (word16)rc;
+
                         rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
                         PRINTF("MQTT Publish: Topic %s, %s (%d)",
                             mqttCtx->publish.topic_name,

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -194,11 +194,11 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
             case MQTT_PROP_SERVER_REF:
             case MQTT_PROP_AUTH_METHOD:
             case MQTT_PROP_AUTH_DATA:
+            case MQTT_PROP_NONE:
                 break;
             case MQTT_PROP_REQ_PROB_INFO:
             case MQTT_PROP_WILL_DELAY_INTERVAL:
             case MQTT_PROP_REQ_RESP_INFO:
-            case MQTT_PROP_NONE:
             default:
                 /* Invalid */
                 rc = MQTT_CODE_ERROR_PROPERTY;

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -32,6 +32,14 @@
 /* Requires BSD Style Socket */
 #ifdef HAVE_SOCKET
 
+#ifndef ENABLE_MQTT_TLS
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+#endif
+
 /* Configuration */
 #define MQTT_HOST            "mqtt.eclipse.org" /* broker.hivemq.com */
 #define MQTT_QOS             MQTT_QOS_0

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -146,6 +146,7 @@ typedef struct _MqttClient {
     byte    max_qos;       /* Server property */
     byte    retain_avail;  /* Server property */
     byte    enable_eauth;  /* Enhanced authentication */
+    byte protocol_level;
 #endif
 
 #ifdef WOLFMQTT_DISCONNECT_CB

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -384,6 +384,7 @@ typedef struct _MqttConnectAck {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttConnectAck;
 /* Connect Ack has no payload */
@@ -444,6 +445,7 @@ typedef struct _MqttPublishResp {
 #ifdef WOLFMQTT_V5
     byte reason_code;
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttPublishResp;
 
@@ -484,6 +486,7 @@ typedef struct _MqttMessage {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttMessage;
 typedef MqttMessage MqttPublish; /* Publish is message */
@@ -505,6 +508,7 @@ typedef struct _MqttSubscribeAck {
     byte       *return_codes; /* MqttSubscribeAckReturnCodes */
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttSubscribeAck;
 
@@ -525,6 +529,7 @@ typedef struct _MqttSubscribe {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttSubscribe;
 
@@ -538,6 +543,7 @@ typedef struct _MqttUnsubscribeAck {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
     byte*     reason_codes;
+    byte protocol_level;
 #endif
 } MqttUnsubscribeAck;
 
@@ -558,6 +564,7 @@ typedef struct _MqttUnsubscribe {
 
 #ifdef WOLFMQTT_V5
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttUnsubscribe;
 
@@ -580,6 +587,7 @@ typedef struct _MqttDisconnect {
 #ifdef WOLFMQTT_V5
     byte reason_code;
     MqttProp* props;
+    byte protocol_level;
 #endif
 } MqttDisconnect;
 


### PR DESCRIPTION
Allows broker examples that do not work with MQTTv5 to run even when `--enable-mqtt5` option is used.

Also fixed an include issue for simple example without TLS enabled.