### PR TITLE
Change anon union for ARMv6 error

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2547,7 +2547,7 @@ int SN_Client_Will(MqttClient *client, SN_Will *will)
             if ((will != NULL) && (rc == len)) {
 
                 /* Wait for Will Message Request */
-                rc = SN_Client_WaitType(client, &will->msgResp,
+                rc = SN_Client_WaitType(client, &will->resp.msgResp,
                         SN_MSG_TYPE_WILLMSGREQ, 0, client->cmd_timeout_ms);
 
                 if (rc == 0) {
@@ -2590,7 +2590,7 @@ int SN_Client_WillTopicUpdate(MqttClient *client, SN_Will *will)
 
             if (will != NULL) {
                 /* Wait for Will Topic Update Response packet */
-                rc = SN_Client_WaitType(client, &will->topicResp,
+                rc = SN_Client_WaitType(client, &will->resp.topicResp,
                         SN_MSG_TYPE_WILLTOPICREQ, 0, client->cmd_timeout_ms);
             }
         }
@@ -2617,7 +2617,7 @@ int SN_Client_WillMsgUpdate(MqttClient *client, SN_Will *will)
         rc = MqttPacket_Write(client, client->tx_buf, len);
         if (rc == len) {
             /* Wait for Will Message Update Response packet */
-            rc = SN_Client_WaitType(client, &will->msgUpd,
+            rc = SN_Client_WaitType(client, &will->resp.msgUpd,
                     SN_MSG_TYPE_WILLMSGRESP, 0, client->cmd_timeout_ms);
         }
     }

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -851,6 +851,13 @@ typedef struct _SN_WillTopicResp {
 
 typedef SN_WillTopicResp SN_WillMsgResp;
 
+typedef union _SN_WillResp {
+    SN_WillMsgResp   msgResp;
+    SN_WillMsgUpd    msgUpd;
+    SN_WillTopicResp topicResp;
+    SN_WillTopicUpd  topicUpd;
+} SN_WillResp;
+
 typedef struct _SN_Will {
     MqttMsgStat stat;
 
@@ -860,12 +867,7 @@ typedef struct _SN_Will {
     byte* willMsg;
     word16 willMsgLen;
 
-    union {
-        SN_WillMsgResp   msgResp;
-        SN_WillMsgUpd    msgUpd;
-        SN_WillTopicResp topicResp;
-        SN_WillTopicUpd  topicUpd;
-    };
+    SN_WillResp resp;
 } SN_Will;
 
 /* Connect */


### PR DESCRIPTION
Anonymous unions are treated as warnings with later versions of the ARM compiler:
https://developer.arm.com/documentation/dui0742/j/compiler-source-code-compatibility/language-extension-compatibility--pragmas

This address an issue from ZD10324