### PR TITLE
Add runtime message option to client

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -629,6 +629,7 @@ int main(int argc, char** argv)
     /* init defaults */
     mqtt_init_ctx(&mqttCtx);
     mqttCtx.app_name = "mqttclient";
+    mqttCtx.message = DEFAULT_MESSAGE;
 
     /* parse arguments */
     rc = mqtt_parse_args(&mqttCtx, argc, argv);

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -37,7 +37,6 @@ static int mStopRead = 0;
 /* Maximum size for network read/write callbacks. There is also a v5 define that
    describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
 #define MAX_BUFFER_SIZE 1024
-#define TEST_MESSAGE    "test"
 
 #ifdef WOLFMQTT_PROPERTY_CB
 #define MAX_CLIENT_ID_LEN 64
@@ -78,10 +77,10 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         PRINTF("MQTT Message: Topic %s, Qos %d, Len %u",
             buf, msg->qos, msg->total_len);
 
-        /* for test mode: check if TEST_MESSAGE was received */
+        /* for test mode: check if DEFAULT_MESSAGE was received */
         if (mqttCtx->test_mode) {
-            if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
-                XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer,
+            if (XSTRLEN(DEFAULT_MESSAGE) == msg->buffer_len &&
+                XSTRNCMP(DEFAULT_MESSAGE, (char*)msg->buffer,
                          msg->buffer_len) == 0)
             {
                 mStopRead = 1;
@@ -435,8 +434,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     mqttCtx->publish.duplicate = 0;
     mqttCtx->publish.topic_name = mqttCtx->topic_name;
     mqttCtx->publish.packet_id = mqtt_get_packetid();
-    mqttCtx->publish.buffer = (byte*)TEST_MESSAGE;
-    mqttCtx->publish.total_len = (word16)XSTRLEN(TEST_MESSAGE);
+    mqttCtx->publish.buffer = (byte*)mqttCtx->message;
+    mqttCtx->publish.total_len = (word16)XSTRLEN(mqttCtx->message);
 #ifdef WOLFMQTT_V5
     {
         /* Payload Format Indicator */

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -193,7 +193,10 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
     PRINTF("-l          Enable LWT (Last Will and Testament)");
     PRINTF("-u <str>    Username");
     PRINTF("-w <str>    Password");
-    PRINTF("-m <str>    Message, default: %s", mqttCtx->message);
+    if (mqttCtx->message) {
+        /* Only mqttclient example can set message from CLI */
+        PRINTF("-m <str>    Message, default: %s", mqttCtx->message);
+    }
     PRINTF("-n <str>    Topic name, default: %s", mqttCtx->topic_name);
     PRINTF("-r          Set Retain flag on publish message");
     PRINTF("-C <num>    Command Timeout, default: %dms",
@@ -218,7 +221,6 @@ void mqtt_init_ctx(MQTTCtx* mqttCtx)
     mqttCtx->keep_alive_sec = DEFAULT_KEEP_ALIVE_SEC;
     mqttCtx->client_id = kDefClientId;
     mqttCtx->topic_name = kDefTopicName;
-    mqttCtx->message = DEFAULT_MESSAGE;
     mqttCtx->cmd_timeout_ms = DEFAULT_CMD_TIMEOUT_MS;
 #ifdef WOLFMQTT_V5
     mqttCtx->max_packet_size = DEFAULT_MAX_PKT_SZ;

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -21,7 +21,7 @@
 
 /* Include the autoconf generated config.h */
 #ifdef HAVE_CONFIG_H
-    #include <config.h>
+#include <config.h>
 #endif
 
 #include "wolfmqtt/mqtt_client.h"
@@ -39,7 +39,7 @@ static int myoptind = 0;
 static char* myoptarg = NULL;
 
 #ifdef ENABLE_MQTT_TLS
-	static const char* mTlsCaFile;
+static const char* mTlsCaFile;
 #endif
 
 static int mygetopt(int argc, char** argv, const char* optstring)
@@ -57,7 +57,7 @@ static int mygetopt(int argc, char** argv, const char* optstring)
             myoptind++;
 
         if (myoptind >= argc || argv[myoptind][0] != '-' ||
-                                argv[myoptind][1] == '\0') {
+                argv[myoptind][1] == '\0') {
             myoptarg = NULL;
             if (myoptind < argc)
                 myoptarg = argv[myoptind];
@@ -172,40 +172,41 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
 {
     PRINTF("%s:", mqttCtx->app_name);
     PRINTF("-?          Help, print this usage");
-    PRINTF("-h <host>   Host to connect to, default %s",
-        mqttCtx->host);
+    PRINTF("-h <host>   Host to connect to, default: %s",
+            mqttCtx->host);
 #ifdef ENABLE_MQTT_TLS
     PRINTF("-p <num>    Port to connect on, default: Normal %d, TLS %d",
-        MQTT_DEFAULT_PORT, MQTT_SECURE_PORT);
+            MQTT_DEFAULT_PORT, MQTT_SECURE_PORT);
     PRINTF("-t          Enable TLS");
     PRINTF("-c <file>   Use provided certificate file");
 #else
     PRINTF("-p <num>    Port to connect on, default: %d",
-        MQTT_DEFAULT_PORT);
+            MQTT_DEFAULT_PORT);
 #endif
-    PRINTF("-q <num>    Qos Level 0-2, default %d",
-        mqttCtx->qos);
+    PRINTF("-q <num>    Qos Level 0-2, default: %d",
+            mqttCtx->qos);
     PRINTF("-s          Disable clean session connect flag");
-    PRINTF("-k <num>    Keep alive seconds, default %d",
-        mqttCtx->keep_alive_sec);
-    PRINTF("-i <id>     Client Id, default %s",
-        mqttCtx->client_id);
+    PRINTF("-k <num>    Keep alive seconds, default: %d",
+            mqttCtx->keep_alive_sec);
+    PRINTF("-i <id>     Client Id, default: %s",
+            mqttCtx->client_id);
     PRINTF("-l          Enable LWT (Last Will and Testament)");
     PRINTF("-u <str>    Username");
     PRINTF("-w <str>    Password");
-    PRINTF("-n <str>    Topic name, default %s", mqttCtx->topic_name);
+    PRINTF("-m <str>    Message, default: %s", mqttCtx->message);
+    PRINTF("-n <str>    Topic name, default: %s", mqttCtx->topic_name);
     PRINTF("-r          Set Retain flag on publish message");
-    PRINTF("-C <num>    Command Timeout, default %dms",
-        mqttCtx->cmd_timeout_ms);
+    PRINTF("-C <num>    Command Timeout, default: %dms",
+            mqttCtx->cmd_timeout_ms);
 #ifdef WOLFMQTT_V5
     PRINTF("-P <num>    Max packet size the client will accept, default: %d",
             DEFAULT_MAX_PKT_SZ);
 #endif
     PRINTF("-T          Test mode");
     if (mqttCtx->pub_file) {
-	    PRINTF("-f <file>   Use file for publish, default %s",
-	        mqttCtx->pub_file);
-	}
+        PRINTF("-f <file>   Use file for publish, default: %s",
+                mqttCtx->pub_file);
+    }
 }
 
 void mqtt_init_ctx(MQTTCtx* mqttCtx)
@@ -217,6 +218,7 @@ void mqtt_init_ctx(MQTTCtx* mqttCtx)
     mqttCtx->keep_alive_sec = DEFAULT_KEEP_ALIVE_SEC;
     mqttCtx->client_id = kDefClientId;
     mqttCtx->topic_name = kDefTopicName;
+    mqttCtx->message = DEFAULT_MESSAGE;
     mqttCtx->cmd_timeout_ms = DEFAULT_CMD_TIMEOUT_MS;
 #ifdef WOLFMQTT_V5
     mqttCtx->max_packet_size = DEFAULT_MAX_PKT_SZ;
@@ -240,8 +242,8 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
         #define MQTT_V5_ARGS ""
     #endif
 
-    while ((rc = mygetopt(argc, argv, "?h:p:q:sk:i:lu:w:n:C:Tf:rt" \
-                            MQTT_TLS_ARGS MQTT_V5_ARGS)) != -1) {
+    while ((rc = mygetopt(argc, argv, "?h:p:q:sk:i:lu:w:m:n:C:Tf:rt" \
+            MQTT_TLS_ARGS MQTT_V5_ARGS)) != -1) {
         switch ((char)rc) {
         case '?' :
             mqtt_show_usage(mqttCtx);
@@ -289,6 +291,10 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
             mqttCtx->password = myoptarg;
             break;
 
+        case 'm':
+            mqttCtx->message = myoptarg;
+            break;
+
         case 'n':
             mqttCtx->topic_name = myoptarg;
             break;
@@ -298,6 +304,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
             break;
 
         case 'T':
+
             mqttCtx->test_mode = 1;
             break;
 
@@ -317,7 +324,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
         case 'c':
             mTlsCaFile = myoptarg;
             break;
-	#endif
+    #endif
 
     #ifdef WOLFMQTT_V5
         case 'P':
@@ -349,7 +356,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
     /* add random data to end of client_id and topic_name */
     if (mqttCtx->test_mode && mqttCtx->topic_name == kDefTopicName) {
         char* topic_name = mqtt_append_random(kDefTopicName,
-            (word32)XSTRLEN(kDefTopicName));
+                (word32)XSTRLEN(kDefTopicName));
         if (topic_name) {
             mqttCtx->topic_name = (const char*)topic_name;
             mqttCtx->dynamicTopic = 1;
@@ -357,7 +364,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
     }
     if (mqttCtx->test_mode && mqttCtx->client_id == kDefClientId) {
         char* client_id = mqtt_append_random(kDefClientId,
-            (word32)XSTRLEN(kDefClientId));
+                (word32)XSTRLEN(kDefClientId));
         if (client_id) {
             mqttCtx->client_id = (const char*)client_id;
             mqttCtx->dynamicClientId = 1;
@@ -384,14 +391,14 @@ void mqtt_free_ctx(MQTTCtx* mqttCtx)
 }
 
 #if defined(__GNUC__) && !defined(NO_EXIT)
-     __attribute__ ((noreturn))
+    __attribute__ ((noreturn))
 #endif
 int err_sys(const char* msg)
 {
     if (msg) {
         PRINTF("wolfMQTT error: %s", msg);
     }
-	exit(EXIT_FAILURE);
+    exit(EXIT_FAILURE);
 }
 
 
@@ -406,10 +413,10 @@ word16 mqtt_get_packetid(void)
 }
 
 #ifdef WOLFMQTT_NONBLOCK
-#if defined(MICROCHIP_MPLAB_HARMONY)
-    #include <system/tmr/sys_tmr.h>
-#else
-    #include <time.h>
+    #if defined(MICROCHIP_MPLAB_HARMONY)
+        #include <system/tmr/sys_tmr.h>
+    #else
+        #include <time.h>
 #endif
 
 static word32 mqtt_get_timer_seconds(void)
@@ -418,7 +425,7 @@ static word32 mqtt_get_timer_seconds(void)
 
 #if defined(MICROCHIP_MPLAB_HARMONY)
     timer_sec = (word32)(SYS_TMR_TickCountGet() /
-                         SYS_TMR_TickCounterFrequencyGet());
+            SYS_TMR_TickCounterFrequencyGet());
 #else
     /* Posix style time */
     timer_sec = (word32)time(0);
@@ -464,13 +471,13 @@ static int mqtt_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
         mqttCtx = (MQTTCtx *)store->userCtx;
         XSTRNCPY(appName, " for ", PRINT_BUFFER_SIZE-1);
         XSTRNCAT(appName, mqttCtx->app_name,
-                 PRINT_BUFFER_SIZE-XSTRLEN(appName)-1);
+                PRINT_BUFFER_SIZE-XSTRLEN(appName)-1);
     }
 
     PRINTF("MQTT TLS Verify Callback%s: PreVerify %d, Error %d (%s)",
-        appName, preverify,
-        store->error, store->error != 0 ?
-            wolfSSL_ERR_error_string(store->error, buffer) : "none");
+            appName, preverify,
+            store->error, store->error != 0 ?
+                    wolfSSL_ERR_error_string(store->error, buffer) : "none");
     PRINTF("  Subject's domain name is %s", store->domain);
 
     if (store->error != 0) {
@@ -490,49 +497,59 @@ int mqtt_tls_cb(MqttClient* client)
     client->tls.ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
     if (client->tls.ctx) {
         wolfSSL_CTX_set_verify(client->tls.ctx, WOLFSSL_VERIFY_PEER,
-                               mqtt_tls_verify_cb);
+                mqtt_tls_verify_cb);
 
-		/* default to success */
+        /* default to success */
         rc = WOLFSSL_SUCCESS;
 
-	#if !defined(NO_CERT)
+#if !defined(NO_CERT)
     #if !defined(NO_FILESYSTEM)
         if (mTlsCaFile) {
-	        /* Load CA certificate file */
-	        rc = wolfSSL_CTX_load_verify_locations(client->tls.ctx,
-	                mTlsCaFile, NULL);
-	    }
 
-        /* If using a client certificate it can be loaded using: */
-        /* rc = wolfSSL_CTX_use_certificate_file(client->tls.ctx,
-         *                              clientCertFile, WOLFSSL_FILETYPE_PEM);*/
+            /* Load CA certificate file */
+            rc = wolfSSL_CTX_load_verify_locations(client->tls.ctx,
+                    mTlsCaFile, NULL);
+
+            /* If using a client certificate it can be loaded using: */
+            /*
+            rc = wolfSSL_CTX_use_certificate_file(client->tls.ctx,
+                                    mTlsCaFile, WOLFSSL_FILETYPE_PEM);
+            */
+        }
     #else
