### PR TITLE
Add example for MQTT-SN predefined topic usage. Disable WIOT test.

### DIFF
--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -285,6 +285,84 @@ int sn_test(MQTTCtx *mqttCtx)
         }
     }
 
+    /* The predefined topic examples require modification of the gateway
+       configuration. To add a predefined topic to a Paho MQTTSN-Embedded-C
+       Gateway, open the gateway config file and enable the following:
+
+           PredefinedTopic=YES
+           PredefinedTopicList=./predefinedTopic.conf
+
+       Then in the "predefinedTopic.conf" file, add a topic:
+
+           *, wolfMQTT/example/predefTopic7, 7
+
+       Then restart the gateway.
+     */
+#if 0
+    {
+        SN_Publish publish;
+        SN_Subscribe subscribe;
+        SN_Unsubscribe unsub;
+        char pd_topic_id[] = {0,7}; /* Same ID as set above */
+
+        /* Subscribe Predefined Topic */
+        XMEMSET(&subscribe, 0, sizeof(SN_Subscribe));
+
+        subscribe.duplicate = 0;
+        subscribe.qos = MQTT_QOS_0;
+        subscribe.topic_type = SN_TOPIC_ID_TYPE_PREDEF;
+        subscribe.topicNameId = pd_topic_id;
+        subscribe.packet_id = mqtt_get_packetid();
+
+        PRINTF("MQTT-SN Predefined Subscribe: topic id = %d",
+                subscribe.topicNameId[1]);
+        rc = SN_Client_Subscribe(&mqttCtx->client, &subscribe);
+
+        PRINTF("....MQTT-SN Predefined Subscribe Ack: topic id = %d, rc = %d",
+                subscribe.subAck.topicId, subscribe.subAck.return_code);
+
+        /* Publish Predefined Topic */
+        XMEMSET(&publish, 0, sizeof(SN_Publish));
+        publish.retain = 0;
+        publish.qos = MQTT_QOS_0;
+        publish.duplicate = 0;
+        publish.topic_type = SN_TOPIC_ID_TYPE_PREDEF;
+
+        /* Use the topic ID saved from the subscribe */
+        publish.topic_name = pd_topic_id;
+
+        if (publish.qos > MQTT_QOS_0) {
+            publish.packet_id = mqtt_get_packetid();
+        }
+
+        publish.buffer = (byte*)TEST_MESSAGE" predefined";
+        publish.total_len = (word16)XSTRLEN(TEST_MESSAGE" predefined");
+
+        rc = SN_Client_Publish(&mqttCtx->client, &publish);
+
+        PRINTF("MQTT-SN Predefined Publish: topic id = %d, rc = %d\r\nPayload = %s",
+                publish.topic_name[1],
+                publish.return_code,
+                publish.buffer);
+
+        if (rc != MQTT_CODE_SUCCESS) {
+            goto disconn;
+        }
+
+        /* Unsubscribe from Predefined Topic */
+        XMEMSET(&unsub, 0, sizeof(SN_Unsubscribe));
+
+        unsub.topic_type = SN_TOPIC_ID_TYPE_PREDEF;
+        unsub.topicNameId = pd_topic_id;
+        unsub.packet_id = mqtt_get_packetid();
+
+        PRINTF("MQTT-SN Unsubscribe Predefined Topic: topic ID = %d",
+                unsub.topicNameId[1]);
+        rc = SN_Client_Unsubscribe(&mqttCtx->client, &unsub);
+        PRINTF("....MQTT-SN Unsubscribe Predefined Topic Ack: rc = %d", rc);
+    }
+#endif
+
     {
         /* Short topic name subscribe */
         SN_Subscribe subscribe;

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -7,8 +7,9 @@ dist_noinst_SCRIPTS += scripts/client.test \
                        scripts/firmware.test \
                        scripts/azureiothub.test \
                        scripts/awsiot.test \
-                       scripts/wiot.test \
                        scripts/nbclient.test
+# WIOT test broker disabled 31MAY2021
+#                      scripts/wiot.test
 if BUILD_MULTITHREAD
 dist_noinst_SCRIPTS += scripts/multithread.test
 endif

--- a/scripts/wiot.test
+++ b/scripts/wiot.test
@@ -2,6 +2,8 @@
 
 # Watson IoT Client test
 
+# NOTE: 31MAY2021 Quickstart broker was disabled
+
 # Check for application
 [ ! -x ./examples/wiot/wiot ] && echo -e "\n\nWatson IoT MQTT Client doesn't exist" && exit 1
 

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2892,8 +2892,7 @@ int SN_Encode_Subscribe(byte *tx_buf, int tx_buf_len, SN_Subscribe *subscribe)
     }
 
     /* Determine packet length */
