### PR TITLE
Douzzer 20200729

### DIFF
--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -147,7 +147,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     return MQTT_CODE_SUCCESS;
 }
 
-static void client_exit(MQTTCtx *mqttCtx)
+static void client_cleanup(MQTTCtx *mqttCtx)
 {
     /* Free resources */
     if (mqttCtx->tx_buf) WOLFMQTT_FREE(mqttCtx->tx_buf);
@@ -157,6 +157,12 @@ static void client_exit(MQTTCtx *mqttCtx)
     MqttClientNet_DeInit(&mqttCtx->net);
 
     MqttClient_DeInit(&mqttCtx->client);
+}
+
+static void client_exit(MQTTCtx *mqttCtx)
+{
+    client_cleanup(mqttCtx);
+    exit(1);
 }
 
 static void client_disconnect(MQTTCtx *mqttCtx)
@@ -177,7 +183,7 @@ static void client_disconnect(MQTTCtx *mqttCtx)
     PRINTF("MQTT Socket Disconnect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
 
-    client_exit(mqttCtx);
+    client_cleanup(mqttCtx);
 }
 
 static int multithread_test_init(MQTTCtx *mqttCtx)

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -551,6 +551,7 @@ int multithread_test(MQTTCtx *mqttCtx)
         if (mqttCtx->test_mode) {
             if (THREAD_JOIN(threadList, threadCount))
                 return -1;
+            threadCount = 0;
         }
         /* Create the thread that waits for messages */
         if (THREAD_CREATE(&threadList[threadCount++], waitMessage_task, mqttCtx))

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -40,7 +40,7 @@
 #define MAX_BUFFER_SIZE 1024
 #define TEST_MESSAGE    "test00"
 /* Number of publish tasks. Each will send a unique message to the broker. */
-#define NUM_PUB_TASKS   10
+#define NUM_PUB_TASKS   7
 
 
 /* Locals */

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -62,21 +62,16 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
 #elif defined(WOLFMQTT_POSIX_SEMAPHORES)
     /* Posix style semaphore */
     int wm_SemInit(wm_Sem *s){
-        sem_init(s, 0, 1);
-        return 0;
+        return sem_init(s, 0, 1);
     }
     int wm_SemFree(wm_Sem *s){
-        /* no free */
-        (void)s;
-        return 0;
+        return sem_destroy(s);
     }
     int wm_SemLock(wm_Sem *s){
-        sem_wait(s);
-        return 0;
+        return sem_wait(s);
     }
     int wm_SemUnlock(wm_Sem *s){
-        sem_post(s);
-        return 0;
+        return sem_post(s);
     }
 #elif defined(FREERTOS)
     /* FreeRTOS binary semaphore */


### PR DESCRIPTION
fixes examples/multithread enough that scripts/multithread.test succeeds, but more work is needed to identify root cause of the failure described in commit d5b1c22.
