### PR TITLE
Fix for publish with short topic name and example

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2417,9 +2417,6 @@ wait_again:
             goto wait_again;
         }
 
-    #ifdef WOLFMQTT_V5
-        case MQTT_MSG_AUTH:
-    #endif
         case MQTT_MSG_WRITE:
         default:
         {
@@ -2735,9 +2732,6 @@ int SN_Client_Publish(MqttClient *client, SN_Publish *publish)
             break;
         }
 
-    #ifdef WOLFMQTT_V5
-        case MQTT_MSG_AUTH:
-    #endif
         case MQTT_MSG_READ:
         case MQTT_MSG_READ_PAYLOAD:
         #ifdef WOLFMQTT_DEBUG_CLIENT
@@ -2822,6 +2816,7 @@ int SN_Client_Register(MqttClient *client, SN_Register *regist)
 int SN_Client_Ping(MqttClient *client, SN_PingReq *ping)
 {
     int rc, len;
+    SN_PingReq loc_ping;
 
     /* Validate required arguments */
     if (client == NULL) {
@@ -2829,8 +2824,8 @@ int SN_Client_Ping(MqttClient *client, SN_PingReq *ping)
     }
 
     if (ping == NULL) {
-        /* use client global */
-        ping = &client->msgSN.pingReq;
+        XMEMSET(&loc_ping, 0, sizeof(SN_PingReq));
+        ping = &loc_ping;
     }
 
     if (ping->stat == MQTT_MSG_BEGIN) {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2712,7 +2712,17 @@ int SN_Encode_Publish(byte *tx_buf, int tx_buf_len, SN_Publish *publish)
 
     *tx_payload++ = flags;
 
-    tx_payload += MqttEncode_Num(tx_payload, (word16)*publish->topic_name);
+    /* Encode topic */
+    if (publish->topic_type == SN_TOPIC_ID_TYPE_SHORT) {
+        /* Short topic name is 2 chars */
+        XMEMCPY(tx_payload, publish->topic_name, 2);
+        tx_payload += 2;
+    }
+    else {
+        /* Topic ID */
+        tx_payload += MqttEncode_Num(tx_payload, (word16)*publish->topic_name);
+    }
+
     tx_payload += MqttEncode_Num(tx_payload, publish->packet_id);
 
     /* Encode payload */


### PR DESCRIPTION
Publishing to a short topic name was not working because the topic was encoded incorrectly. An example of short topic usage was added to the sn-client demo. Also fixed ping to use a zeroed structure by default.

This was reported in ZD10725.