### PR TITLE
Use MqttClient_Ping_ex instead of MqttClient_Ping in examples.

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -528,7 +528,7 @@ int awsiot_test(MQTTCtx *mqttCtx)
                     /* Keep Alive */
                     PRINTF("Keep-alive timeout, sending ping");
 
-                    rc = MqttClient_Ping(&mqttCtx->client);
+                    rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;
                     }

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -505,7 +505,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                     /* Keep Alive */
                     PRINTF("Keep-alive timeout, sending ping");
 
-                    rc = MqttClient_Ping(&mqttCtx->client);
+                    rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;
                     }

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -392,7 +392,7 @@ int fwclient_test(MQTTCtx *mqttCtx)
                     /* Keep Alive */
                     PRINTF("Keep-alive timeout, sending ping");
 
-                    rc = MqttClient_Ping(&mqttCtx->client);
+                    rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;
                     }

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -527,7 +527,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             /* Keep Alive */
             PRINTF("Keep-alive timeout, sending ping");
 
-            rc = MqttClient_Ping(&mqttCtx->client);
+            rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
             if (rc != MQTT_CODE_SUCCESS) {
                 PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
                     MqttClient_ReturnCodeToString(rc), rc);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -114,7 +114,7 @@ typedef struct _MQTTCtx {
     MqttTopic topics[1];
     MqttPublish publish;
     MqttDisconnect disconnect;
-
+    MqttPing ping;
 #ifdef WOLFMQTT_SN
     SN_Publish publishSN;
 #endif

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -430,7 +430,7 @@ int mqttsimple_test(void)
 
         if (rc == MQTT_CODE_ERROR_TIMEOUT) {
             /* send keep-alive ping */
-            rc = MqttClient_Ping(&mClient);
+            rc = MqttClient_Ping_ex(&mClient, &mqttObj.ping);
             if (rc != MQTT_CODE_SUCCESS) {
                 break;
             }

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -336,10 +336,11 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                     return rc;
                 }
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
+
                     /* Keep Alive */
                     PRINTF("Keep-alive timeout, sending ping");
 
-                    rc = MqttClient_Ping(&mqttCtx->client);
+                    rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;
                     }

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -310,7 +310,7 @@ int wiot_test(MQTTCtx *mqttCtx)
             /* Keep Alive */
             PRINTF("Keep-alive timeout, sending ping");
 
-            rc = MqttClient_Ping(&mqttCtx->client);
+            rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
             if (rc != MQTT_CODE_SUCCESS) {
                 PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
                     MqttClient_ReturnCodeToString(rc), rc);

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -335,6 +335,15 @@ WOLFMQTT_API int MqttClient_Unsubscribe(
  */
 WOLFMQTT_API int MqttClient_Ping(
     MqttClient *client);
+
+/*! \brief      Encodes and sends the MQTT Ping Request packet and waits for the
+                Ping Response packet. This version takes a MqttPing structure
+                and can be used with non-blocking applications.
+ *  \discussion This is a blocking function that will wait for MqttNet.read
+ *  \param      client      Pointer to MqttClient structure
+ *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
+                (see enum MqttPacketResponseCodes)
+ */
 WOLFMQTT_API int MqttClient_Ping_ex(MqttClient *client, MqttPing* ping);
 
 #ifdef WOLFMQTT_V5


### PR DESCRIPTION
The `MqttClient_Ping()` API does not take a structure pointer, and as such does not preserve the state for non-blocking applications. This updates the examples to use the `MqttClient_Ping_ex()` API and clarifies usage in the header.

This work is the result of a report in ZD11233.