-	    if (mTlsCaFile) {
-	    #if 0
-	    	/* As example, load file into buffer for testing */
-	    	long  caCertSize = 0;
-	        byte  caCertBuf[10000];
-	        FILE* file = fopen(mTlsCaFile, "rb");
-	        if (!file) {
-	            err_sys("can't open file for CA buffer load");
-	        }
-	        fseek(file, 0, SEEK_END);
-	        caCertSize = ftell(file);
-	        rewind(file);
-	        fread(caCertBuf, sizeof(caCertBuf), 1, file);
-	        fclose(file);
+        if (mTlsCaFile) {
+        #if 0
+            /* As example, load file into buffer for testing */
+            long  caCertSize = 0;
+            byte  caCertBuf[10000];
+            FILE* file = fopen(mTlsCaFile, "rb");
 
-	    	/* Load CA certificate buffer */
-	        rc = wolfSSL_CTX_load_verify_buffer(client->tls.ctx, caCertBuf,
-                                              caCertSize, WOLFSSL_FILETYPE_PEM);
-	    #endif
-	    }
+            if (!file) {
+                err_sys("can't open file for CA buffer load");
+            }
+
+            fseek(file, 0, SEEK_END);
+            caCertSize = ftell(file);
+            rewind(file);
+            fread(caCertBuf, sizeof(caCertBuf), 1, file);
+            fclose(file);
+
+            /* Load CA certificate buffer */
+            rc = wolfSSL_CTX_load_verify_buffer(client->tls.ctx, caCertBuf,
+                    caCertSize, WOLFSSL_FILETYPE_PEM);
+            /* If using a client certificate it can be loaded using: */
+            /*
+            rc = wolfSSL_CTX_use_certificate_buffer(client->tls.ctx,
+                        clientCertBuf, clientCertSize, WOLFSSL_FILETYPE_PEM);
+            */
+        #endif
+        }
 
         /* If using a client certificate it can be loaded using: */
         /* rc = wolfSSL_CTX_use_certificate_buffer(client->tls.ctx,
          *               clientCertBuf, clientCertSize, WOLFSSL_FILETYPE_PEM);*/
     #endif /* !NO_FILESYSTEM */
-    #endif /* !NO_CERT */
+#endif /* !NO_CERT */
     }
 
     PRINTF("MQTT TLS Setup (%d)", rc);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -71,6 +71,7 @@
 #define DEFAULT_TOPIC_NAME      WOLFMQTT_TOPIC_NAME"testTopic"
 #define DEFAULT_AUTH_METHOD    "EXTERNAL"
 #define PRINT_BUFFER_SIZE       80
+#define DEFAULT_MESSAGE         "test"
 
 #ifdef WOLFMQTT_V5
 #define DEFAULT_MAX_PKT_SZ      768 /* The max MQTT control packet size the
@@ -125,6 +126,7 @@ typedef struct _MQTTCtx {
     const char* username;
     const char* password;
     const char* topic_name;
+    const char* message;
     const char* pub_file;
     const char* client_id;
     byte *tx_buf, *rx_buf;


### PR DESCRIPTION
This adds the `-m` option to the mqttclient, to allow passing in the first message to be published.
Also fix some white-space issues in `mqttexample.c`.