### PR TITLE
SN feature enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,6 @@ examples/wiot/wiot
 wolfmqtt/options.h
 /IDE/Microchip-Harmony/wolfmqtt_client/firmware/mqtt_client.X/dist/default/
 examples/sn-client/sn-client
+examples/sn-client/sn-client_qos-1
 examples/multithread/multithread
 examples/mqttsimple/mqttsimple

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This example enables the wolfMQTT client to connect to the IBM Watson Internet o
 ### MQTT-SN Example
 The Sensor Network client implements the MQTT-SN protocol for low-bandwidth networks. There are several differences from MQTT, including the ability to use a two byte Topic ID instead the full topic during subscribe and publish. The SN client requires an MQTT-SN gateway. The gateway acts as an intermediary between the SN clients and the broker. This client was tested with the Eclipse Paho MQTT-SN Gateway, which connects by default to the public Eclipse broker, much like our wolfMQTT Client example. The address of the gateway must be configured as the host. The example is located in `/examples/sn-client/`.
 
-A special feature of MQTT-SN is the ability to use QoS level -1 to publish to a predefined topic without connecting to the gateway. There is an example provided in `/examples/sn-client/sn-client_qos-1`. It requires some configuration changes of the gateway. 
+A special feature of MQTT-SN is the ability to use QoS level -1 (negative one) to publish to a predefined topic without first connecting to the gateway. There is no feedback in the application if there was an error, so confirmation of the test would involve running the `sn-client` first and watching for the publish from the `sn-client_qos-1`. There is an example provided in `/examples/sn-client/sn-client_qos-1`. It requires some configuration changes of the gateway.
 
 * Enable the the QoS-1 feature, predefined topics, and change the gateway name in `gateway.conf`:
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ This example enables the wolfMQTT client to connect to the IBM Watson Internet o
 ### MQTT-SN Example
 The Sensor Network client implements the MQTT-SN protocol for low-bandwidth networks. There are several differences from MQTT, including the ability to use a two byte Topic ID instead the full topic during subscribe and publish. The SN client requires an MQTT-SN gateway. The gateway acts as an intermediary between the SN clients and the broker. This client was tested with the Eclipse Paho MQTT-SN Gateway, which connects by default to the public Eclipse broker, much like our wolfMQTT Client example. The address of the gateway must be configured as the host. The example is located in `/examples/sn-client/`.
 
+A special feature of MQTT-SN is the ability to use QoS level -1 to publish to a predefined topic without connecting to the gateway. There is an example provided in `/examples/sn-client/sn-client_qos-1`. It requires some configuration changes of the gateway. 
+
+* Enable the the QoS-1 feature, predefined topics, and change the gateway name in `gateway.conf`:
+
+```
+QoS-1=YES
+PredefinedTopic=YES
+PredefinedTopicList=./predefinedTopic.conf
+.
+.
+.
+#GatewayName=PahoGateway-01
+GatewayName=WolfGateway
+```
+
+* Comment out all entries and add a new topic in `predefinedTopic.conf`:
+
+```
+WolfGatewayQoS-1,wolfMQTT/example/testTopic, 1
+```
+
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 

--- a/examples/include.am
+++ b/examples/include.am
@@ -15,6 +15,7 @@ noinst_PROGRAMS += examples/multithread/multithread
 endif
 if BUILD_SN
 noinst_PROGRAMS += examples/sn-client/sn-client
+noinst_PROGRAMS += examples/sn-client/sn-client_qos-1
 endif
 
 noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
@@ -109,6 +110,13 @@ examples_sn_client_sn_client_SOURCES        = examples/sn-client/sn-client.c \
 examples_sn_client_sn_client_LDADD          = src/libwolfmqtt.la
 examples_sn_client_sn_client_DEPENDENCIES   = src/libwolfmqtt.la
 examples_sn_client_sn_client_CPPFLAGS       = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
+
+examples_sn_client_sn_client_qos_1_SOURCES      = examples/sn-client/sn-client_qos-1.c \
+                                                  examples/mqttnet.c \
+                                                  examples/mqttexample.c
+examples_sn_client_sn_client_qos_1_LDADD        = src/libwolfmqtt.la
+examples_sn_client_sn_client_qos_1_DEPENDENCIES = src/libwolfmqtt.la
+examples_sn_client_sn_client_qos_1_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 endif
 endif
 
@@ -128,6 +136,7 @@ dist_example_DATA+= examples/multithread/multithread.c
 endif
 if BUILD_SN
 dist_example_DATA+= examples/sn-client/sn-client.c
