### PR TITLE
Add support for SNI in example. Also HiveMQ Cloud instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ wolfMQTT client library has been tested with the following brokers:
 * AWS by Amazon
 * Azure by Microsoft
 * flespi by Gurtam
-* HiveMQ by dc-square GmbH
+* HiveMQ and HiveMQ Cloud by HiveMQ GmbH
 * IBM WIoTP Message Gateway by IBM
 * Mosquitto by Eclipse
 * Paho MQTT-SN Gateway by Eclipse
@@ -223,6 +223,8 @@ The v5 enabled wolfMQTT client was tested with the following MQTT v5 brokers:
 * HiveMQ 4.0.0 EAP
 ** Runs locally.
 ** `./examples/mqttclient/mqttclient -h localhost`
+* HiveMQ Cloud
+** `./examples/mqttclient/mqttclient -h 833f87e253304692bd2b911f0c18dba1.s1.eu.hivemq.cloud -t -u wolf1 -w NEZjcm7i8eRjFKF -p 8883 -S 833f87e253304692bd2b911f0c18dba1.s1.eu.hivemq.cloud`
 * Watson IoT Quickserver
 ** `./examples/wiot/wiot`
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The v5 enabled wolfMQTT client was tested with the following MQTT v5 brokers:
 ** Runs locally.
 ** `./examples/mqttclient/mqttclient -h localhost`
 * HiveMQ Cloud
-** `./examples/mqttclient/mqttclient -h 833f87e253304692bd2b911f0c18dba1.s1.eu.hivemq.cloud -t -u wolf1 -w NEZjcm7i8eRjFKF -p 8883 -S 833f87e253304692bd2b911f0c18dba1.s1.eu.hivemq.cloud`
+** `./examples/mqttclient/mqttclient -h 833f87e253304692bd2b911f0c18dba1.s1.eu.hivemq.cloud -t -S -u wolf1 -w NEZjcm7i8eRjFKF -p 8883`
 * Watson IoT Quickserver
 ** `./examples/wiot/wiot`
 

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -42,6 +42,9 @@ static char* myoptarg = NULL;
 static const char* mTlsCaFile;
 static const char* mTlsCertFile;
 static const char* mTlsKeyFile;
+#ifdef HAVE_SNI
+static const char* mTlsSniHostName;
+#endif
 #endif
 
 static int mygetopt(int argc, char** argv, const char* optstring)
@@ -183,6 +186,9 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
     PRINTF("-A <file>   Load CA (validate peer)");
     PRINTF("-K <key>    Use private key (for TLS mutual auth)");
     PRINTF("-c <cert>   Use certificate (for TLS mutual auth)");
+#ifdef HAVE_SNI
+    PRINTF("-S <str>    Use Host Name Indication");
+#endif
 #else
     PRINTF("-p <num>    Port to connect on, default: %d",
             MQTT_DEFAULT_PORT);
@@ -238,7 +244,11 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
     int rc;
 
     #ifdef ENABLE_MQTT_TLS
-        #define MQTT_TLS_ARGS "c:A:K:"
+        #ifdef HAVE_SNI
+            #define MQTT_TLS_ARGS "c:A:K:S:"
+        #else
+            #define MQTT_TLS_ARGS "c:A:K:"
+        #endif
     #else
         #define MQTT_TLS_ARGS ""
     #endif
@@ -336,6 +346,11 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
         case 'K':
             mTlsKeyFile = myoptarg;
             break;
+        #ifdef HAVE_SNI
+        case 'S':
+            mTlsSniHostName = myoptarg;
+            break;
+        #endif
     #endif
 
     #ifdef WOLFMQTT_V5
@@ -565,6 +580,14 @@ int mqtt_tls_cb(MqttClient* client)
     #endif /* !NO_FILESYSTEM */
 #endif /* !NO_CERT */
     }
+#ifdef HAVE_SNI
+    if ((rc == WOLFSSL_SUCCESS) && (mTlsSniHostName != NULL)) {
+        rc = wolfSSL_CTX_UseSNI(client->tls.ctx, WOLFSSL_SNI_HOST_NAME,
+                mTlsSniHostName, (word16) XSTRLEN(mTlsSniHostName));
+        if (rc != WOLFSSL_SUCCESS)
+            PRINTF("UseSNI failed");
+    }
+#endif /* HAVE_SNI */
 
     PRINTF("MQTT TLS Setup (%d)", rc);
 


### PR DESCRIPTION
Some brokers now require the SNI extension to complete the TLS connection. This adds an option to the example CLI to specify the SNI string. Also adds notes in the readme for connecting to the HiveMQ Cloud broker.

This addresses an issue reported in ZD12216