### PR TITLE
Fix FALL_THROUGH compilation warnings.

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -281,9 +281,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             if (!mqttCtx->use_tls) {
                 return MQTT_CODE_ERROR_BAD_ARG;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_INIT:
         {
@@ -303,9 +302,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             /* setup tx/rx buffers */
             mqttCtx->tx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
             mqttCtx->rx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_INIT:
         {
@@ -330,9 +328,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             mqttCtx->client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
         #endif
 
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_TCP_CONN:
         {
@@ -372,9 +369,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_MQTT_CONN:
         {
@@ -409,9 +405,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_SUB:
         {
@@ -448,9 +443,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             mqttCtx->publish.packet_id = mqtt_get_packetid();
             mqttCtx->publish.buffer = (byte*)mqttCtx->app_ctx;
             mqttCtx->publish.total_len = (word32)XSTRLEN((char*)mqttCtx->app_ctx);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_PUB:
         {
@@ -468,9 +462,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_WAIT_MSG:
         {
@@ -550,9 +543,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DISCONNECT:
         {
@@ -566,9 +558,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_DISCONNECT:
         {
@@ -580,9 +571,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
             }
             PRINTF("MQTT Socket Disconnect: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DONE:
         {

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -255,9 +255,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             if (!mqttCtx->use_tls) {
                 return MQTT_CODE_ERROR_BAD_ARG;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_INIT:
         {
@@ -286,9 +285,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             if (rc < 0) {
                 goto exit;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_INIT:
         {
@@ -312,9 +310,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             /* AWS broker only supports v3.1.1 client */
             mqttCtx->client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
         #endif
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_TCP_CONN:
         {
@@ -355,9 +352,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             /* Authentication */
             mqttCtx->connect.username = AZURE_USERNAME;
             mqttCtx->connect.password = (const char *)mqttCtx->app_ctx;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_MQTT_CONN:
         {
@@ -392,9 +388,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             mqttCtx->subscribe.packet_id = mqtt_get_packetid();
             mqttCtx->subscribe.topic_count = sizeof(mqttCtx->topics)/sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_SUB:
         {
@@ -427,9 +422,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             mqttCtx->publish.packet_id = mqtt_get_packetid();
             mqttCtx->publish.buffer = NULL;
             mqttCtx->publish.total_len = 0;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_PUB:
         {
@@ -447,9 +441,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_WAIT_MSG:
         {
@@ -527,9 +520,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DISCONNECT:
         {
@@ -543,9 +535,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_DISCONNECT:
         {
@@ -557,9 +548,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             }
             PRINTF("MQTT Socket Disconnect: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DONE:
         {

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -210,9 +210,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
         case WMQ_BEGIN:
         {
             PRINTF("MQTT Firmware Client: QoS %d, Use TLS %d", mqttCtx->qos, mqttCtx->use_tls);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_INIT:
         {
@@ -232,9 +231,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             /* setup tx/rx buffers */
             mqttCtx->tx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
             mqttCtx->rx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_INIT:
         {
@@ -255,9 +253,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
             mqttCtx->client.ctx = mqttCtx;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_TCP_CONN:
         {
@@ -293,9 +290,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_MQTT_CONN:
         {
@@ -331,9 +327,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             mqttCtx->subscribe.topics = mqttCtx->topics;
             mqttCtx->topics[0].topic_filter = FIRMWARE_TOPIC_NAME;
             mqttCtx->topics[0].qos = mqttCtx->qos;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_SUB:
         {
@@ -358,9 +353,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             }
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_WAIT_MSG:
         {
@@ -419,9 +413,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DISCONNECT:
         {
@@ -435,9 +428,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_DISCONNECT:
         {
@@ -449,9 +441,8 @@ int fwclient_test(MQTTCtx *mqttCtx)
             }
             PRINTF("MQTT Socket Disconnect: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DONE:
         {

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -279,9 +279,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
         {
             PRINTF("MQTT Firmware Push Client: QoS %d, Use TLS %d",
                     mqttCtx->qos, mqttCtx->use_tls);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_INIT:
         {
@@ -301,9 +300,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
             /* setup tx/rx buffers */
             mqttCtx->tx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
             mqttCtx->rx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_INIT:
         {
@@ -324,9 +322,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
             mqttCtx->client.ctx = mqttCtx;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_TCP_CONN:
         {
@@ -363,9 +360,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_MQTT_CONN:
         {
@@ -429,9 +425,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
                 PRINTF("Firmware message build failed! %d", rc);
                 exit(rc);
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_PUB:
         {
@@ -454,9 +449,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DISCONNECT:
         {
@@ -470,9 +464,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_DISCONNECT:
         {
@@ -484,9 +477,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
             }
             PRINTF("MQTT Socket Disconnect: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DONE:
         {

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -416,9 +416,8 @@ static int NetConnect(void *context, const char* host, word16 port,
                 goto exit;
 
             sock->stat = SOCK_CONN;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case SOCK_CONN:
         {
@@ -631,9 +630,8 @@ static int NetConnect(void *context, const char* host, word16 port,
                 goto exit;
 
             sock->stat = SOCK_CONN;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case SOCK_CONN:
         {

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -114,9 +114,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                     mqttCtx->use_tls);
 
             mqttCtx->useNonBlockMode = 1;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_INIT:
         {
@@ -136,9 +135,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             /* setup tx/rx buffers */
             mqttCtx->tx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
             mqttCtx->rx_buf = (byte*)WOLFMQTT_MALLOC(MAX_BUFFER_SIZE);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_INIT:
         {
@@ -168,8 +166,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 goto exit;
             }
         #endif
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_TCP_CONN:
         {
@@ -211,8 +209,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             /* Optional authentication */
             mqttCtx->connect.username = mqttCtx->username;
             mqttCtx->connect.password = mqttCtx->password;
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_MQTT_CONN:
         {
@@ -250,9 +248,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->subscribe.topic_count =
                     sizeof(mqttCtx->topics) / sizeof(MqttTopic);
             mqttCtx->subscribe.topics = mqttCtx->topics;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_SUB:
         {
@@ -297,9 +294,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 mqttCtx->publish.buffer = (byte*)mqttCtx->message;
                 mqttCtx->publish.total_len = (word16)XSTRLEN(mqttCtx->message);
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_PUB:
         {
@@ -330,9 +326,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
             /* Read Loop */
             PRINTF("MQTT Waiting for message...");
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_WAIT_MSG:
         {
@@ -387,9 +382,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
             mqttCtx->stat = WMQ_UNSUB;
             mqttCtx->start_sec = 0;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_PING:
         {
@@ -425,9 +419,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 goto disconn;
             }
             mqttCtx->return_code = rc;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DISCONNECT:
         {
@@ -442,9 +435,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_NET_DISCONNECT:
         {
@@ -456,9 +448,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             }
             PRINTF("MQTT Socket Disconnect: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case WMQ_DONE:
         {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -821,9 +821,9 @@ wait_again:
 
             /* reset the packet state */
             client->packet.stat = MQTT_PK_BEGIN;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
+
     #ifdef WOLFMQTT_V5
         case MQTT_MSG_AUTH:
     #endif
@@ -881,9 +881,8 @@ wait_again:
         #endif
 
             *mms_stat = MQTT_MSG_READ;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_MSG_READ:
         case MQTT_MSG_READ_PAYLOAD:
@@ -1553,9 +1552,9 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
         #endif
 
             publish->stat = MQTT_MSG_WRITE;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
+
         case MQTT_MSG_WRITE:
         {
             /* Send packet */
@@ -1579,9 +1578,9 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
 
             /* advance state */
             publish->stat = MQTT_MSG_WRITE_PAYLOAD;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
+
         case MQTT_MSG_WRITE_PAYLOAD:
         {
             rc = MqttClient_Publish_WritePayload(client, publish, pubCb);
@@ -1608,9 +1607,8 @@ int MqttClient_Publish_ex(MqttClient *client, MqttPublish *publish,
                 break;
             }
             publish->stat = MQTT_MSG_WAIT;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_MSG_WAIT:
         {
@@ -2671,9 +2669,9 @@ wait_again:
 
             /* reset the packet state */
             client->packet.stat = MQTT_PK_BEGIN;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
+
         case MQTT_MSG_WAIT:
         {
         #ifdef WOLFMQTT_MULTITHREAD
@@ -2727,9 +2725,8 @@ wait_again:
         #endif
 
             *mms_stat = MQTT_MSG_READ;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_MSG_READ:
         case MQTT_MSG_READ_PAYLOAD:
@@ -3526,9 +3523,9 @@ int SN_Client_Publish(MqttClient *client, SN_Publish *publish)
         #endif
 
             publish->stat = MQTT_MSG_WRITE;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
+
         case MQTT_MSG_WRITE:
         {
             /* Send packet and payload */
@@ -3566,9 +3563,8 @@ int SN_Client_Publish(MqttClient *client, SN_Publish *publish)
             }
 
             publish->stat = MQTT_MSG_WAIT;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_MSG_WAIT:
         {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1880,9 +1880,8 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
                 return MqttPacket_HandleNetError(client,
                          MQTT_CODE_ERROR_NETWORK);
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_PK_READ_HEAD:
         {
@@ -1928,9 +1927,8 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
                 rc += sizeof(header->type_flags);
                 client->packet.header_len = rc;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_PK_READ:
         {
@@ -3478,16 +3476,14 @@ int SN_Packet_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
                 total_len = rx_buf[0];
                 client->packet.header_len = len;
             }
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_PK_READ_HEAD:
         {
             client->packet.stat = MQTT_PK_READ_HEAD;
-
-            FALL_THROUGH;
         }
+        FALL_THROUGH;
 
         case MQTT_PK_READ:
         {

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -302,7 +302,7 @@ enum MqttPacketResponseCodes {
 #if defined(__GNUC__)
     #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
         #undef  FALL_THROUGH
-        #define FALL_THROUGH __attribute__ ((fallthrough));
+        #define FALL_THROUGH __attribute__ ((fallthrough))
     #endif
 #endif
 #endif


### PR DESCRIPTION
Remove semi-colon in FALL_THROUGH macro.
Move FALL_THROUGH outside of case statement scope.