+dist_example_DATA+= examples/sn-client/sn-client_qos-1.c
 endif
 
 DISTCLEANFILES+=   examples/mqttclient/.libs/mqttclient \
@@ -142,6 +151,7 @@ DISTCLEANFILES+=   examples/multithread/.libs/multithread
 endif
 if BUILD_SN
 DISTCLEANFILES+=   examples/sn-client/.libs/sn-client
+DISTCLEANFILES+=   examples/sn-client/.libs/sn-client_qos-1
 endif
 
 EXTRA_DIST+=       examples/mqttuart.c \

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -341,9 +341,10 @@ int sn_test(MQTTCtx *mqttCtx)
     {
         /* Will Topic and Message update */
         SN_Will willUpdate;
-        XMEMSET(&willUpdate, 0, sizeof(SN_Will));
         char willTopicName[] = WOLFMQTT_TOPIC_NAME"lastWishes";
         char willTopicMsg[] = "I'LL BE BACK";
+
+        XMEMSET(&willUpdate, 0, sizeof(SN_Will));
 
         /* Set new topic */
         willUpdate.willTopic = willTopicName;

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -260,10 +260,10 @@ int sn_test(MQTTCtx *mqttCtx)
         subscribe.topicNameId = SHORT_TOPIC_NAME;
         subscribe.packet_id = mqtt_get_packetid();
 
-        PRINTF("MQTT-SN Subscribe: topic name = %s", subscribe.topicNameId);
+        PRINTF("MQTT-SN Subscribe Short Topic: topic name = %s", subscribe.topicNameId);
         rc = SN_Client_Subscribe(&mqttCtx->client, &subscribe);
 
-        PRINTF("....MQTT-SN Subscribe Ack: topic id = %d, rc = %d",
+        PRINTF("....MQTT-SN Subscribe Short Topic Ack: topic id = %d, rc = %d",
                 subscribe.subAck.topicId, subscribe.subAck.return_code);
 
         /* Short Topic Name Publish */
@@ -285,7 +285,7 @@ int sn_test(MQTTCtx *mqttCtx)
 
         rc = SN_Client_Publish(&mqttCtx->client, &publish);
 
-        PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
+        PRINTF("MQTT-SN Publish Short Topic: topic id = %d, rc = %d\r\nPayload = %s",
             (word16)*publish.topic_name,
             publish.return_code,
             publish.buffer);
@@ -293,6 +293,32 @@ int sn_test(MQTTCtx *mqttCtx)
             goto disconn;
         }
     }
+
+#if 0
+    /* Disabled because not currently supported by Paho MQTT-SN Gateway */
+    {
+        /* Will Topic and Message update */
+        SN_Will willUpdate;
+        XMEMSET(&willUpdate, 0, sizeof(SN_Will));
+        char willTopicName[] = WOLFMQTT_TOPIC_NAME"lastWishes";
+        char willTopicMsg[] = "I'LL BE BACK";
+
+        /* Set new topic */
+        willUpdate.willTopic = willTopicName;
+        PRINTF("MQTT-SN Will Topic Update: topic name = %s", willUpdate.willTopic);
+        rc = SN_Client_WillTopicUpdate(&mqttCtx->client, &willUpdate);
+        PRINTF("....MQTT-SN Will Topic Update: response = %d, rc = %d",
+                willUpdate.resp.topicResp.return_code, rc);
+
+        /* Set new message*/
+        willUpdate.willMsg = (byte*)willTopicMsg;
+        willUpdate.willMsgLen = XSTRLEN(willTopicMsg);
+        PRINTF("MQTT-SN Will Message Update: message = %s", willUpdate.willMsg);
+        rc = SN_Client_WillMsgUpdate(&mqttCtx->client, &willUpdate);
+        PRINTF("....MQTT-SN Will Message Update: response = %d, rc = %d",
+                willUpdate.resp.msgResp.return_code, rc);
+    }
+#endif
 
     /* Read Loop */
     PRINTF("MQTT Waiting for message...");

