### PR TITLE
Fix potential NULL printf in MqttSocket_Connect with verbose debug enabled.

### DIFF
--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -416,7 +416,7 @@ exit:
     /* Handle error case */
     if (rc) {
     #ifdef WOLFMQTT_DEBUG_SOCKET
-    	const char* errstr = NULL;
+        const char* errstr = "";
     #endif
         int errnum = 0;
         if (client->tls.ssl) {


### PR DESCRIPTION
If `client->tls.ssl` is NULL and `WOLFMQTT_DEBUG_SOCKET` is defined, `printf` will be called with a NULL `errstr`. 