### PR TITLE
Remove deprecated call to wolfSSL_set_using_nonblock()

### DIFF
--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -397,9 +397,6 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
 
             wolfSSL_SetIOReadCtx(client->tls.ssl, (void *)client);
             wolfSSL_SetIOWriteCtx(client->tls.ssl, (void *)client);
-        #if !defined(WOLFMQTT_NO_TIMEOUT) && defined(WOLFMQTT_NONBLOCK)
-            wolfSSL_set_using_nonblock(client->tls.ssl, 1);
-        #endif
         }
 
         if (client->ctx != NULL) {


### PR DESCRIPTION
This call only affects DTLS connections, and was triggering the warning:

```
wolfSSL_dtls_set_using_nonblock() is DEPRECATED for non-DTLS use
```