### PR TITLE
Fix chunked publish with non-block

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,38 @@ WolfGatewayQoS-1,wolfMQTT/example/testTopic, 1
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 
+## Example Options
+The command line examples can be executed with optional parameters. To see a list of the available parameters, add the `-?`
+
+```
+ ./examples/mqttclient/mqttclient -?
+mqttclient:
+-?          Help, print this usage
+-h <host>   Host to connect to, default: test.mosquitto.org
+-p <num>    Port to connect on, default: Normal 1883, TLS 8883
+-t          Enable TLS
+-A <file>   Load CA (validate peer)
+-K <key>    Use private key (for TLS mutual auth)
+-c <cert>   Use certificate (for TLS mutual auth)
+-S <str>    Use Host Name Indication, blank defaults to host
+-q <num>    Qos Level 0-2, default: 0
+-s          Disable clean session connect flag
+-k <num>    Keep alive seconds, default: 60
+-i <id>     Client Id, default: WolfMQTTClient
+-l          Enable LWT (Last Will and Testament)
+-u <str>    Username
+-w <str>    Password
+-m <str>    Message, default: test
+-n <str>    Topic name, default: wolfMQTT/example/testTopic
+-r          Set Retain flag on publish message
+-C <num>    Command Timeout, default: 30000ms
+-P <num>    Max packet size the client will accept, default: 1048576
+-T          Test mode
+-f <file>   Use file contents for publish
+```
+The available options vary depending on the library configuration.
+
+
 ## Broker compatibility
 wolfMQTT client library has been tested with the following brokers:
 * Adafruit IO by Adafruit

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -130,6 +130,8 @@ static int mqtt_publish_cb(MqttPublish *publish) {
             }
         }
     }
+#else
+    (void)publish;
 #endif
     return ret;
 }

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -134,70 +134,6 @@ static int mqtt_publish_cb(MqttPublish *publish) {
     return ret;
 }
 
