### PR TITLE
Fix v5 prop handling

### DIFF
--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -62,6 +62,16 @@
 
 
 /* Default Configurations */
+
+#ifndef DEFAULT_MQTT_HOST
+    /* Default MQTT host broker to use,
+     * when none is specified in the examples */
+    #define DEFAULT_MQTT_HOST   "test.mosquitto.org"
+    /* "iot.eclipse.org" */
+    /* "broker.emqx.io" */
+    /* "broker.hivemq.com" */
+#endif
+
 #define DEFAULT_CMD_TIMEOUT_MS  30000
 #define DEFAULT_CON_TIMEOUT_MS  5000
 #define DEFAULT_MQTT_QOS        MQTT_QOS_0

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -28,11 +28,6 @@
 
 #include "examples/mqttexample.h"
 
-/* Default MQTT host broker to use, when none is specified in the examples */
-#ifndef DEFAULT_MQTT_HOST
-#define DEFAULT_MQTT_HOST       "test.mosquitto.org" /* broker.hivemq.com */
-#endif
-
 /* Functions used to handle the MqttNet structure creation / destruction */
 int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);
 int MqttClientNet_DeInit(MqttNet* net);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -362,7 +362,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             rc = MqttDecode_ConnectAck(rx_buf, rx_len, p_connect_ack);
         #ifdef WOLFMQTT_V5
             if (rc >= 0) {
-                rc = Handle_Props(client, p_connect_ack->props);
+                int tmp = Handle_Props(client, p_connect_ack->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             }
         #endif
             break;
@@ -383,7 +386,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             if (rc >= 0) {
                 packet_id = p_publish->packet_id;
             #ifdef WOLFMQTT_V5
-                rc = Handle_Props(client, p_publish->props);
+                int tmp = Handle_Props(client, p_publish->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             #endif
             }
             break;


### PR DESCRIPTION
Fix some v5 property handling issues:
* overwriting return value with `Handle_Props`
* incorrect byte ordering in `MqttDecode_Num` and `MqttDecode_Int`
* check buf write past length in `MqttDecode_Props`
* free allocated props on error in `MqttDecode_Props`