### PR TITLE
Fix for receive timeout in mqttsimple example

### DIFF
--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -843,8 +843,10 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     }
 
 #ifndef WOLFMQTT_NO_TIMEOUT
-    /* Setup timeout and FD's */
+    /* Setup timeout */
     setup_timeout(&tv, timeout_ms);
+
+    /* Setup select file descriptors to watch */
     FD_ZERO(&errfds);
     FD_SET(sock->fd, &errfds);
     FD_ZERO(&recvfds);
@@ -856,10 +858,10 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
     if (!mqttCtx->test_mode) {
         FD_SET(STDIN, &recvfds);
     }
-    #endif
+    #endif /* WOLFMQTT_ENABLE_STDIN_CAP */
 #else
     (void)timeout_ms;
-#endif /* !WOLFMQTT_NO_TIMEOUT && !WOLFMQTT_NONBLOCK */
+#endif /* !WOLFMQTT_NO_TIMEOUT */
 
     /* Loop until buf_len has been read, error or timeout */
     while (bytes < buf_len) {

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -222,16 +222,16 @@ static int mqtt_net_read(void *context, byte* buf, int buf_len, int timeout_ms)
 
     /* Setup timeout */
     setup_timeout(&tv, timeout_ms);
-    setsockopt(*pSockFd, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(tv));
+    setsockopt(*pSockFd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
 
     /* Loop until buf_len has been read, error or timeout */
     while (bytes < buf_len) {
         rc = (int)recv(*pSockFd, &buf[bytes], buf_len - bytes, 0);
         if (rc < 0) {
             rc = socket_get_error(*pSockFd);
-            PRINTF("NetRead: Error %d", rc);
             if (rc == 0)
                 break; /* timeout */
+            PRINTF("NetRead: Error %d", rc);
             return MQTT_CODE_ERROR_NETWORK;
         }
         bytes += rc; /* Data */


### PR DESCRIPTION
Fixes #157.

Fixes issue with the `mqttsimple` example where the read socket would not timeout and would not send ping keep-alive. Moved the read error message so it would not print on timeout case.