### PR TITLE
Prop fix / config update

### DIFF
--- a/commit-tests.sh
+++ b/commit-tests.sh
@@ -30,37 +30,15 @@ make -j 8 test;
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-tls' make test failed " && exit 1
 
-# make sure non-blocking is okay
-echo -e "\n\nTesting Non-Blocking config too...\n\n"
-./configure --enable-nonblock --disable-tls;
+# make sure MQTTv5 is okay
+echo -e "\n\nTesting MQTTv5...\n\n"
+./configure --enable-v5;
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --disable-tls' failed" && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --v5' failed" && exit 1
 
 make -j 8 test;
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --disable-tls' make test failed " && exit 1
-
-
-# make sure non-blocking plus TLS is okay
-echo -e "\n\nTesting Non-Blocking TLS config as well...\n\n"
-./configure --enable-nonblock --enable-tls;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --enable-tls' failed" && exit 1
-
-make -j 8 test;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --enable-tls' make test failed " && exit 1
-
-
-# make sure mqtt5 with property callback is okay
-echo -e "\n\nTesting mqtt5 with property callback config additionally...\n\n"
-./configure --enable-mqtt5 --enable-propcb;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mqtt5 --enable-propcb' failed" && exit 1
-
-make -j 8 test;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mqtt5 --enable-propcb' make test failed " && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-v5' make test failed " && exit 1
 
 
 # make sure multithread is okay
@@ -73,6 +51,16 @@ make -j 8 test;
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt' make test failed " && exit 1
 
+# make sure enable-all is okay
+echo -e "\n\nTesting enable-all config...\n\n"
+./configure --enable-all;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-all' failed" && exit 1
+
+make -j 8 test;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-all' make test failed " && exit 1
+
 # make sure multithread with non-blocking is okay
 echo -e "\n\nTesting multithread with non-block config...\n\n"
 ./configure --enable-mt;
@@ -83,5 +71,24 @@ make -j 8 test;
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt --enable-nonblock' make test failed " && exit 1
 
+# make sure non-blocking plus TLS is okay
+echo -e "\n\nTesting Non-Blocking TLS config as well...\n\n"
+./configure --enable-nonblock --enable-tls;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --enable-tls' failed" && exit 1
+
+make -j 8 test;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --enable-tls' make test failed " && exit 1
+
+# make sure non-blocking is okay
+echo -e "\n\nTesting Non-Blocking config too...\n\n"
+./configure --enable-nonblock --disable-tls;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --disable-tls' failed" && exit 1
+
+make -j 8 test;
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --disable-tls' make test failed " && exit 1
 
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -100,9 +100,28 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_DEBUG_CLIENT -DWOLFMQTT_DEBUG_SOCKET"
 fi
 
+# ALL FEATURES
+AC_ARG_ENABLE([all],
+    [AS_HELP_STRING([--enable-all],[Enable all wolfMQTT features (default: disabled)])],
+    [ ENABLED_ALL=$enableval ],
+    [ ENABLED_ALL=no ]
+    )
+if test "$ENABLED_ALL" = "yes"
+then
+    test "$enable_tls" = "" && enable_tls=yes
+    test "$enable_nonblock" = "" && enable_nonblock=yes
+    test "$enable_timeout" = "" && enable_timeout=yes
+    test "$enable_examples" = "" && enable_examples=yes
+    test "$enable_errorstrings" = "" && enable_errorstrings=yes
+    test "$enable_stdincap" = "" && enable_stdincap=yes
+    test "$enable_sn" = "" && enable_sn=yes
+    test "$enable_v5" = "" && enable_v5=yes
+    test "$enable_discb" = "" && enable_discb=yes
+    test "$enable_mt" = "" && enable_mt=yes
+    test "$enable_" = "" && enable_=yes
+fi
 
 # TLS Support with wolfSSL
