### PR TITLE
Fix pubrec response handling and warning in MqttDecode_Props

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -465,6 +465,11 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT Publish: Topic %s, %s (%d)",
         mqttCtx->publish.topic_name,
         MqttClient_ReturnCodeToString(rc), rc);
+#ifdef WOLFMQTT_V5
+    if (mqttCtx->qos > 0) {
+        PRINTF("\tResponse Reason Code %d", mqttCtx->publish.resp.reason_code);
+    }
+#endif
     if (rc != MQTT_CODE_SUCCESS) {
         goto disconn;
     }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -507,8 +507,7 @@ int MqttDecode_Props(MqttPacketType packet, MqttProp** props, byte* pbuf,
         /* TODO: validate packet type */
         (void)packet;
 
-        if (cur_prop->type < 0 ||
-            cur_prop->type >= sizeof(gPropMatrix) / sizeof(gPropMatrix[0])) {
+        if (cur_prop->type >= sizeof(gPropMatrix) / sizeof(gPropMatrix[0])) {
             return MQTT_CODE_ERROR_PROPERTY;
         }
 


### PR DESCRIPTION
1. The PUBREC reason code is not reported to the application
2. The PUBREL contained an invalid reason code.
    (cause: the PUBREC reason code was sent back in the PUBREL packet, instead of one of the allowed codes).
3. A compiler warning on line 511 of mqtt_packet.c

Fixes issues reported in forum post:
https://www.wolfssl.com/forums/post6137.html#p6137