--- a/examples/sn-client/sn-client_qos-1.c
+++ b/examples/sn-client/sn-client_qos-1.c
@@ -1,0 +1,209 @@
+/* sn-client_qos-1.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfMQTT.
+ *
+ * wolfMQTT is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfMQTT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* Include the autoconf generated config.h */
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include "wolfmqtt/mqtt_client.h"
+
+#include "sn-client.h"
+#include "examples/mqttnet.h"
+
+/* Locals */
+static int mStopRead = 0;
+
+#ifdef WOLFMQTT_SN
+
+/* Configuration */
+/* Maximum size for network read/write callbacks. */
+#define MAX_BUFFER_SIZE 1024
+#define TEST_MESSAGE    "QoS-1 test message"
+char    SHORT_TOPIC_NAME[] = {1};
+
+
+int sn_test(MQTTCtx *mqttCtx)
+{
+    int rc = MQTT_CODE_SUCCESS;
+
+    PRINTF("MQTT-SN Client: QoS %d", mqttCtx->qos);
+
+    /* Initialize Network */
+    rc = SN_ClientNet_Init(&mqttCtx->net, mqttCtx);
+    PRINTF("MQTT-SN Net Init: %s (%d)",
+        MqttClient_ReturnCodeToString(rc), rc);
+    if (rc != MQTT_CODE_SUCCESS) {
+        goto exit;
+    }
+
+    /* setup tx/rx buffers */
+    mqttCtx->tx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
+    mqttCtx->rx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
+
+    /* Initialize MqttClient structure */
+    rc = MqttClient_Init(&mqttCtx->client, &mqttCtx->net,
+        NULL,
+        mqttCtx->tx_buf, MAX_BUFFER_SIZE,
+        mqttCtx->rx_buf, MAX_BUFFER_SIZE,
+        mqttCtx->cmd_timeout_ms);
+
+    PRINTF("MQTT-SN Init: %s (%d)",
+        MqttClient_ReturnCodeToString(rc), rc);
+    if (rc != MQTT_CODE_SUCCESS) {
+        goto exit;
+    }
+
+    /* Setup socket direct to gateway */
+    rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host,
+           mqttCtx->port, DEFAULT_CON_TIMEOUT_MS,
+           0, NULL);
+
+    PRINTF("MQTT-SN Socket Connect: %s (%d)",
+        MqttClient_ReturnCodeToString(rc), rc);
+    if (rc != MQTT_CODE_SUCCESS) {
+        goto exit;
+    }
+
+    {
+        SN_Publish publish;
+
+        /* Predefined Topic Name Publish */
+        XMEMSET(&publish, 0, sizeof(SN_Publish));
+        publish.qos = MQTT_QOS_3; /* Set QoS level -1 */
+        publish.topic_type = SN_TOPIC_ID_TYPE_PREDEF;
+        publish.topic_name = (char*)SHORT_TOPIC_NAME;
+        publish.buffer = (byte*)TEST_MESSAGE;
+        publish.total_len = (word16)XSTRLEN(TEST_MESSAGE);
+
+        rc = SN_Client_Publish(&mqttCtx->client, &publish);
+
+        PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
+            (word16)*publish.topic_name,
+            publish.return_code,
+            publish.buffer);
+        if (rc != MQTT_CODE_SUCCESS) {
+            goto disconn;
+        }
+    }
+
+    /* Check for error */
+    if (rc != MQTT_CODE_SUCCESS) {
+        goto disconn;
+    }
+
+disconn:
+
+    rc = MqttClient_NetDisconnect(&mqttCtx->client);
+
+    PRINTF("MQTT Socket Disconnect: %s (%d)",
+        MqttClient_ReturnCodeToString(rc), rc);
+
+exit:
+
+    /* Free resources */
+    if (mqttCtx->tx_buf) WOLFMQTT_FREE(mqttCtx->tx_buf);
+    if (mqttCtx->rx_buf) WOLFMQTT_FREE(mqttCtx->rx_buf);
+
+    /* Cleanup network */
+    MqttClientNet_DeInit(&mqttCtx->net);
+
+    MqttClient_DeInit(&mqttCtx->client);
+
+    return rc;
+}
+
+#endif /* WOLFMQTT_SN */
+
+/* so overall tests can pull in test function */
+#if !defined(NO_MAIN_DRIVER) && !defined(MICROCHIP_MPLAB_HARMONY)
+    #ifdef USE_WINDOWS_API
+        #include <windows.h> /* for ctrl handler */
+
+        static BOOL CtrlHandler(DWORD fdwCtrlType)
+        {
+            if (fdwCtrlType == CTRL_C_EVENT) {
+                mStopRead = 1;
+                PRINTF("Received Ctrl+c");
+                return TRUE;
+            }
+            return FALSE;
+        }
+    #elif HAVE_SIGNAL
+        #include <signal.h>
+        static void sig_handler(int signo)
+        {
+            if (signo == SIGINT) {
+                mStopRead = 1;
+                PRINTF("Received SIGINT");
+            }
+        }
+    #endif
+
+int main(int argc, char** argv)
+{
+    int rc;
+#ifdef WOLFMQTT_SN
+    MQTTCtx mqttCtx;
+
+    /* init defaults */
+    mqtt_init_ctx(&mqttCtx);
+    mqttCtx.app_name = "sn-client_qos-1";
+
+    /* Settings for MQTT-SN gateway */
+    mqttCtx.host = "localhost";
+    mqttCtx.port = 1883;
+
+    /* parse arguments */
+    rc = mqtt_parse_args(&mqttCtx, argc, argv);
+    if (rc != 0) {
+        return rc;
+    }
+#endif
+#ifdef USE_WINDOWS_API
+    if (SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler,
+          TRUE) == FALSE)
+    {
+        PRINTF("Error setting Ctrl Handler! Error %d", (int)GetLastError());
+    }
+#elif HAVE_SIGNAL
+    if (signal(SIGINT, sig_handler) == SIG_ERR) {
+        PRINTF("Can't catch SIGINT");
+    }
+#endif
+
+#ifdef WOLFMQTT_SN
+    rc = sn_test(&mqttCtx);
+#else
+    (void)argc;
+    (void)argv;
+
+    /* This example requires MQTT-SN mode to be enabled
+       ./configure --enable-sn */
+    PRINTF("Example not compiled in!");
+    rc = EXIT_FAILURE;
+#endif
+
+
+    return (rc == 0) ? 0 : EXIT_FAILURE;
+}
+
+#endif /* NO_MAIN_DRIVER */

