### PR TITLE
Cleanup MQTT-SN multithread

### DIFF
--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -45,22 +45,18 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
 {
     byte buf[PRINT_BUFFER_SIZE+1];
     word32 len;
+    word16 topicId;
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
 
     (void)mqttCtx;
 
     if (msg_new) {
-        /* Determine min size to dump */
-        len = msg->topic_name_len;
-        if (len > PRINT_BUFFER_SIZE) {
-            len = PRINT_BUFFER_SIZE;
-        }
-        XMEMCPY(buf, msg->topic_name, len);
-        buf[len] = '\0'; /* Make sure its null terminated */
+        /* Topic ID or short topic name */
+        topicId = (word16)(msg->topic_name[0] << 8 | msg->topic_name[1]);
 
         /* Print incoming message */
-        PRINTF("MQTT-SN Message: Topic %s, Qos %d, Len %u",
-            buf, msg->qos, msg->total_len);
+        PRINTF("MQTT-SN Message: Topic ID %d, Qos %d, Id %d, Len %u",
+                topicId, msg->qos, msg->packet_id, msg->total_len);
 
         /* for test mode: check if TEST_MESSAGE was received */
         if (mqttCtx->test_mode) {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1944,8 +1944,8 @@ const char* SN_Packet_TypeDesc(SN_MsgType packet_type)
             return "Will message response";
         case SN_MSG_TYPE_ENCAPMSG:
             return "Encapsulated message";
-        case SN_MSG_TYPE_RESERVED:
-            return "Reserved";
+        case SN_MSG_TYPE_ANY:
+            return "Any";
         default:
             break;
     }
@@ -2975,6 +2975,7 @@ int SN_Decode_Publish(byte *rx_buf, int rx_buf_len, SN_Publish *publish)
 
     publish->topic_name = (char*)rx_payload;
     rx_payload += MQTT_DATA_LEN_SIZE;
+    publish->topic_name_len = MQTT_DATA_LEN_SIZE;
 
     rx_payload += MqttDecode_Num(rx_payload, &publish->packet_id);
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -768,7 +768,7 @@ typedef enum _SN_MsgType {
     SN_MSG_TYPE_ENCAPMSG        = 0xFE,    /* Encapsulated message */
     /* 0xFF reserved */
     SN_MSG_TYPE_RESERVED        = 0xFF,
-    SN_MQTT_PACKET_TYPE_ANY     = 0xFF
+    SN_MSG_TYPE_ANY     = 0xFF
 } SN_MsgType;
 
 /* Topic ID types */


### PR DESCRIPTION
Fixed example print messages and mutlithread debug comments. Modified `SN_Client_HandlePacket` to not return unused `ppacket_id`. Clarified usage of `SN_MSG_TYPE_ANY`.