### PR TITLE
`topic` can be a local variable

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -270,6 +270,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
 int awsiot_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     switch (mqttCtx->stat)
     {
@@ -429,10 +430,10 @@ int awsiot_test(MQTTCtx *mqttCtx)
 
             /* show subscribe results */
             for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-                mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+                topic = &mqttCtx->subscribe.topics[i];
                 PRINTF("  Topic %s, Qos %u, Return Code %u",
-                    mqttCtx->topic->topic_filter,
-                    mqttCtx->topic->qos, mqttCtx->topic->return_code);
+                    topic->topic_filter,
+                    topic->qos, topic->return_code);
             }
 
             /* Publish Topic */

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -244,6 +244,7 @@ static int SasTokenCreate(char* sasToken, int sasTokenLen)
 int azureiothub_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     switch (mqttCtx->stat)
     {
@@ -412,10 +413,10 @@ int azureiothub_test(MQTTCtx *mqttCtx)
 
             /* show subscribe results */
             for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-                mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+                topic = &mqttCtx->subscribe.topics[i];
                 PRINTF("  Topic %s, Qos %u, Return Code %u",
-                    mqttCtx->topic->topic_filter,
-                    mqttCtx->topic->qos, mqttCtx->topic->return_code);
+                    topic->topic_filter,
+                    topic->qos, topic->return_code);
             }
 
             /* Publish Topic */

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -205,6 +205,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
 int fwclient_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     switch(mqttCtx->stat) {
         case WMQ_BEGIN:
@@ -350,11 +351,11 @@ int fwclient_test(MQTTCtx *mqttCtx)
                 goto disconn;
             }
             for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-                mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+                topic = &mqttCtx->subscribe.topics[i];
                 PRINTF("  Topic %s, Qos %u, Return Code %u",
-                    mqttCtx->topic->topic_filter,
-                    mqttCtx->topic->qos,
-                    mqttCtx->topic->return_code);
+                    topic->topic_filter,
+                    topic->qos,
+                    topic->return_code);
             }
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -216,6 +216,7 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
 int mqttclient_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos,
             mqttCtx->use_tls);
@@ -409,10 +410,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
     /* show subscribe results */
     for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-        mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+        topic = &mqttCtx->subscribe.topics[i];
         PRINTF("  Topic %s, Qos %u, Return Code %u",
-            mqttCtx->topic->topic_filter,
-            mqttCtx->topic->qos, mqttCtx->topic->return_code);
+            topic->topic_filter,
+            topic->qos, topic->return_code);
     }
 
     /* Publish Topic */

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -110,7 +110,7 @@ typedef struct _MQTTCtx {
     MqttMessage lwt_msg;
     MqttSubscribe subscribe;
     MqttUnsubscribe unsubscribe;
-    MqttTopic topics[1], *topic;
+    MqttTopic topics[1];
     MqttPublish publish;
     MqttDisconnect disconnect;
 

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -318,6 +318,7 @@ static void *subscribe_task(void *param)
     int rc = MQTT_CODE_SUCCESS;
     uint16_t i;
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
+    MqttTopic *topic;
 
     /* Build list of topics */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
@@ -350,10 +351,10 @@ static void *subscribe_task(void *param)
     if (rc == MQTT_CODE_SUCCESS) {
         /* show subscribe results */
         for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-            mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+            topic = &mqttCtx->subscribe.topics[i];
             PRINTF("  Topic %s, Qos %u, Return Code %u",
-                mqttCtx->topic->topic_filter,
-                mqttCtx->topic->qos, mqttCtx->topic->return_code);
+                topic->topic_filter,
+                topic->qos, topic->return_code);
         }
     }
 

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -106,6 +106,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
 int mqttclient_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     switch (mqttCtx->stat) {
         case WMQ_BEGIN:
@@ -271,10 +272,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
             /* show subscribe results */
             for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-                mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+                topic = &mqttCtx->subscribe.topics[i];
                 PRINTF("  Topic %s, Qos %u, Return Code %u",
-                    mqttCtx->topic->topic_filter,
-                    mqttCtx->topic->qos, mqttCtx->topic->return_code);
+                    topic->topic_filter,
+                    topic->qos, topic->return_code);
             }
 
             /* Publish Topic */

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -127,6 +127,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
 int wiot_test(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
+    MqttTopic *topic;
 
     PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos, mqttCtx->use_tls);
 
@@ -243,10 +244,10 @@ int wiot_test(MQTTCtx *mqttCtx)
 
     /* show subscribe results */
     for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-        mqttCtx->topic = &mqttCtx->subscribe.topics[i];
+        topic = &mqttCtx->subscribe.topics[i];
         PRINTF("  Topic %s, Qos %u, Return Code %u",
-            mqttCtx->topic->topic_filter,
-            mqttCtx->topic->qos, mqttCtx->topic->return_code);
+            topic->topic_filter,
+            topic->qos, topic->return_code);
     }
 
     /* Publish Topic */


### PR DESCRIPTION
`MQTTCtx`'s `topic` member isn't used anywhere but printing
`mqttCtx->subscribe.topics`, so it can be local variable.