### PR TITLE
Fix to make TLS IO callback functions public

### DIFF
--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -35,7 +35,7 @@
 
     /* The signature wrapper for this example was added in wolfSSL after 3.7.1 */
     #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX > 0x03007001 \
-    	    && defined(HAVE_ECC)
+    	    && defined(HAVE_ECC) && !defined(NO_SIG_WRAPPER)
         #undef ENABLE_FIRMWARE_EXAMPLE
         #define ENABLE_FIRMWARE_EXAMPLE
     #endif

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -35,7 +35,7 @@
 
     /* The signature wrapper for this example was added in wolfSSL after 3.7.1 */
     #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX > 0x03007001 \
-    	    && defined(HAVE_ECC)
+    	    && defined(HAVE_ECC) && !defined(NO_SIG_WRAPPER)
         #undef ENABLE_FIRMWARE_EXAMPLE
         #define ENABLE_FIRMWARE_EXAMPLE
     #endif

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -383,9 +383,9 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         wolfSSL_CTX_SetMinDhKey_Sz(client->tls.ctx, WOLF_TLS_DHKEY_BITS_MIN);
     #endif
 
-        /* Setup the async IO callbacks */
-        wolfSSL_SetIORecv(client->tls.ctx, MqttSocket_TlsSocketReceive);
-        wolfSSL_SetIOSend(client->tls.ctx, MqttSocket_TlsSocketSend);
+        /* Setup the IO callbacks */
+        wolfSSL_CTX_SetIORecv(client->tls.ctx, MqttSocket_TlsSocketReceive);
+        wolfSSL_CTX_SetIOSend(client->tls.ctx, MqttSocket_TlsSocketSend);
 
         if (client->tls.ssl == NULL) {
             client->tls.ssl = wolfSSL_new(client->tls.ctx);
@@ -394,10 +394,10 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
                 rc = -1;
                 goto exit;
             }
-
-            wolfSSL_SetIOReadCtx(client->tls.ssl, (void *)client);
-            wolfSSL_SetIOWriteCtx(client->tls.ssl, (void *)client);
         }
+        /* Set the IO callback context */
+        wolfSSL_SetIOReadCtx(client->tls.ssl, (void *)client);
+        wolfSSL_SetIOWriteCtx(client->tls.ssl, (void *)client);
 
         if (client->ctx != NULL) {
             /* Store any app data for use by the tls verify callback*/

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -104,8 +104,10 @@ WOLFMQTT_LOCAL int MqttSocket_Connect(struct _MqttClient *client,
 WOLFMQTT_LOCAL int MqttSocket_Disconnect(struct _MqttClient *client);
 
 #ifdef ENABLE_MQTT_TLS
-int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz, void *ptr);
-int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz, void *ptr);
+/* make these public for cases where user needs to create 
+ * WOLFSSL_CTX context and WOLFSSL object in the TLS callback */
+WOLFMQTT_API int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz, void *ptr);
+WOLFMQTT_API int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz, void *ptr);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Fix to make TLS IO callback functions public and make sure the expected IO context is always set.
* Fix for building firmware examples without signature wrapper.
ZD 1162