--- a/examples/sn-client/sn-client_qos-1.c
+++ b/examples/sn-client/sn-client_qos-1.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+/* This example requires a gateway that supports and is configured
+   for Quality of Service level -1. The Paho gateway must be configured
+   as described in the wolfMQTT README.md */
+
 /* Include the autoconf generated config.h */
 #ifdef HAVE_CONFIG_H
     #include <config.h>

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2909,7 +2909,7 @@ int SN_Client_Disconnect_ex(MqttClient *client, SN_Disconnect *disconnect)
     if (rc != len) { return rc; }
 
     /* If sleep was set, wait for response disconnect packet */
-    if (disconnect->sleepTmr != 0) {
+    if ((disconnect != NULL) && (disconnect->sleepTmr != 0)) {
         rc = SN_Client_WaitType(client, NULL,
                 SN_MSG_TYPE_DISCONNECT, 0, client->cmd_timeout_ms);
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2317,6 +2317,34 @@ static int SN_Client_HandlePacket(MqttClient* client, SN_MsgType packet_type,
             rc = SN_Decode_Ping(client->rx_buf, client->packet.buf_len);
             break;
         }
+        case SN_MSG_TYPE_WILLTOPICRESP:
+        {
+            /* Decode Will Topic Response */
+            SN_WillTopicResp *resp;
+            if (packet_obj) {
+                resp = (SN_WillTopicResp*)packet_obj;
+            }
+            else {
+                XMEMSET(resp, 0, sizeof(SN_WillTopicResp));
+            }
+            rc = SN_Decode_WillTopicResponse(client->rx_buf,
+                    client->packet.buf_len, &resp->return_code);
+            break;
+        }
+        case SN_MSG_TYPE_WILLMSGRESP:
+        {
+            /* Decode Will Message Response */
+            SN_WillMsgResp *resp;
+            if (packet_obj) {
+                resp = (SN_WillMsgResp*)packet_obj;
+            }
+            else {
+                XMEMSET(resp, 0, sizeof(SN_WillMsgResp));
+            }
+            rc = SN_Decode_WillMsgResponse(client->rx_buf,
+                    client->packet.buf_len, &resp->return_code);
+            break;
+        }
         default:
         {
             /* Other types are server side only, ignore */
@@ -2591,7 +2619,7 @@ int SN_Client_WillTopicUpdate(MqttClient *client, SN_Will *will)
             if (will != NULL) {
                 /* Wait for Will Topic Update Response packet */
                 rc = SN_Client_WaitType(client, &will->resp.topicResp,
-                        SN_MSG_TYPE_WILLTOPICREQ, 0, client->cmd_timeout_ms);
+                        SN_MSG_TYPE_WILLTOPICRESP, 0, client->cmd_timeout_ms);
             }
         }
     }
