### PR TITLE
Fix MqttClient_WaitType for nonblock mode

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -922,8 +922,13 @@ wait_again:
     }
 #endif
 
-    /* reset state */
-    *mms_stat = MQTT_MSG_BEGIN;
+#ifdef WOLFMQTT_NONBLOCK
+    if (rc != MQTT_CODE_CONTINUE)
+#endif
+    {
+        /* reset state */
+        *mms_stat = MQTT_MSG_BEGIN;
+    }
 
     if (rc < 0) {
     #ifdef WOLFMQTT_DEBUG_CLIENT
@@ -2433,8 +2438,13 @@ wait_again:
         }
     } /* switch (msg->stat) */
 
-    /* reset state */
-    *mms_stat = MQTT_MSG_BEGIN;
+#ifdef WOLFMQTT_NONBLOCK
+    if (rc != MQTT_CODE_CONTINUE)
+#endif
+    {
+        /* reset state */
+        *mms_stat = MQTT_MSG_BEGIN;
+    }
 
     return rc;
 }


### PR DESCRIPTION
In the `MQTT_MSG_WAIT` case of `MqttClient_WaitType`, if `MqttPacket_Read` returns `MQTT_CODE_CONTINUE` the state machine should not be reset.

This fix addresses an issue from ZD10283