### PR TITLE
Fix MQTT-SN register topic name string term

### DIFF
--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2788,6 +2788,9 @@ int SN_Decode_Register(byte *rx_buf, int rx_buf_len, SN_Register *regist)
 
         /* Decode Topic Name */
         regist->topicName = (char*)rx_payload;
+
+        /* Terminate the string */
+        rx_payload[total_len-6] = '\0';
     }
     (void)rx_payload;
 


### PR DESCRIPTION
If a subsequent topic name is registered with a length that is less than that of the previous name, then the string is not null terminated correctly.

This fixes an issue reported in ZD11171.