### PR TITLE
Fix build error in Handle_Props

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -294,6 +294,8 @@ static int Handle_Props(MqttClient* client, MqttProp* props)
                 rc = rc_err;
             }
         }
+    #else
+        (void)client;
     #endif
         /* Free the properties */
         MqttProps_Free(props);


### PR DESCRIPTION
Fix for:

```
src/mqtt_client.c: In function ‘Handle_Props’:
src/mqtt_client.c:281:37: error: unused parameter ‘client’ [-Werror=unused-parameter]
  281 | static int Handle_Props(MqttClient* client, MqttProp* props)
      |                         ~~~~~~~~~~~~^~~~~~
```