### PR TITLE
wolfMQTT Release v1.10 preparation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 
 ## Release Notes
+### v1.10 (11/2/2021)
+* Improve FALL_THROUGH macro logic for XC32. (PR #227)
+* Fix potential NULL printf in MqttSocket_Connect with verbose debug enabled. (PR #229)
+* Fix non-block chunked transfer. (PR #230)
+* Fix QoS responses (PR #231, 240)
+* Fix MQTTv5 property handling (PR #232, 233, 234, 236, 238, 241)
+* Fix fuzzing test issues (PR #242)
+
 ### v1.9 (07/16/2021)
 * Fixes for Sensor Network client (PR #204, 214, 219)
 * Fixes for non-blocking (PR #205)

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # All right reserved.
 
 AC_COPYRIGHT([Copyright (C) 2014-2021 wolfSSL Inc.])
-AC_INIT([wolfmqtt],[1.9.0],[https://github.com/wolfssl/wolfMQTT/issues],[wolfmqtt],[http://www.wolfssl.com])
+AC_INIT([wolfmqtt],[1.10.0],[https://github.com/wolfssl/wolfMQTT/issues],[wolfmqtt],[http://www.wolfssl.com])
 
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -23,7 +23,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFMQTT_LIBRARY_VERSION=9:0:0
+WOLFMQTT_LIBRARY_VERSION=9:1:0
 #                        | | |
 #                 +------+ | +---+
 #                 |        |     |

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -563,6 +563,7 @@ exit:
         PRINTF("Example not compiled in!");
         rc = 0; /* return success, so make check passes with TLS disabled */
 #endif
+        mqtt_free_ctx(&mqttCtx);
 
         return (rc == 0) ? 0 : EXIT_FAILURE;
     }

--- a/wolfmqtt/version.h
+++ b/wolfmqtt/version.h
@@ -34,8 +34,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFMQTT_VERSION_STRING "1.9.0"
-#define LIBWOLFMQTT_VERSION_HEX 0x01009000
+#define LIBWOLFMQTT_VERSION_STRING "1.10.0"
+#define LIBWOLFMQTT_VERSION_HEX 0x0100A000
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### v1.10 (11/2/2021)
* Improve FALL_THROUGH macro logic for XC32. (PR #227)
* Fix potential NULL printf in MqttSocket_Connect with verbose debug enabled. (PR #229)
* Fix non-block chunked transfer. (PR #230)
* Fix QoS responses (PR #231, 240)
* Fix MQTTv5 property handling (PR #232, 233, 234, 236, 238, 241)
* Fix fuzzing test issues (PR #242)
