### PR TITLE
Fixes for multi-threading issues

### DIFF
--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -67,7 +67,7 @@ static int mNumMsgsRecvd;
     #define THREAD_EXIT(e)         pthread_exit((void*)e)
 #endif
 
-static wm_Sem packetIdLock; /* Protect access to mqtt_get_packetid() */
+static wm_Sem mtLock; /* Protect "packetId" and "stop" */
 static wm_Sem pingSignal;
 
 static MQTTCtx gMqttCtx;
@@ -75,10 +75,26 @@ static MQTTCtx gMqttCtx;
 static word16 mqtt_get_packetid_threadsafe(void)
 {
     word16 packet_id;
-    wm_SemLock(&packetIdLock);
+    wm_SemLock(&mtLock);
     packet_id = mqtt_get_packetid();
-    wm_SemUnlock(&packetIdLock);
+    wm_SemUnlock(&mtLock);
     return packet_id;
+}
+
+static void mqtt_stop_set(void)
+{
+    wm_SemLock(&mtLock);
+    mStopRead = 1;
+    wm_SemUnlock(&mtLock);
+}
+
+static int mqtt_stop_get(void)
+{
+    int rc;
+    wm_SemLock(&mtLock);
+    rc = mStopRead;
+    wm_SemUnlock(&mtLock);
+    return rc;
 }
 
 #ifdef WOLFMQTT_DISCONNECT_CB
@@ -123,7 +139,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
             {
                 mNumMsgsRecvd++;
                 if (mNumMsgsRecvd == NUM_PUB_TASKS) {
-                    mStopRead = 1;
+                    mqtt_stop_set();
                 }
             }
         }
@@ -193,13 +209,13 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
     mNumMsgsRecvd = 0;
 
     /* Create a demo mutex for making packet id values */
-    rc = wm_SemInit(&packetIdLock);
+    rc = wm_SemInit(&mtLock);
     if (rc != 0) {
         client_exit(mqttCtx);
     }
     rc = wm_SemInit(&pingSignal);
     if (rc != 0) {
-        wm_SemFree(&packetIdLock);
+        wm_SemFree(&mtLock);
         client_exit(mqttCtx);
     }
     wm_SemLock(&pingSignal); /* default to locked */
@@ -309,7 +325,7 @@ static int multithread_test_finish(MQTTCtx *mqttCtx)
     client_disconnect(mqttCtx);
 
     wm_SemFree(&pingSignal);
-    wm_SemFree(&packetIdLock);
+    wm_SemFree(&mtLock);
 
     return mqttCtx->return_code;
 }
@@ -390,7 +406,7 @@ static void *waitMessage_task(void *param)
         rc = MqttClient_WaitMessage(&mqttCtx->client, mqttCtx->cmd_timeout_ms);
 
         /* check for test mode */
-        if (mStopRead) {
+        if (mqtt_stop_get()) {
             rc = MQTT_CODE_SUCCESS;
             PRINTF("MQTT Exiting...");
             break;
@@ -440,7 +456,7 @@ static void *waitMessage_task(void *param)
                 MqttClient_ReturnCodeToString(rc), rc);
             break;
         }
-    } while (!mStopRead);
+    } while (!mqtt_stop_get());
 
     mqttCtx->return_code = rc;
     wm_SemUnlock(&pingSignal); /* wake ping thread */
@@ -497,7 +513,7 @@ static void *ping_task(void *param)
 
     do {
         wm_SemLock(&pingSignal);
-        if (mStopRead)
+        if (mqtt_stop_get())
             break;
 
         /* Keep Alive Ping */
@@ -509,7 +525,7 @@ static void *ping_task(void *param)
                 MqttClient_ReturnCodeToString(rc), rc);
             break;
         }
-    } while (!mStopRead);
+    } while (!mqtt_stop_get());
 
     THREAD_EXIT(0);
 }
@@ -599,7 +615,7 @@ int multithread_test(MQTTCtx *mqttCtx)
         static BOOL CtrlHandler(DWORD fdwCtrlType)
         {
             if (fdwCtrlType == CTRL_C_EVENT) {
-                mStopRead = 1;
+                mqtt_stop_set();
                 PRINTF("Received Ctrl+c");
             #ifdef WOLFMQTT_ENABLE_STDIN_CAP
                 MqttClientNet_Wake(&gMqttCtx.net);
@@ -613,7 +629,7 @@ int multithread_test(MQTTCtx *mqttCtx)
         static void sig_handler(int signo)
         {
             if (signo == SIGINT) {
-                mStopRead = 1;
+                mqtt_stop_set();
                 PRINTF("Received SIGINT");
             #ifdef WOLFMQTT_ENABLE_STDIN_CAP
                 MqttClientNet_Wake(&gMqttCtx.net);

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1276,7 +1276,10 @@ int MqttDecode_SubscribeAck(byte* rx_buf, int rx_buf_len,
         }
 #endif
 
-        subscribe_ack->return_codes = rx_payload; /* List of return codes */
+        /* payload is list of return codes (MqttSubscribeAckReturnCodes) */
+        if (remain_len > MAX_MQTT_TOPICS)
+            remain_len = MAX_MQTT_TOPICS;
+        XMEMCMP(subscribe_ack->return_codes, rx_payload, remain_len);
     }
 
     /* Return total length of packet */

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -40,7 +40,12 @@
 #define MQTT_DATA_INT_SIZE   4
 
 #ifndef MAX_PACKET_ID
-#define MAX_PACKET_ID           ((1 << 16) - 1)
+#define MAX_PACKET_ID        ((1 << 16) - 1)
+#endif
+
+/* maximum list of topics to subscribe at once */
+#ifndef MAX_MQTT_TOPICS
+#define MAX_MQTT_TOPICS      12
 #endif
 
 #ifdef WOLFMQTT_V5
@@ -509,7 +514,7 @@ typedef struct _MqttSubscribeAck {
     MqttMsgStat stat; /* must be first member at top */
 
     word16      packet_id;
-    byte       *return_codes; /* MqttSubscribeAckReturnCodes */
+    byte        return_codes[MAX_MQTT_TOPICS];
 #ifdef WOLFMQTT_V5
     MqttProp* props;
     byte protocol_level;


### PR DESCRIPTION
1) The client lock is needed earlier to protect the "reset the packet state".
2) The subscribe ack was using an unprotected pointer to response code list. Now it makes a copy of those codes.
3) Add protection to multi-thread example "stop" variable.
Thanks to Fatimah Aljaafari (@fatimahkj) for the report.
ZD 12379 and PR #198