### PR TITLE
Fixing LWT prop and allow null LWT

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -292,8 +292,16 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         mqttCtx->lwt_msg.retain = 0;
         mqttCtx->lwt_msg.topic_name = WOLFMQTT_TOPIC_NAME"lwttopic";
         mqttCtx->lwt_msg.buffer = (byte*)mqttCtx->client_id;
-        mqttCtx->lwt_msg.total_len =
-          (word16)XSTRLEN(mqttCtx->client_id);
+        mqttCtx->lwt_msg.total_len = (word16)XSTRLEN(mqttCtx->client_id);
+
+#ifdef WOLFMQTT_V5
+        {
+            /* Add a 5 second delay to sending the LWT */
+            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->lwt_msg.props);
+            prop->type = MQTT_PROP_WILL_DELAY_INTERVAL;
+            prop->data_int = 5;
+        }
+#endif
     }
     /* Optional authentication */
     mqttCtx->connect.username = mqttCtx->username;
@@ -351,6 +359,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     if (mqttCtx->connect.props != NULL) {
         /* Release the allocated properties */
         MqttClient_PropsFree(mqttCtx->connect.props);
+    }
+    if (mqttCtx->lwt_msg.props != NULL) {
+        /* Release the allocated properties */
+        MqttClient_PropsFree(mqttCtx->lwt_msg.props);
     }
 #endif
 


### PR DESCRIPTION
Allow last will and testament message to be zero length (addresses #159 )
Add support for the last will and testament properties when using the MQTTV5 client (addresses #160 )
Also adds a LWT property to the mqttclient example that delays sending the LWT message by 5 seconds.