@@ -2617,7 +2645,7 @@ int SN_Client_WillMsgUpdate(MqttClient *client, SN_Will *will)
         rc = MqttPacket_Write(client, client->tx_buf, len);
         if (rc == len) {
             /* Wait for Will Message Update Response packet */
-            rc = SN_Client_WaitType(client, &will->resp.msgUpd,
+            rc = SN_Client_WaitType(client, &will->resp.msgResp,
                     SN_MSG_TYPE_WILLMSGRESP, 0, client->cmd_timeout_ms);
         }
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2700,7 +2700,8 @@ int SN_Client_Publish(MqttClient *client, SN_Publish *publish)
             }
 
             /* if not expecting a reply, the reset state and exit */
-            if (publish->qos == MQTT_QOS_0) {
+            if ((publish->qos == MQTT_QOS_0) ||
+                (publish->qos == MQTT_QOS_3)) {
                 publish->stat = MQTT_MSG_BEGIN;
                 break;
             }
@@ -2713,7 +2714,8 @@ int SN_Client_Publish(MqttClient *client, SN_Publish *publish)
             publish->stat = MQTT_MSG_WAIT;
 
             /* Handle QoS */
-            if (publish->qos > MQTT_QOS_0) {
+            if ((publish->qos == MQTT_QOS_1) ||
+                (publish->qos == MQTT_QOS_2)) {
 
                 XMEMSET(&publish->resp, 0, sizeof(SN_PublishResp));
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2160,6 +2160,46 @@ static int SN_Client_HandlePacket(MqttClient* client, SN_MsgType packet_type,
 
             break;
         }
+        case SN_MSG_TYPE_REGISTER:
+        {
+            /* Decode register */
+            SN_Register reg_s;
+            int len;
+
+            XMEMSET(&reg_s, 0, sizeof(SN_Register));
+
+            rc = SN_Decode_Register(client->rx_buf, client->packet.buf_len,
+                    &reg_s);
+
+            if (rc > 0) {
+                /* Initialize the regack */
+                reg_s.regack.packet_id = reg_s.packet_id;
+                reg_s.regack.topicId = reg_s.topicId;
+                reg_s.regack.return_code = SN_RC_NOTSUPPORTED;
+
+                /* Call the register callback to allow app to
+                   handle new topic ID assignment. */
+                if (client->reg_cb != NULL) {
+                     rc = client->reg_cb(reg_s.topicId,
+                            reg_s.topicName, client->reg_ctx);
+                     /* Set the regack return code */
+                     reg_s.regack.return_code = (rc >= 0) ? SN_RC_ACCEPTED :
+                             SN_RC_INVTOPICNAME;
+                }
+
+                /* Encode the register acknowledgment */
+                rc = SN_Encode_RegAck(client->tx_buf, client->tx_buf_len,
+                        &reg_s.regack);
+                if (rc <= 0) { return rc; }
+                len = rc;
+
+                /* Send regack packet */
+                rc = MqttPacket_Write(client, client->tx_buf, len);
+                if (rc != len) { return rc; }
+            }
+
+            break;
+        }
         case SN_MSG_TYPE_REGACK:
         {
             /* Decode register ack */
@@ -2495,6 +2535,20 @@ wait_again:
 }
 
 /* Public Functions */
+
+int SN_Client_SetRegisterCallback(MqttClient *client,
+        SN_ClientRegisterCb regCb,
+        void* ctx)
+{
+    if (client == NULL)
+        return MQTT_CODE_ERROR_BAD_ARG;
+
+    client->reg_cb = regCb;
+    client->reg_ctx = ctx;
+
+    return MQTT_CODE_SUCCESS;
+}
+
 int SN_Client_SearchGW(MqttClient *client, SN_SearchGw *search)
 {
     int rc, len = 0;
@@ -2527,6 +2581,53 @@ int SN_Client_SearchGW(MqttClient *client, SN_SearchGw *search)
         client->cmd_timeout_ms);
 
     return rc;
+}
+
+static int SN_Client_Will(MqttClient *client, SN_Will *will)
+{
+    int rc, len;
+
+    /* Validate required arguments */
+    if (client == NULL) {
+        return MQTT_CODE_ERROR_BAD_ARG;
+    }
+
+    /* Wait for Will Topic Request packet */
+    rc = SN_Client_WaitType(client, will,
+            SN_MSG_TYPE_WILLTOPICREQ, 0, client->cmd_timeout_ms);
+    if (rc == 0) {
+
+        /* Encode Will Topic */
+        len = rc = SN_Encode_WillTopic(client->tx_buf, client->tx_buf_len, will);
+        if (rc > 0) {
+
+            /* Send Will Topic packet */
+            rc = MqttPacket_Write(client, client->tx_buf, len);
+            if ((will != NULL) && (rc == len)) {
+
+                /* Wait for Will Message Request */
+                rc = SN_Client_WaitType(client, &will->resp.msgResp,
+                        SN_MSG_TYPE_WILLMSGREQ, 0, client->cmd_timeout_ms);
+
+                if (rc == 0) {
+
+                    /* Encode Will Message */
+                    len = rc = SN_Encode_WillMsg(client->tx_buf,
+                        client->tx_buf_len, will);
+                    if (rc > 0) {
+
+                        /* Send Will Topic packet */
+                        rc = MqttPacket_Write(client, client->tx_buf, len);
+                        if (rc == len)
+                            rc = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    return rc;
+
 }
 
 int SN_Client_Connect(MqttClient *client, SN_Connect *mc_connect)
@@ -2577,53 +2678,6 @@ int SN_Client_Connect(MqttClient *client, SN_Connect *mc_connect)
     }
 
     return rc;
-}
-
-int SN_Client_Will(MqttClient *client, SN_Will *will)
-{
-    int rc, len;
-
-    /* Validate required arguments */
-    if (client == NULL) {
-        return MQTT_CODE_ERROR_BAD_ARG;
-    }
-
-    /* Wait for Will Topic Request packet */
-    rc = SN_Client_WaitType(client, will,
-            SN_MSG_TYPE_WILLTOPICREQ, 0, client->cmd_timeout_ms);
-    if (rc == 0) {
-
-        /* Encode Will Topic */
-        len = rc = SN_Encode_WillTopic(client->tx_buf, client->tx_buf_len, will);
-        if (rc > 0) {
-
-            /* Send Will Topic packet */
-            rc = MqttPacket_Write(client, client->tx_buf, len);
-            if ((will != NULL) && (rc == len)) {
-
-                /* Wait for Will Message Request */
-                rc = SN_Client_WaitType(client, &will->resp.msgResp,
-                        SN_MSG_TYPE_WILLMSGREQ, 0, client->cmd_timeout_ms);
-
-                if (rc == 0) {
-
-                    /* Encode Will Message */
-                    len = rc = SN_Encode_WillMsg(client->tx_buf,
-                        client->tx_buf_len, will);
-                    if (rc > 0) {
-
-                        /* Send Will Topic packet */
-                        rc = MqttPacket_Write(client, client->tx_buf, len);
-                        if (rc == len)
-                            rc = 0;
-                    }
-                }
-            }
-        }
-    }
-
-    return rc;
-
 }
 
 int SN_Client_WillTopicUpdate(MqttClient *client, SN_Will *will)

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2380,7 +2380,7 @@ static int SN_Client_HandlePacket(MqttClient* client, SN_MsgType packet_type,
         case SN_MSG_TYPE_WILLTOPICRESP:
         {
             /* Decode Will Topic Response */
-            SN_WillTopicResp *resp;
+            SN_WillTopicResp resp_s, *resp = &resp_s;
             if (packet_obj) {
                 resp = (SN_WillTopicResp*)packet_obj;
             }
@@ -2394,7 +2394,7 @@ static int SN_Client_HandlePacket(MqttClient* client, SN_MsgType packet_type,
         case SN_MSG_TYPE_WILLMSGRESP:
         {
             /* Decode Will Message Response */
-            SN_WillMsgResp *resp;
+            SN_WillMsgResp resp_s, *resp = &resp_s;
             if (packet_obj) {
                 resp = (SN_WillMsgResp*)packet_obj;
             }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -3021,6 +3021,33 @@ int SN_Encode_Disconnect(byte *tx_buf, int tx_buf_len,
     return total_len;
 }
 
+int SN_Decode_Disconnect(byte *rx_buf, int rx_buf_len)
+{
+    word16 total_len;
+    byte *rx_payload = rx_buf, type;
+
+    /* Validate required arguments */
+    if (rx_buf == NULL || rx_buf_len <= 0) {
+        return MQTT_CODE_ERROR_BAD_ARG;
+    }
+
+    /* Decode fixed header */
+    total_len = *rx_payload++;
+    if (total_len != 2) {
+        return MQTT_CODE_ERROR_MALFORMED_DATA;
+    }
+
+    type = *rx_payload++;
+    if (type != SN_MSG_TYPE_DISCONNECT) {
+        return MQTT_CODE_ERROR_PACKET_TYPE;
+    }
+
+    (void)rx_payload;
+
+    /* Return total length of packet */
+    return total_len;
+}
+
 int SN_Encode_Ping(byte *tx_buf, int tx_buf_len, SN_PingReq *ping)
 {
     int total_len = 2, clientId_len = 0;

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2325,7 +2325,7 @@ int SN_Encode_WillTopicUpdate(byte *tx_buf, int tx_buf_len, SN_Will *willTopic)
 
 }
 
-int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len)
+int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len, byte *ret_code)
 {
     int total_len;
     byte *rx_payload = rx_buf, type;
@@ -2337,7 +2337,7 @@ int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len)
 
     /* Decode fixed header */
     total_len = *rx_payload++;
-    if (total_len != 2) {
+    if (total_len != 3) {
         return MQTT_CODE_ERROR_MALFORMED_DATA;
     }
 
@@ -2345,7 +2345,9 @@ int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len)
     if (type != SN_MSG_TYPE_WILLTOPICRESP) {
         return MQTT_CODE_ERROR_PACKET_TYPE;
     }
-    (void)rx_payload;
+
+    /* Return Code */
+    *ret_code = *rx_payload;
 
     /* Return total length of packet */
     return total_len;
@@ -2400,7 +2402,7 @@ int SN_Encode_WillMsgUpdate(byte *tx_buf, int tx_buf_len, SN_Will *willMsg)
     return total_len;
 }
 
-int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len)
+int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len, byte *ret_code)
 {
     int total_len;
     byte *rx_payload = rx_buf, type;
@@ -2412,7 +2414,7 @@ int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len)
 
     /* Decode fixed header */
     total_len = *rx_payload++;
-    if (total_len != 2) {
+    if (total_len != 3) {
         return MQTT_CODE_ERROR_MALFORMED_DATA;
     }
 
@@ -2420,7 +2422,9 @@ int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len)
     if (type != SN_MSG_TYPE_WILLMSGRESP) {
         return MQTT_CODE_ERROR_PACKET_TYPE;
     }
-    (void)rx_payload;
+
+    /* Return Code */
+    *ret_code = *rx_payload;
 
     /* Return total length of packet */
     return total_len;

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -3048,17 +3048,19 @@ int SN_Decode_Disconnect(byte *rx_buf, int rx_buf_len)
     return total_len;
 }
 
-int SN_Encode_Ping(byte *tx_buf, int tx_buf_len, SN_PingReq *ping)
+int SN_Encode_Ping(byte *tx_buf, int tx_buf_len, SN_PingReq *ping, byte type)
 {
     int total_len = 2, clientId_len = 0;
     byte *tx_payload = tx_buf;
 
     /* Validate required arguments */
-    if (tx_buf == NULL) {
+    if ((tx_buf == NULL) ||
+        ((type != SN_MSG_TYPE_PING_REQ) && (type != SN_MSG_TYPE_PING_RESP))) {
         return MQTT_CODE_ERROR_BAD_ARG;
     }
 
-    if (ping != NULL && ping->clientId != NULL) {
+    if ((type == SN_MSG_TYPE_PING_REQ) && (ping != NULL) &&
+        (ping->clientId != NULL)) {
         total_len += clientId_len = (int)XSTRLEN(ping->clientId);
     }
 
@@ -3068,7 +3070,7 @@ int SN_Encode_Ping(byte *tx_buf, int tx_buf_len, SN_PingReq *ping)
 
     *tx_payload++ = (byte)total_len;
 
-    *tx_payload++ = SN_MSG_TYPE_PING_REQ;
+    *tx_payload++ = type;
 
     if (clientId_len > 0) {
         XMEMCPY(tx_payload, ping->clientId, clientId_len);
@@ -3096,7 +3098,8 @@ int SN_Decode_Ping(byte *rx_buf, int rx_buf_len)
     }
 
     type = *rx_payload++;
-    if (type != SN_MSG_TYPE_PING_RESP) {
+    if ((type != SN_MSG_TYPE_PING_REQ) &&
+        (type != SN_MSG_TYPE_PING_RESP)) {
         return MQTT_CODE_ERROR_PACKET_TYPE;
     }
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -1088,6 +1088,10 @@ WOLFMQTT_LOCAL int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len,
         byte *ret_code);
 WOLFMQTT_LOCAL int SN_Encode_Register(byte *tx_buf, int tx_buf_len,
         SN_Register *regist);
+WOLFMQTT_LOCAL int SN_Decode_Register(byte *rx_buf, int rx_buf_len,
+        SN_Register *regist);
+WOLFMQTT_LOCAL int SN_Encode_RegAck(byte *tx_buf, int tx_buf_len,
+        SN_RegAck *regack);
 WOLFMQTT_LOCAL int SN_Decode_RegAck(byte *rx_buf, int rx_buf_len,
         SN_RegAck *regack);
 WOLFMQTT_LOCAL int SN_Encode_Subscribe(byte *tx_buf, int tx_buf_len,

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -176,7 +176,8 @@ typedef enum _MqttQoS {
     MQTT_QOS_0 = 0, /* At most once delivery */
     MQTT_QOS_1 = 1, /* At least once delivery */
     MQTT_QOS_2 = 2, /* Exactly once delivery */
-    MQTT_QOS_3 = 3, /* Reserved - must not be used */
+    MQTT_QOS_3 = 3, /* MQTT - Reserved - must not be used
+                       MQTT-SN - QoS -1 allows publish without connection */
 } MqttQoS;
 
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -1108,6 +1108,7 @@ WOLFMQTT_LOCAL int SN_Decode_UnsubscribeAck(byte *rx_buf, int rx_buf_len,
         SN_UnsubscribeAck *unsubscribe_ack);
 WOLFMQTT_LOCAL int SN_Encode_Disconnect(byte *tx_buf, int tx_buf_len,
         SN_Disconnect* disconnect);
+WOLFMQTT_LOCAL int SN_Decode_Disconnect(byte *rx_buf, int rx_buf_len);
 WOLFMQTT_LOCAL int SN_Encode_Ping(byte *tx_buf, int tx_buf_len,
         SN_PingReq *ping);
 WOLFMQTT_LOCAL int SN_Decode_Ping(byte *rx_buf, int rx_buf_len);

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -1110,7 +1110,7 @@ WOLFMQTT_LOCAL int SN_Encode_Disconnect(byte *tx_buf, int tx_buf_len,
         SN_Disconnect* disconnect);
 WOLFMQTT_LOCAL int SN_Decode_Disconnect(byte *rx_buf, int rx_buf_len);
 WOLFMQTT_LOCAL int SN_Encode_Ping(byte *tx_buf, int tx_buf_len,
-        SN_PingReq *ping);
+        SN_PingReq *ping, byte type);
 WOLFMQTT_LOCAL int SN_Decode_Ping(byte *rx_buf, int rx_buf_len);
 WOLFMQTT_LOCAL int SN_Packet_Read(struct _MqttClient *client, byte* rx_buf,
         int rx_buf_len, int timeout_ms);

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -1080,10 +1080,12 @@ WOLFMQTT_LOCAL int SN_Encode_WillMsg(byte *tx_buf, int tx_buf_len,
         SN_Will *willMsg);
 WOLFMQTT_LOCAL int SN_Encode_WillTopicUpdate(byte *tx_buf, int tx_buf_len,
         SN_Will *willTopic);
-WOLFMQTT_LOCAL int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len);
+WOLFMQTT_LOCAL int SN_Decode_WillTopicResponse(byte *rx_buf, int rx_buf_len,
+        byte *ret_code);
 WOLFMQTT_LOCAL int SN_Encode_WillMsgUpdate(byte *tx_buf, int tx_buf_len,
         SN_Will *willMsg);
-WOLFMQTT_LOCAL int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len);
+WOLFMQTT_LOCAL int SN_Decode_WillMsgResponse(byte *rx_buf, int rx_buf_len,
+        byte *ret_code);
 WOLFMQTT_LOCAL int SN_Encode_Register(byte *tx_buf, int tx_buf_len,
         SN_Register *regist);
 WOLFMQTT_LOCAL int SN_Decode_RegAck(byte *rx_buf, int rx_buf_len,


### PR DESCRIPTION
Adding support for several features of the specification:
* Will Topic update and Will Message update
* Publish with QoS-1
* Receiving Disconnect Packet while going to sleep
* New callback for REGISTER topic ID from gateway when client subscribes to wildcard topics
* Handling PINGREQ message from the gateway to client

A new example has been added to demonstrate the QoS level -1 feature. Also the README has been updated with instructions for configuring the Paho gateway to support QoS -1 client. The standard `sn-client` has been updated to demonstrate the other features.