### PR TITLE
Fix multithread qos > 0 response

### DIFF
--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -61,6 +61,7 @@ static int mNumMsgsRecvd;
     /* Posix (Linux/Mac) */
 	#include <pthread.h>
 	#include <sched.h>
+    #include <errno.h>
     typedef pthread_t THREAD_T;
     #define THREAD_CREATE(h, f, c) ({ int ret = pthread_create(h, NULL, f, c); if (ret) { errno = ret; } ret; })
     #define THREAD_JOIN(h, c)      ({ int ret, x; for(x=0;x<c;x++) { ret = pthread_join(h[x], NULL); if (ret) { errno = ret; break; }} ret; })


### PR DESCRIPTION
Fix two issues with non-block / multithread:
1. When receiving a QoS 2 message, the correct responses were not sent (PUBREC / PUBCOMP)
2. If `MQTT_CODE_CONTINUE` during `MqttClient_Connect`, the pending ack was removed from the response list.

Also fixed a build error in multithread.c with `--enable-mt --disable-tls`

This issue was first reported in ZD12784.