-static int fwfile_load(const char* filePath, byte** fileBuf, int *fileLen)
-{
-#if !defined(NO_FILESYSTEM)
-    int rc = 0;
-    FILE* file = NULL;
-
-    /* Check arguments */
-    if (filePath == NULL || XSTRLEN(filePath) == 0 || fileLen == NULL ||
-        fileBuf == NULL) {
-        return EXIT_FAILURE;
-    }
-
-    /* Open file */
-    file = fopen(filePath, "rb");
-    if (file == NULL) {
-        PRINTF("File %s does not exist!", filePath);
-        rc = EXIT_FAILURE;
-        goto exit;
-    }
-
-    /* Determine length of file */
-    fseek(file, 0, SEEK_END);
-    *fileLen = (int) ftell(file);
-    fseek(file, 0, SEEK_SET);
-    //PRINTF("File %s is %d bytes", filePath, *fileLen);
-
-    /* Allocate buffer for image */
-    *fileBuf = (byte*)WOLFMQTT_MALLOC(*fileLen);
-    if (*fileBuf == NULL) {
-        PRINTF("File buffer malloc failed!");
-        rc = EXIT_FAILURE;
-        goto exit;
-    }
-
-    /* Load file into buffer */
-    rc = (int)fread(*fileBuf, 1, *fileLen, file);
-    if (rc != *fileLen) {
-        PRINTF("Error reading file! %d", rc);
-        rc = EXIT_FAILURE;
-        goto exit;
-    }
-    rc = 0; /* Success */
-
-exit:
-    if (file) {
-        fclose(file);
-    }
-    if (rc != 0) {
-        if (*fileBuf) {
-            WOLFMQTT_FREE(*fileBuf);
-            *fileBuf = NULL;
-        }
-    }
-    return rc;
-
-#else
-    (void)filePath;
-    (void)fileBuf;
-    (void)fileLen;
-    #warning No filesystem, so need way to load example firmware file to publish
-    return 0;
-#endif
-}
-
 static int fw_message_build(MQTTCtx *mqttCtx, const char* fwFile,
     byte **p_msgBuf, int *p_msgLen)
 {
@@ -212,7 +148,7 @@ static int fw_message_build(MQTTCtx *mqttCtx, const char* fwFile,
     wc_InitRng(&rng);
 
     /* Verify file can be loaded */
-    rc = fwfile_load(fwFile, &fwBuf, &fwLen);
+    rc = mqtt_file_load(fwFile, &fwBuf, &fwLen);
     if (rc < 0 || fwLen == 0 || fwBuf == NULL) {
         PRINTF("Firmware File %s Load Error!", fwFile);
         mqtt_show_usage(mqttCtx);

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -439,64 +439,70 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         /* If a file is specified, then read into the allocated buffer */
         rc = mqtt_file_load(mqttCtx->pub_file, &mqttCtx->publish.buffer,
                 (int*)&mqttCtx->publish.total_len);
+        if (rc != MQTT_CODE_SUCCESS) {
+            /* There was an error loading the file */
+            PRINTF("MQTT Publish file error: %d", rc);
+        }
     }
     else {
         mqttCtx->publish.buffer = (byte*)mqttCtx->message;
         mqttCtx->publish.total_len = (word16)XSTRLEN(mqttCtx->message);
     }
 
-#ifdef WOLFMQTT_V5
-    {
-        /* Payload Format Indicator */
-        MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-        prop->type = MQTT_PROP_PAYLOAD_FORMAT_IND;
-        prop->data_int = 1;
-    }
-    {
-        /* Content Type */
-        MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-        prop->type = MQTT_PROP_CONTENT_TYPE;
-        prop->data_str.str = (char*)"wolf_type";
-        prop->data_str.len = (word16)XSTRLEN(prop->data_str.str);
-    }
-    if ((mqttCtx->topic_alias_max > 0) &&
-        (mqttCtx->topic_alias > 0) &&
-        (mqttCtx->topic_alias < mqttCtx->topic_alias_max)) {
-        /* Topic Alias */
-        MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-        prop->type = MQTT_PROP_TOPIC_ALIAS;
-        prop->data_short = mqttCtx->topic_alias;
-    }
-#endif
+    if (rc == MQTT_CODE_SUCCESS) {
+    #ifdef WOLFMQTT_V5
+        {
+            /* Payload Format Indicator */
+            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
+            prop->type = MQTT_PROP_PAYLOAD_FORMAT_IND;
+            prop->data_int = 1;
+        }
+        {
+            /* Content Type */
+            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
+            prop->type = MQTT_PROP_CONTENT_TYPE;
+            prop->data_str.str = (char*)"wolf_type";
+            prop->data_str.len = (word16)XSTRLEN(prop->data_str.str);
+        }
+        if ((mqttCtx->topic_alias_max > 0) &&
+            (mqttCtx->topic_alias > 0) &&
+            (mqttCtx->topic_alias < mqttCtx->topic_alias_max)) {
+            /* Topic Alias */
+            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
+            prop->type = MQTT_PROP_TOPIC_ALIAS;
+            prop->data_short = mqttCtx->topic_alias;
+        }
+    #endif
 
-    /* This loop allows payloads larger than the buffer to be sent by
-       repeatedly calling publish.
-    */
-    do {
-        rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-    } while(rc == MQTT_CODE_PUB_CONTINUE);
+        /* This loop allows payloads larger than the buffer to be sent by
+           repeatedly calling publish.
+        */
+        do {
+            rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
+        } while(rc == MQTT_CODE_PUB_CONTINUE);
 
-    if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
-        WOLFMQTT_FREE(mqttCtx->publish.buffer);
-    }
+        if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
+            WOLFMQTT_FREE(mqttCtx->publish.buffer);
+        }
 
-    PRINTF("MQTT Publish: Topic %s, %s (%d)",
-        mqttCtx->publish.topic_name,
-        MqttClient_ReturnCodeToString(rc), rc);
-#ifdef WOLFMQTT_V5
-    if (mqttCtx->qos > 0) {
-        PRINTF("\tResponse Reason Code %d", mqttCtx->publish.resp.reason_code);
+        PRINTF("MQTT Publish: Topic %s, %s (%d)",
+            mqttCtx->publish.topic_name,
+            MqttClient_ReturnCodeToString(rc), rc);
+    #ifdef WOLFMQTT_V5
+        if (mqttCtx->qos > 0) {
+            PRINTF("\tResponse Reason Code %d", mqttCtx->publish.resp.reason_code);
+        }
+    #endif
+        if (rc != MQTT_CODE_SUCCESS) {
+            goto disconn;
+        }
+    #ifdef WOLFMQTT_V5
+        if (mqttCtx->publish.props != NULL) {
+            /* Release the allocated properties */
+            MqttClient_PropsFree(mqttCtx->publish.props);
+        }
+    #endif
     }
-#endif
-    if (rc != MQTT_CODE_SUCCESS) {
-        goto disconn;
-    }
-#ifdef WOLFMQTT_V5
-    if (mqttCtx->publish.props != NULL) {
-        /* Release the allocated properties */
-        MqttClient_PropsFree(mqttCtx->publish.props);
-    }
-#endif
 
     /* Read Loop */
     PRINTF("MQTT Waiting for message...");

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -231,10 +231,7 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
             DEFAULT_MAX_PKT_SZ);
 #endif
     PRINTF("-T          Test mode");
-    if (mqttCtx->pub_file) {
-        PRINTF("-f <file>   Use file for publish, default: %s",
-                mqttCtx->pub_file);
-    }
+    PRINTF("-f <file>   Use file contents for publish");
 }
 
 void mqtt_init_ctx(MQTTCtx* mqttCtx)