-# Examples, used to disable examples
 AC_ARG_ENABLE([tls],
     [AS_HELP_STRING([--enable-tls],[Enable TLS support with wolfSSL  (default: enabled)])],
     [ ENABLED_TLS=$enableval ],
@@ -143,7 +162,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_NO_TIMEOUT"
 fi
 
-# Examples
+# Examples, used to disable examples
 AC_ARG_ENABLE([examples],
     [AS_HELP_STRING([--enable-examples],[Enable examples (default: enabled)])],
     [ ENABLED_EXAMPLES=$enableval ],
@@ -196,35 +215,46 @@ fi
 AM_CONDITIONAL([BUILD_SN], [test "x$ENABLED_SN" = "xyes"])
 
 # MQTT v5.0
-AC_ARG_ENABLE([mqtt5],
-    [AS_HELP_STRING([--enable-mqtt5],[Enable MQTT v5.0 support (default: disabled)])],
+AC_ARG_ENABLE([v5],
+    [AS_HELP_STRING([--enable-v5],[Enable MQTT v5.0 support (default: disabled)])],
     [ ENABLED_MQTTV50=$enableval ],
     [ ENABLED_MQTTV50=no ]
     )
-
+# Keep old config option for backward compatibility
+AC_ARG_ENABLE([mqtt5],
+    ,
+    [ ENABLED_MQTTV50_old=$enableval ],
+    [ ENABLED_MQTTV50_old=no ]
+    )
+if test "x$ENABLED_MQTTV50_old" = "xyes"
+then
+    ENABLED_MQTTV50=yes
+fi
 if test "x$ENABLED_MQTTV50" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_V5"
+    if test "x$ENABLED_PROPCB" = "xyes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_PROPERTY_CB"
+    fi
 fi
 
 AM_CONDITIONAL([BUILD_MQTT5], [test "x$ENABLED_MQTTV50" = "xyes"])
 
-# Property callback
-AC_ARG_ENABLE([propcb],
-    [AS_HELP_STRING([--enable-propcb],[Enable property callback (v5 only) (default: disabled)])],
-    [ ENABLED_PROPCB=$enableval ],
-    [ ENABLED_PROPCB=no ]
-    )
-
-if test "x$ENABLED_PROPCB" = "xyes"
+if test "x$ENABLED_MQTTV50" = "xyes"
 then
-    if test "x$ENABLED_MQTTV50" = "xno"
+    # Property callback, only available when v5 is configured
+    AC_ARG_ENABLE([propcb],
+        [AS_HELP_STRING([--enable-propcb],[Enable property callback (v5 only) (default: enabled)])],
+        [ ENABLED_PROPCB=$enableval ],
+        [ ENABLED_PROPCB=yes ]
+        )
+    
+    if test "x$ENABLED_PROPCB" = "xyes"
     then
-        AC_MSG_ERROR([cannot enable propcb without enabling mqtt5.])
+        AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_PROPERTY_CB"
     fi
-    AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_PROPERTY_CB"
 fi
-
 
 # Disconnect callback
 AC_ARG_ENABLE([discb],
@@ -365,7 +395,10 @@ echo "   * Disconnect Callback:       $ENABLED_DISCB"
 echo "   * Error Strings:             $ENABLED_ERROR_STRINGS"
 echo "   * Enable MQTT-SN:            $ENABLED_SN"
 echo "   * Enable MQTT v5.0:          $ENABLED_MQTTV50"
-echo "   * Property Callback:         $ENABLED_PROPCB"
+if test "x$ENABLED_MQTTV50" = "xyes"
+then
+    echo "   * Property Callback:         $ENABLED_PROPCB"
+fi
 echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * Non-Blocking:              $ENABLED_NONBLOCK"
 echo "   * STDIN Capture:             $ENABLED_STDINCAP"

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -414,7 +414,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             if (rc >= 0) {
                 packet_id = p_publish_resp->packet_id;
             #ifdef WOLFMQTT_V5
-                rc = Handle_Props(client, p_publish_resp->props);
+                int tmp = Handle_Props(client, p_publish_resp->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             #endif
             }
             break;
@@ -435,7 +438,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             if (rc >= 0) {
                 packet_id = p_subscribe_ack->packet_id;
             #ifdef WOLFMQTT_V5
-                rc = Handle_Props(client, p_subscribe_ack->props);
+                int tmp = Handle_Props(client, p_subscribe_ack->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             #endif
             }
             break;
@@ -457,7 +463,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             if (rc >= 0) {
                 packet_id = p_unsubscribe_ack->packet_id;
             #ifdef WOLFMQTT_V5
-                rc = Handle_Props(client, p_unsubscribe_ack->props);
+                int tmp = Handle_Props(client, p_unsubscribe_ack->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             #endif
             }
             break;
@@ -486,7 +495,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             }
             rc = MqttDecode_Auth(rx_buf, rx_len, p_auth);
             if (rc >= 0) {
-                rc = Handle_Props(client, p_auth->props);
+                int tmp = Handle_Props(client, p_auth->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             }
         #else
             rc = MQTT_CODE_ERROR_PACKET_TYPE;
@@ -505,7 +517,10 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             }
             rc = MqttDecode_Disconnect(rx_buf, rx_len, p_disc);
             if (rc >= 0) {
-                rc = Handle_Props(client, p_disc->props);
+                int tmp = Handle_Props(client, p_disc->props);
+                if (tmp != MQTT_CODE_SUCCESS) {
+                    rc = tmp;
+                }
             }
         #else
             rc = MQTT_CODE_ERROR_PACKET_TYPE;


### PR DESCRIPTION
* Missed some instances of this fix from the last PR. This was causing failures with v5 and QoS 2.
* Updating config to allow `--enable-all` and `--enable-v5` which enables `propcb` by default (keep `mqtt5` for backward comp.
* Change order of commit-tests.sh so "nonblock without TLS" anomaly occurs at end.