### PR TITLE
Fix memory problems related to handling getaddrinfo result

### DIFF
--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -584,17 +584,16 @@ static int NetConnect(void *context, const char* host, word16 port,
                 /* prefer ip4 addresses */
                 while (res) {
                     if (res->ai_family == AF_INET) {
-                        result = res;
                         break;
                     }
                     res = res->ai_next;
                 }
 
-                if (result->ai_family == AF_INET) {
+                if (res && res->ai_family == AF_INET) {
                     sock->addr.sin_port = htons(port);
                     sock->addr.sin_family = AF_INET;
                     sock->addr.sin_addr =
-                        ((SOCK_ADDR_IN*)(result->ai_addr))->sin_addr;
+                        ((SOCK_ADDR_IN*)(res->ai_addr))->sin_addr;
                 }
                 else {
                     rc = -1;
@@ -707,17 +706,16 @@ static int SN_NetConnect(void *context, const char* host, word16 port,
         /* prefer ip4 addresses */
         while (res) {
             if (res->ai_family == AF_INET) {
-                result = res;
                 break;
             }
             res = res->ai_next;
         }
 
-        if (result->ai_family == AF_INET) {
+        if (res && res->ai_family == AF_INET) {
             sock->addr.sin_port = htons(port);
             sock->addr.sin_family = AF_INET;
             sock->addr.sin_addr =
-                ((SOCK_ADDR_IN*)(result->ai_addr))->sin_addr;
+                ((SOCK_ADDR_IN*)(res->ai_addr))->sin_addr;
         }
         else {
             rc = -1;

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -169,16 +169,15 @@ static int mqtt_net_connect(void *context, const char* host, word16 port,
         /* prefer ip4 addresses */
         while (res) {
             if (res->ai_family == AF_INET) {
-                result = res;
                 break;
             }
             res = res->ai_next;
         }
-        if (result->ai_family == AF_INET) {
+        if (res && res->ai_family == AF_INET) {
             addr.sin_port = htons(port);
             addr.sin_family = AF_INET;
             addr.sin_addr =
-                ((struct sockaddr_in*)(result->ai_addr))->sin_addr;
+                ((struct sockaddr_in*)(res->ai_addr))->sin_addr;
         }
         else {
             rc = -1;


### PR DESCRIPTION
This commits addresses two problems:

1. In case if `getaddrinfo` returns no interfaces with `ai_family ==
   AF_INET` the check if suitable interface found accesses NULL pointer.

2. `result` is changed in process of searching suitable interface, so
   `freeaddrinfo` is called for found interface, not the original
   pointer.