-    if ((subscribe->topic_type & SN_PACKET_FLAG_TOPICIDTYPE_MASK) ==
-            SN_TOPIC_ID_TYPE_NORMAL) {
+    if (subscribe->topic_type == SN_TOPIC_ID_TYPE_NORMAL) {
         /* Topic name is a string */
         total_len = (int)XSTRLEN(subscribe->topicNameId);
     }
@@ -2942,8 +2941,7 @@ int SN_Encode_Subscribe(byte *tx_buf, int tx_buf_len, SN_Subscribe *subscribe)
     tx_payload += MqttEncode_Num(tx_payload, subscribe->packet_id);
 
     /* Encode topic */
-    if ((subscribe->topic_type & SN_PACKET_FLAG_TOPICIDTYPE_MASK) ==
-            SN_TOPIC_ID_TYPE_NORMAL) {
+    if (subscribe->topic_type == SN_TOPIC_ID_TYPE_NORMAL) {
         /* Topic name is a string */
         XMEMCPY(tx_payload, subscribe->topicNameId, XSTRLEN(subscribe->topicNameId));
     }
@@ -3042,8 +3040,9 @@ int SN_Encode_Publish(byte *tx_buf, int tx_buf_len, SN_Publish *publish)
     *tx_payload++ = flags;
 
     /* Encode topic */
-    if (publish->topic_type == SN_TOPIC_ID_TYPE_SHORT) {
-        /* Short topic name is 2 chars */
+    if ((publish->topic_type == SN_TOPIC_ID_TYPE_SHORT) ||
+        (publish->topic_type == SN_TOPIC_ID_TYPE_PREDEF)) {
+        /* Short and predefined topic names are 2 chars */
         XMEMCPY(tx_payload, publish->topic_name, 2);
         tx_payload += 2;
     }
@@ -3216,8 +3215,7 @@ int SN_Encode_Unsubscribe(byte *tx_buf, int tx_buf_len,
     }
 
     /* Determine packet length */
-    if ((unsubscribe->topic_type & SN_PACKET_FLAG_TOPICIDTYPE_MASK) ==
-            SN_TOPIC_ID_TYPE_NORMAL) {
+    if (unsubscribe->topic_type == SN_TOPIC_ID_TYPE_NORMAL) {
         /* Topic name is a string */
         total_len = (int)XSTRLEN(unsubscribe->topicNameId);
     }
@@ -3264,8 +3262,7 @@ int SN_Encode_Unsubscribe(byte *tx_buf, int tx_buf_len,
     tx_payload += MqttEncode_Num(tx_payload, unsubscribe->packet_id);
 
     /* Encode topic */
-    if ((unsubscribe->topic_type & SN_PACKET_FLAG_TOPICIDTYPE_MASK) ==
-            SN_TOPIC_ID_TYPE_NORMAL) {
+    if (unsubscribe->topic_type == SN_TOPIC_ID_TYPE_NORMAL) {
         /* Topic name is a string */
         XMEMCPY(tx_payload, unsubscribe->topicNameId,
                 XSTRLEN(unsubscribe->topicNameId));


### PR DESCRIPTION
The MQTT-SN client predefined topic example requires modification of the gateway config, as described in the example.

Upon testing, it was discovered that the Watson IoT Platform Quickstart broker was sunset on 31MAY2021. Those tests have been disabled until a path forward is determined.