@@ -633,13 +630,13 @@ int mqtt_file_load(const char* filePath, byte** fileBuf, int *fileLen)
     /* Check arguments */
     if (filePath == NULL || XSTRLEN(filePath) == 0 || fileLen == NULL ||
         fileBuf == NULL) {
-        return EXIT_FAILURE;
+        return MQTT_CODE_ERROR_BAD_ARG;
     }
 
     /* Open file */
     file = fopen(filePath, "rb");
     if (file == NULL) {
-        PRINTF("File %s does not exist!", filePath);
+        PRINTF("File '%s' does not exist!", filePath);
         rc = EXIT_FAILURE;
         goto exit;
     }
@@ -672,7 +669,7 @@ int mqtt_file_load(const char* filePath, byte** fileBuf, int *fileLen)
     *fileBuf = (byte*)WOLFMQTT_MALLOC(*fileLen);
     if (*fileBuf == NULL) {
         PRINTF("File buffer malloc failed!");
-        rc = EXIT_FAILURE;
+        rc = MQTT_CODE_ERROR_MEMORY;
         goto exit;
     }
 
@@ -701,7 +698,7 @@ exit:
     (void)filePath;
     (void)fileBuf;
     (void)fileLen;
-    #warning No filesystem, so need way to load example firmware file to publish
-    return 0;
+    PRINTF("File system support is not configured.");
+    return EXIT_FAILURE;
 #endif
 }

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -176,6 +176,8 @@ word16 mqtt_get_packetid(void);
 int mqtt_check_timeout(int rc, word32* start_sec, word32 timeout_sec);
 #endif
 
+int mqtt_file_load(const char* filePath, byte** fileBuf, int *fileLen);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -74,8 +74,8 @@
 #define DEFAULT_MESSAGE         "test"
 
 #ifdef WOLFMQTT_V5
-#define DEFAULT_MAX_PKT_SZ      768 /* The max MQTT control packet size the
-                                       client is willing to accept. */
+#define DEFAULT_MAX_PKT_SZ      1024*1024 /* The max MQTT control packet size
+                                             the client is willing to accept. */
 #endif
 
 /* MQTT Client state */

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1428,7 +1428,7 @@ static int MqttClient_Publish_WritePayload(MqttClient *client,
 
             /* Check if we are done sending publish message */
             if (publish->buffer_pos < publish->buffer_len) {
-                return MQTT_CODE_CONTINUE;
+                return MQTT_CODE_PUB_CONTINUE;
             }
     #else
         do {
@@ -1467,7 +1467,7 @@ static int MqttClient_Publish_WritePayload(MqttClient *client,
                 if (client->write.len > client->tx_buf_len) {
                     client->write.len = client->tx_buf_len;
                 }
-                rc = MQTT_CODE_CONTINUE;
+                rc = MQTT_CODE_PUB_CONTINUE;
             }
         }
     }
@@ -1652,9 +1652,11 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
     } /* switch (publish->stat) */
 
     /* reset state */
+    if ((rc != MQTT_CODE_PUB_CONTINUE)
 #ifdef WOLFMQTT_NONBLOCK
-    if (rc != MQTT_CODE_CONTINUE)
+         && (rc != MQTT_CODE_CONTINUE)
 #endif
+        )
     {
         publish->stat = MQTT_MSG_BEGIN;
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2181,6 +2181,8 @@ const char* MqttClient_ReturnCodeToString(int return_code)
             return "Continue"; /* would block */
         case MQTT_CODE_STDIN_WAKE:
             return "STDIN Wake";
+        case MQTT_CODE_PUB_CONTINUE:
+            return "Continue calling publish"; /* Chunked publish */
         case MQTT_CODE_ERROR_BAD_ARG:
             return "Error (Bad argument)";
         case MQTT_CODE_ERROR_OUT_OF_BUFFER:
@@ -2209,7 +2211,6 @@ const char* MqttClient_ReturnCodeToString(int return_code)
             return "Error (Error in Callback)";
         case MQTT_CODE_ERROR_SYSTEM:
             return "Error (System resource failed)";
-
     }
     return "Unknown";
 }

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -184,6 +184,7 @@ enum MqttPacketResponseCodes {
 
     MQTT_CODE_CONTINUE = -101,
     MQTT_CODE_STDIN_WAKE = -102,
+    MQTT_CODE_PUB_CONTINUE = -103,
 };
 
 


### PR DESCRIPTION
Created `MQTT_CODE_PUB_CONTINUE` to be used when publishing a payload larger than the MQTT buffer size (publish in chunks). 

```
do {
    rc = MqttClient_Publish(client, publish);
}while ((rc != MQTT_CODE_PUB_CONTINUE) && (rc != MQTT_CODE_CONTINUE));
```

This fixes an issue from ZD12608

This fixes #192

