### PR TITLE
Fixes for multithreading with non-blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,26 +50,30 @@ diff
 
 # scan-build
 client.plist
-examples/mqttclient/mqttclient
-examples/nbclient/nbclient
+
+# other
 Debug
 .vs
 *.aps
 *.sdf
 *.user
+*.opensdf
+*.trs
+firmware.bin
+wolfmqtt/options.h
+IDE/ARDUINO/wolfMQTT
+IDE/Microchip-Harmony/wolfmqtt_client/firmware/mqtt_client.X/dist/default/
+
+# examples
+examples/aws/awsiot
+examples/azure/azureiothub
 examples/firmware/fwclient
 examples/firmware/fwpush
-*.opensdf
-firmware.bin
-*.trs
-IDE/ARDUINO/wolfMQTT
-examples/azure/azureiothub
-examples/aws/awsiot
-examples/wiot/wiot
-wolfmqtt/options.h
-/IDE/Microchip-Harmony/wolfmqtt_client/firmware/mqtt_client.X/dist/default/
+examples/mqttclient/mqttclient
+examples/mqttsimple/mqttsimple
+examples/nbclient/nbclient
 examples/sn-client/sn-client
 examples/sn-client/sn-client_qos-1
 examples/sn-client/sn-multithread
 examples/multithread/multithread
-examples/mqttsimple/mqttsimple
+examples/wiot/wiot

--- a/configure.ac
+++ b/configure.ac
@@ -134,7 +134,6 @@ then
 
     TAO_REQUIRE_LIBWOLFSSL
 fi
-AM_CONDITIONAL([HAVE_LIBWOLFSSL], [test "x$ENABLED_TLS" = "xyes"])
 
 
 # Non-Blocking support
@@ -169,8 +168,6 @@ AC_ARG_ENABLE([examples],
     [ ENABLED_EXAMPLES=yes ]
     )
 
-AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
-
 
 # Error strings
 AC_ARG_ENABLE([errorstrings],
@@ -197,8 +194,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_NO_STDIN_CAP"
 fi
 
-AM_CONDITIONAL([BUILD_STDINCAP], [test "x$ENABLED_STDINCAP" = "xyes"])
-
 
 # MQTT-SN Sensor Network
 AC_ARG_ENABLE([sn],
@@ -212,7 +207,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_SN"
 fi
 
-AM_CONDITIONAL([BUILD_SN], [test "x$ENABLED_SN" = "xyes"])
 
 # MQTT v5.0
 AC_ARG_ENABLE([v5],
@@ -239,7 +233,6 @@ then
     fi
 fi
 
-AM_CONDITIONAL([BUILD_MQTT5], [test "x$ENABLED_MQTTV50" = "xyes"])
 
 if test "x$ENABLED_MQTTV50" = "xyes"
 then
@@ -280,7 +273,17 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_MULTITHREAD"
 fi
 
+
+
+AM_CONDITIONAL([HAVE_LIBWOLFSSL], [test "x$ENABLED_TLS" = "xyes"])
+AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
+AM_CONDITIONAL([BUILD_STDINCAP], [test "x$ENABLED_STDINCAP" = "xyes"])
+AM_CONDITIONAL([BUILD_SN], [test "x$ENABLED_SN" = "xyes"])
+AM_CONDITIONAL([BUILD_MQTT5], [test "x$ENABLED_MQTTV50" = "xyes"])
+AM_CONDITIONAL([BUILD_NONBLOCK], [test "x$ENABLED_NONBLOCK" = "xyes"])
 AM_CONDITIONAL([BUILD_MULTITHREAD], [test "x$ENABLED_MULTITHREAD" = "xyes"])
+
+
 
 # HARDEN FLAGS
 AX_HARDEN_CC_COMPILER_FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ DEBUG_CFLAGS="-g -O0 -DDEBUG_WOLFMQTT"
 OPTIMIZE_CFLAGS="-O2"
 
 AX_DEBUG
-AS_IF([test "x$ax_enable_debug" = "xyes" || test "x$ax_enable_debug" = "xverbose"],
+AS_IF([test "x$ax_enable_debug" = "xyes" || test "x$ax_enable_debug" = "xverbose" || test "x$ax_enable_debug" = "xtrace"],
       [AM_CFLAGS="$DEBUG_CFLAGS $AM_CFLAGS -DDEBUG"],
       [AM_CFLAGS="$AM_CFLAGS $OPTIMIZE_CFLAGS -DNDEBUG"])
 
@@ -94,11 +94,16 @@ else
 fi
 
 
-# Verbose Logging
-if test "x$ax_enable_debug" = "xverbose"
+# Logging / Tracing
+if test "x$ax_enable_debug" = "xverbose" || test "x$ax_enable_debug" = "xtrace"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_DEBUG_CLIENT -DWOLFMQTT_DEBUG_SOCKET"
+    if test "x$ax_enable_debug" = "xtrace"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFMQTT_DEBUG_TRACE"
+    fi
 fi
+
 
 # ALL FEATURES
 AC_ARG_ENABLE([all],

--- a/examples/include.am
+++ b/examples/include.am
@@ -4,26 +4,19 @@
 if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/mqttclient/mqttclient \
                    examples/mqttsimple/mqttsimple \
-                   examples/nbclient/nbclient \
                    examples/firmware/fwpush \
                    examples/firmware/fwclient \
                    examples/azure/azureiothub \
                    examples/aws/awsiot \
-                   examples/wiot/wiot
-if BUILD_MULTITHREAD
-noinst_PROGRAMS += examples/multithread/multithread
-endif
-if BUILD_SN
-noinst_PROGRAMS += examples/sn-client/sn-client
-noinst_PROGRAMS += examples/sn-client/sn-client_qos-1
-if BUILD_MULTITHREAD
-noinst_PROGRAMS += examples/sn-client/sn-multithread
-endif
-endif
+                   examples/wiot/wiot \
+                   examples/nbclient/nbclient \
+                   examples/multithread/multithread \
+                   examples/sn-client/sn-client \
+                   examples/sn-client/sn-client_qos-1 \
+                   examples/sn-client/sn-multithread
 
 noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
                    examples/mqttsimple/mqttsimple.h \
-                   examples/nbclient/nbclient.h \
                    examples/firmware/fwpush.h \
                    examples/firmware/fwclient.h \
                    examples/firmware/firmware.h \
@@ -31,14 +24,12 @@ noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
                    examples/aws/awsiot.h \
                    examples/wiot/wiot.h \
                    examples/mqttnet.h \
-                   examples/mqttexample.h
-if BUILD_MULTITHREAD
-noinst_HEADERS +=  examples/multithread/multithread.h
-endif
-if BUILD_SN
-noinst_HEADERS +=  examples/sn-client/sn-client.h
-endif
+                   examples/mqttexample.h \
+                   examples/nbclient/nbclient.h \
+                   examples/multithread/multithread.h \
+                   examples/sn-client/sn-client.h
 
+# MQTT Client Example
 examples_mqttclient_mqttclient_SOURCES      = examples/mqttclient/mqttclient.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -46,19 +37,23 @@ examples_mqttclient_mqttclient_LDADD        = src/libwolfmqtt.la
 examples_mqttclient_mqttclient_DEPENDENCIES = src/libwolfmqtt.la
 examples_mqttclient_mqttclient_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
+
+# MQTT Client Simple Example (self contained)
 examples_mqttsimple_mqttsimple_SOURCES      = examples/mqttsimple/mqttsimple.c
 examples_mqttsimple_mqttsimple_LDADD        = src/libwolfmqtt.la
 examples_mqttsimple_mqttsimple_DEPENDENCIES = src/libwolfmqtt.la
 
-if BUILD_MULTITHREAD
+
+# MQTT Multi-threading example
 examples_multithread_multithread_SOURCES      = examples/multithread/multithread.c \
                                                 examples/mqttnet.c \
                                                 examples/mqttexample.c
 examples_multithread_multithread_LDADD        = src/libwolfmqtt.la
 examples_multithread_multithread_DEPENDENCIES = src/libwolfmqtt.la
 examples_multithread_multithread_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
-endif
 
+
+# MQTT Non-Blocking Client Example
 examples_nbclient_nbclient_SOURCES          = examples/nbclient/nbclient.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -67,13 +62,13 @@ examples_nbclient_nbclient_DEPENDENCIES     = src/libwolfmqtt.la
 examples_nbclient_nbclient_CPPFLAGS         = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
 
+# Firmware Examples
 examples_firmware_fwpush_SOURCES            = examples/firmware/fwpush.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
 examples_firmware_fwpush_LDADD              = src/libwolfmqtt.la
 examples_firmware_fwpush_DEPENDENCIES       = src/libwolfmqtt.la
 examples_firmware_fwpush_CPPFLAGS           = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
-
 
 examples_firmware_fwclient_SOURCES          = examples/firmware/fwclient.c \
                                               examples/mqttnet.c \
@@ -83,6 +78,7 @@ examples_firmware_fwclient_DEPENDENCIES     = src/libwolfmqtt.la
 examples_firmware_fwclient_CPPFLAGS         = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
 
+# Microsoft Azure IoT Hub Example
 examples_azure_azureiothub_SOURCES          = examples/azure/azureiothub.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -91,6 +87,7 @@ examples_azure_azureiothub_DEPENDENCIES     = src/libwolfmqtt.la
 examples_azure_azureiothub_CPPFLAGS         = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
 
+# Amazon Web Services Example
 examples_aws_awsiot_SOURCES                 = examples/aws/awsiot.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -99,6 +96,7 @@ examples_aws_awsiot_DEPENDENCIES            = src/libwolfmqtt.la
 examples_aws_awsiot_CPPFLAGS                = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
 
+# IBM Watson IoT Example
 examples_wiot_wiot_SOURCES                  = examples/wiot/wiot.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -106,7 +104,8 @@ examples_wiot_wiot_LDADD                    = src/libwolfmqtt.la
 examples_wiot_wiot_DEPENDENCIES             = src/libwolfmqtt.la
 examples_wiot_wiot_CPPFLAGS                 = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
-if BUILD_SN
+
+# MQTT-SN Examples
 examples_sn_client_sn_client_SOURCES        = examples/sn-client/sn-client.c \
                                               examples/mqttnet.c \
                                               examples/mqttexample.c
@@ -121,15 +120,12 @@ examples_sn_client_sn_client_qos_1_LDADD        = src/libwolfmqtt.la
 examples_sn_client_sn_client_qos_1_DEPENDENCIES = src/libwolfmqtt.la
 examples_sn_client_sn_client_qos_1_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 
-if BUILD_MULTITHREAD
-examples_sn_client_sn_multithread_SOURCES        = examples/sn-client/sn-multithread.c \
-                                                   examples/mqttnet.c \
-                                                   examples/mqttexample.c
-examples_sn_client_sn_multithread_LDADD          = src/libwolfmqtt.la
-examples_sn_client_sn_multithread_DEPENDENCIES   = src/libwolfmqtt.la
-examples_sn_client_sn_multithread_CPPFLAGS       = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
-endif
-endif
+examples_sn_client_sn_multithread_SOURCES       = examples/sn-client/sn-multithread.c \
+                                                  examples/mqttnet.c \
+                                                  examples/mqttexample.c
+examples_sn_client_sn_multithread_LDADD         = src/libwolfmqtt.la
+examples_sn_client_sn_multithread_DEPENDENCIES  = src/libwolfmqtt.la
+examples_sn_client_sn_multithread_CPPFLAGS      = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 endif
 
 
@@ -137,40 +133,28 @@ dist_example_DATA+= examples/mqttnet.c \
                     examples/mqttexample.c \
                     examples/mqttclient/mqttclient.c \
                     examples/mqttsimple/mqttsimple.c \
-                    examples/nbclient/nbclient.c \
                     examples/firmware/fwpush.c \
                     examples/firmware/fwclient.c \
                     examples/azure/azureiothub.c \
                     examples/aws/awsiot.c \
                     examples/wiot/wiot.c
-if BUILD_MULTITHREAD
+dist_example_DATA+= examples/nbclient/nbclient.c
 dist_example_DATA+= examples/multithread/multithread.c
-endif
-if BUILD_SN
 dist_example_DATA+= examples/sn-client/sn-client.c
 dist_example_DATA+= examples/sn-client/sn-client_qos-1.c
-if BUILD_MULTITHREAD
 dist_example_DATA+= examples/sn-client/sn-multithread.c
-endif
-endif
 
 DISTCLEANFILES+=   examples/mqttclient/.libs/mqttclient \
-                   examples/nbclient/.libs/nbclient \
                    examples/firmware/.libs/fwpush \
                    examples/firmware/.libs/fwclient \
                    examples/azure/.libs/azureiothub \
                    examples/aws/.libs/awsiot \
-                   examples/wiot/.libs/wiot
-if BUILD_MULTITHREAD
-DISTCLEANFILES+=   examples/multithread/.libs/multithread
-endif
-if BUILD_SN
-DISTCLEANFILES+=   examples/sn-client/.libs/sn-client
-DISTCLEANFILES+=   examples/sn-client/.libs/sn-client_qos-1
-if BUILD_MULTITHREAD
-DISTCLEANFILES+=   examples/sn-client/.libs/sn-multithread
-endif
-endif
+                   examples/wiot/.libs/wiot \
+                   examples/nbclient/.libs/nbclient \
+                   examples/multithread/.libs/multithread \
+                   examples/sn-client/.libs/sn-client \
+                   examples/sn-client/.libs/sn-client_qos-1 \
+                   examples/sn-client/.libs/sn-multithread
 
 EXTRA_DIST+=       examples/mqttuart.c \
                    examples/mqttclient/mqttclient.vcxproj \

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -512,6 +512,12 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     PRINTF("MQTT Waiting for message...");
 
     do {
+        /* check for test mode */
+        if (mqttCtx->test_mode) {
+            PRINTF("MQTT Test mode, exit now");
+            break;            
+        }
+
         /* Try and read packet */
         rc = MqttClient_WaitMessage(&mqttCtx->client,
                                             mqttCtx->cmd_timeout_ms);
@@ -522,7 +528,6 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->cmd_timeout_ms/1000);
     #endif
 
-        /* check for test mode */
         if (mStopRead) {
             rc = MQTT_CODE_SUCCESS;
             PRINTF("MQTT Exiting...");
@@ -573,7 +578,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 MqttClient_ReturnCodeToString(rc), rc);
             break;
         }
-    } while (1);
+    } while (!mStopRead);
 
     /* Check for error */
     if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -458,10 +458,10 @@ word16 mqtt_get_packetid(void)
 }
 
 #ifdef WOLFMQTT_NONBLOCK
-    #if defined(MICROCHIP_MPLAB_HARMONY)
-        #include <system/tmr/sys_tmr.h>
-    #else
-        #include <time.h>
+#if defined(MICROCHIP_MPLAB_HARMONY)
+    #include <system/tmr/sys_tmr.h>
+#else
+    #include <time.h>
 #endif
 
 static word32 mqtt_get_timer_seconds(void)

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -151,8 +151,8 @@ typedef struct _MQTTCtx {
     int      max_packet_size;
 #endif
     word32 cmd_timeout_ms;
-#if defined(WOLFMQTT_NONBLOCK)
-    word32  start_sec; /* used for keep-alive */
+#ifdef WOLFMQTT_NONBLOCK
+    word32 start_sec; /* used for timeout and keep-alive */
 #endif
     word16 keep_alive_sec;
     word16 port;

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -603,7 +603,7 @@ static void *ping_task(void *param)
     int rc;
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
     MqttPing ping;
-    word32 startSec = 0;
+    word32 startSec;
 
     do {
         wm_SemLock(&pingSignal);
@@ -614,6 +614,7 @@ static void *ping_task(void *param)
         /* Keep Alive Ping */
         PRINTF("Sending ping keep-alive");
 
+        startSec = 0;
         XMEMSET(&ping, 0, sizeof(ping));
         do {
             rc = MqttClient_Ping_ex(&mqttCtx->client, &ping);

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -43,11 +43,12 @@
 #define NUM_PUB_TASKS   10
 
 
+#ifdef WOLFMQTT_MULTITHREAD
+
 /* Locals */
 static int mStopRead = 0;
 static int mNumMsgsRecvd;
-
-#ifdef WOLFMQTT_MULTITHREAD
+static int mNumMsgsDone;
 
 #ifdef USE_WINDOWS_API
     /* Windows Threading */
@@ -85,6 +86,7 @@ static word16 mqtt_get_packetid_threadsafe(void)
 static void mqtt_stop_set(void)
 {
     wm_SemLock(&mtLock);
+    PRINTF("MQTT Stopping");
     mStopRead = 1;
     wm_SemUnlock(&mtLock);
 }
@@ -97,6 +99,33 @@ static int mqtt_stop_get(void)
     wm_SemUnlock(&mtLock);
     return rc;
 }
+
+static int check_response(MQTTCtx* mqttCtx, int rc, word32* startSec)
+{
+    /* check for test mode */
+    if (mqtt_stop_get()) {
+        PRINTF("MQTT Exiting Thread...");
+        return MQTT_CODE_SUCCESS;
+    }
+
+#ifdef WOLFMQTT_NONBLOCK
+    /* Track elapsed time with no activity and trigger timeout */
+    rc = mqtt_check_timeout(rc, startSec, mqttCtx->cmd_timeout_ms/1000);
+
+    /* check return code */
+    if (rc == MQTT_CODE_CONTINUE) {
+    #if 0
+        /* optionally add delay when debugging */
+        usleep(100*1000);
+    #endif
+    }
+#else
+    (void)startSec;
+    (void)mqttCtx;
+#endif
+    return rc;
+}
+
 
 #ifdef WOLFMQTT_DISCONNECT_CB
 /* callback indicates a network error occurred */
@@ -118,6 +147,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
     (void)mqttCtx;
 
+    wm_SemLock(&mtLock);
     if (msg_new) {
         /* Determine min size to dump */
         len = msg->topic_name_len;
@@ -128,8 +158,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         buf[len] = '\0'; /* Make sure its null terminated */
 
         /* Print incoming message */
-        PRINTF("MQTT Message: Topic %s, Qos %d, Id %d, Len %u",
-            buf, msg->qos, msg->packet_id, msg->total_len);
+        PRINTF("MQTT Message: Topic %s, Qos %d, Id %d, Len %u, %u, %u",
+            buf, msg->qos, msg->packet_id, msg->total_len, msg->buffer_len, msg->buffer_pos);
 
         /* for test mode: count the number of TEST_MESSAGE matches received */
         if (mqttCtx->test_mode) {
@@ -139,9 +169,6 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
                          msg->buffer_len-2) == 0)
             {
                 mNumMsgsRecvd++;
-                if (mNumMsgsRecvd == NUM_PUB_TASKS) {
-                    mqtt_stop_set();
-                }
             }
         }
     }
@@ -159,6 +186,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     if (msg_done) {
         PRINTF("MQTT Message: Done");
     }
+    wm_SemUnlock(&mtLock);
 
     /* Return negative to terminate publish processing */
     return MQTT_CODE_SUCCESS;
@@ -206,8 +234,10 @@ static void client_disconnect(MQTTCtx *mqttCtx)
 static int multithread_test_init(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS;
+    word32 startSec;
 
     mNumMsgsRecvd = 0;
+    mNumMsgsDone = 0;
 
     /* Create a demo mutex for making packet id values */
     rc = wm_SemInit(&mtLock);
@@ -253,6 +283,9 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
     /* The client.ctx will be stored in the cert callback ctx during
        MqttSocket_Connect for use by mqtt_tls_verify_cb */
     mqttCtx->client.ctx = mqttCtx;
+#ifdef WOLFMQTT_NONBLOCK
+    mqttCtx->useNonBlockMode = 1;
+#endif
 
 #ifdef WOLFMQTT_DISCONNECT_CB
     /* setup disconnect callback */
@@ -264,10 +297,12 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
 #endif
 
     /* Connect to broker */
-    rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host,
-           mqttCtx->port,
-        DEFAULT_CON_TIMEOUT_MS, mqttCtx->use_tls, mqtt_tls_cb);
-
+    startSec = 0;
+    do {
+        rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host,
+           mqttCtx->port, DEFAULT_CON_TIMEOUT_MS, mqttCtx->use_tls, mqtt_tls_cb);
+        rc = check_response(mqttCtx, rc, &startSec);
+    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
     PRINTF("MQTT Socket Connect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
@@ -299,8 +334,10 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
     mqttCtx->connect.password = mqttCtx->password;
 
     /* Send Connect and wait for Connect Ack */
+    startSec = 0;
     do {
         rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);
+        rc = check_response(mqttCtx, rc, &startSec);
     } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
 
     PRINTF("MQTT Connect: Proto (%s), %s (%d)",
@@ -328,6 +365,8 @@ static int multithread_test_finish(MQTTCtx *mqttCtx)
     wm_SemFree(&pingSignal);
     wm_SemFree(&mtLock);
 
+    PRINTF("MQTT Client Done: %d", mqttCtx->return_code);
+
     return mqttCtx->return_code;
 }
 
@@ -341,6 +380,7 @@ static void *subscribe_task(void *param)
     int rc = MQTT_CODE_SUCCESS;
     uint16_t i;
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
+    word32 startSec = 0;
 
     /* Build list of topics */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
@@ -364,8 +404,11 @@ static void *subscribe_task(void *param)
             sizeof(mqttCtx->topics) / sizeof(MqttTopic);
     mqttCtx->subscribe.topics = mqttCtx->topics;
 
-    rc = MqttClient_Subscribe(&mqttCtx->client, &mqttCtx->subscribe);
-
+    do {
+        rc = MqttClient_Subscribe(&mqttCtx->client, &mqttCtx->subscribe);
+        rc = check_response(mqttCtx, rc, &startSec);
+    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    
     PRINTF("MQTT Subscribe: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
 
@@ -397,6 +440,7 @@ static void *waitMessage_task(void *param)
 {
     int rc;
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
+    word32 startSec = 0;
 
     /* Read Loop */
     PRINTF("MQTT Waiting for message...");
@@ -404,15 +448,23 @@ static void *waitMessage_task(void *param)
     do {
         /* Try and read packet */
         rc = MqttClient_WaitMessage(&mqttCtx->client, mqttCtx->cmd_timeout_ms);
+        rc = check_response(mqttCtx, rc, &startSec);
 
-        /* check for test mode */
-        if (mqtt_stop_get()) {
-            rc = MQTT_CODE_SUCCESS;
-            PRINTF("MQTT Exiting...");
+        /* check if we are in test mode and done */
+        wm_SemLock(&mtLock);
+        if ((rc == 0 || rc == MQTT_CODE_CONTINUE) && mqttCtx->test_mode &&
+              mNumMsgsDone == NUM_PUB_TASKS && mNumMsgsRecvd == NUM_PUB_TASKS) {
+            wm_SemUnlock(&mtLock);
+            mqtt_stop_set();
+            rc = 0; /* success */
             break;
         }
+        wm_SemUnlock(&mtLock);
 
         /* check return code */
+        if (rc == MQTT_CODE_CONTINUE) {
+            continue;
+        }
     #ifdef WOLFMQTT_ENABLE_STDIN_CAP
         else if (rc == MQTT_CODE_STDIN_WAKE) {
             XMEMSET(mqttCtx->rx_buf, 0, MAX_BUFFER_SIZE);
@@ -476,6 +528,7 @@ static void *publish_task(void *param)
     char buf[7];
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
     MqttPublish publish;
+    word32 startSec = 0;
 
     /* Publish Topic */
     XMEMSET(&publish, 0, sizeof(MqttPublish));
@@ -490,11 +543,18 @@ static void *publish_task(void *param)
     publish.buffer = (byte*)buf;
     publish.total_len = (word16)XSTRLEN(buf);
 
-    rc = MqttClient_Publish(&mqttCtx->client, &publish);
+    do {
+        rc = MqttClient_Publish(&mqttCtx->client, &publish);
+        rc = check_response(mqttCtx, rc, &startSec);
+    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
 
+    wm_SemLock(&mtLock);
     PRINTF("MQTT Publish: Topic %s, %s (%d)",
         publish.topic_name,
         MqttClient_ReturnCodeToString(rc), rc);
+
+    mNumMsgsDone++;
+    wm_SemUnlock(&mtLock);
 
     THREAD_EXIT(0);
 }
@@ -508,18 +568,22 @@ static void *ping_task(void *param)
     int rc;
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
     MqttPing ping;
-
-    XMEMSET(&ping, 0, sizeof(ping));
+    word32 startSec = 0;
 
     do {
         wm_SemLock(&pingSignal);
-        if (mqtt_stop_get())
+        if (mqtt_stop_get()) {
             break;
+        }
 
         /* Keep Alive Ping */
         PRINTF("Sending ping keep-alive");
 
-        rc = MqttClient_Ping_ex(&mqttCtx->client, &ping);
+        XMEMSET(&ping, 0, sizeof(ping));
+        do {
+            rc = MqttClient_Ping_ex(&mqttCtx->client, &ping);
+            rc = check_response(mqttCtx, rc, &startSec);
+        } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
         if (rc != MQTT_CODE_SUCCESS) {
             PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
@@ -533,6 +597,7 @@ static void *ping_task(void *param)
 static int unsubscribe_do(MQTTCtx *mqttCtx)
 {
     int rc;
+    word32 startSec = 0;
 
     /* Unsubscribe Topics */
     XMEMSET(&mqttCtx->unsubscribe, 0, sizeof(MqttUnsubscribe));
@@ -542,8 +607,10 @@ static int unsubscribe_do(MQTTCtx *mqttCtx)
     mqttCtx->unsubscribe.topics = mqttCtx->topics;
 
     /* Unsubscribe Topics */
-    rc = MqttClient_Unsubscribe(&mqttCtx->client,
-           &mqttCtx->unsubscribe);
+    do {
+        rc = MqttClient_Unsubscribe(&mqttCtx->client, &mqttCtx->unsubscribe);
+        rc = check_response(mqttCtx, rc, &startSec);
+    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
 
     PRINTF("MQTT Unsubscribe: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
@@ -553,10 +620,8 @@ static int unsubscribe_do(MQTTCtx *mqttCtx)
 
 int multithread_test(MQTTCtx *mqttCtx)
 {
-    int rc = 0;
-    int i;
+    int rc = 0, i, threadCount = 0;
     THREAD_T threadList[NUM_PUB_TASKS+3];
-    int threadCount = 0;
 
     rc = multithread_test_init(mqttCtx);
     if (rc == 0) {
@@ -593,7 +658,9 @@ int multithread_test(MQTTCtx *mqttCtx)
         /* Join threads - wait for completion */
         if (THREAD_JOIN(threadList, threadCount)) {
 #ifdef __GLIBC__
-            PRINTF("THREAD_JOIN failed: %m"); /* %m is specific to glibc/uclibc/musl, and recently (2018) added to FreeBSD */
+            /* %m is specific to glibc/uclibc/musl, and recently (2018) 
+             * added to FreeBSD */
+            PRINTF("THREAD_JOIN failed: %m");
 #else
             PRINTF("THREAD_JOIN failed: %d",errno);
 #endif
@@ -629,9 +696,11 @@ int multithread_test(MQTTCtx *mqttCtx)
         static void sig_handler(int signo)
         {
             if (signo == SIGINT) {
+            #ifdef WOLFMQTT_MULTITHREAD
                 mqtt_stop_set();
+            #endif
                 PRINTF("Received SIGINT");
-            #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+            #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
                 MqttClientNet_Wake(&gMqttCtx.net);
             #endif
             }

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -302,7 +302,8 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
         rc = MqttClient_NetConnect(&mqttCtx->client, mqttCtx->host,
            mqttCtx->port, DEFAULT_CON_TIMEOUT_MS, mqttCtx->use_tls, mqtt_tls_cb);
         rc = check_response(mqttCtx, rc, &startSec);
-    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    } while (rc == MQTT_CODE_CONTINUE);
+
     PRINTF("MQTT Socket Connect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
@@ -338,7 +339,11 @@ static int multithread_test_init(MQTTCtx *mqttCtx)
     do {
         rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);
         rc = check_response(mqttCtx, rc, &startSec);
-    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    } while (rc == MQTT_CODE_CONTINUE);
+    if (rc != MQTT_CODE_SUCCESS) {
+        MqttClient_CancelMessage(&mqttCtx->client,
+            (MqttObject*)&mqttCtx->connect);
+    }
 
     PRINTF("MQTT Connect: Proto (%s), %s (%d)",
         MqttClient_GetProtocolVersionString(&mqttCtx->client),
@@ -407,7 +412,11 @@ static void *subscribe_task(void *param)
     do {
         rc = MqttClient_Subscribe(&mqttCtx->client, &mqttCtx->subscribe);
         rc = check_response(mqttCtx, rc, &startSec);
-    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    } while (rc == MQTT_CODE_CONTINUE);
+    if (rc != MQTT_CODE_SUCCESS) {
+        MqttClient_CancelMessage(&mqttCtx->client,
+            (MqttObject*)&mqttCtx->subscribe);
+    }
     
     PRINTF("MQTT Subscribe: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);
@@ -546,7 +555,10 @@ static void *publish_task(void *param)
     do {
         rc = MqttClient_Publish(&mqttCtx->client, &publish);
         rc = check_response(mqttCtx, rc, &startSec);
-    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    } while (rc == MQTT_CODE_CONTINUE);
+    if (rc != MQTT_CODE_SUCCESS) {
+        MqttClient_CancelMessage(&mqttCtx->client, (MqttObject*)&publish);
+    }
 
     wm_SemLock(&mtLock);
     PRINTF("MQTT Publish: Topic %s, %s (%d)",
@@ -583,7 +595,11 @@ static void *ping_task(void *param)
         do {
             rc = MqttClient_Ping_ex(&mqttCtx->client, &ping);
             rc = check_response(mqttCtx, rc, &startSec);
-        } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+        } while (rc == MQTT_CODE_CONTINUE);
+        if (rc != MQTT_CODE_SUCCESS) {
+            MqttClient_CancelMessage(&mqttCtx->client, (MqttObject*)&ping);
+        }
+
         if (rc != MQTT_CODE_SUCCESS) {
             PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
                 MqttClient_ReturnCodeToString(rc), rc);
@@ -610,7 +626,11 @@ static int unsubscribe_do(MQTTCtx *mqttCtx)
     do {
         rc = MqttClient_Unsubscribe(&mqttCtx->client, &mqttCtx->unsubscribe);
         rc = check_response(mqttCtx, rc, &startSec);
-    } while (rc == MQTT_CODE_CONTINUE || rc == MQTT_CODE_STDIN_WAKE);
+    } while (rc == MQTT_CODE_CONTINUE);
+    if (rc != MQTT_CODE_SUCCESS) {
+        MqttClient_CancelMessage(&mqttCtx->client,
+            (MqttObject*)&mqttCtx->unsubscribe);
+    }
 
     PRINTF("MQTT Unsubscribe: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -355,8 +355,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 }
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Need to send keep-alive ping */
-                    rc = MQTT_CODE_CONTINUE;
                     PRINTF("Keep-alive timeout, sending ping");
+                    rc = MQTT_CODE_CONTINUE;
                     mqttCtx->stat = WMQ_PING;
                     return rc;
                 }
@@ -380,10 +380,11 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 sizeof(mqttCtx->topics) / sizeof(MqttTopic);
             mqttCtx->unsubscribe.topics = mqttCtx->topics;
 
-            mqttCtx->stat = WMQ_UNSUB;
             mqttCtx->start_sec = 0;
+            mqttCtx->stat = WMQ_UNSUB;
+            rc = MQTT_CODE_CONTINUE;
+            return rc;
         }
-        FALL_THROUGH;
 
         case WMQ_PING:
         {

--- a/examples/sn-client/sn-multithread.c
+++ b/examples/sn-client/sn-multithread.c
@@ -41,13 +41,16 @@
 /* Number of publish tasks. Each will send a unique message to the broker. */
 #define NUM_PUB_TASKS   10
 
-
 /* Locals */
 static int mStopRead = 0;
+
+
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_SN)
+
+/* Locals */
 static int mNumMsgsRecvd;
 static word16 topicID;
 
-#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_SN)
 
 #ifdef USE_WINDOWS_API
     /* Windows Threading */
@@ -626,7 +629,8 @@ int sn_multithread_test(MQTTCtx *mqttCtx)
             if (signo == SIGINT) {
                 mStopRead = 1;
                 PRINTF("Received SIGINT");
-            #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+            #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_SN) && \
+                defined(WOLFMQTT_ENABLE_STDIN_CAP)
                 MqttClientNet_Wake(&gMqttCtx.net);
             #endif
             }

--- a/m4/ax_debug.m4
+++ b/m4/ax_debug.m4
@@ -53,7 +53,7 @@ AC_DEFUN([AX_DEBUG],
       [ax_enable_debug=$enableval],
       [ax_enable_debug=no])
 
-  AS_IF([test "x$ax_enable_debug" = xyes || test "x$ax_enable_debug" = xverbose],
+  AS_IF([test "x$ax_enable_debug" = xyes || test "x$ax_enable_debug" = xverbose || test "x$ax_enable_debug" = xtrace],
 		[AC_DEFINE([DEBUG],[1],[Define to 1 to enable debugging code.])],
 		[AC_SUBST([MCHECK])
          AC_DEFINE([DEBUG],[0],[Define to 1 to enable debugging code.])])

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1126,6 +1126,13 @@ wait_again:
         /* if we get here, then the we are still waiting for a packet */
         mms_stat->read = MQTT_MSG_BEGIN;
         MQTT_TRACE_MSG("Wait Again");
+    #ifdef WOLFMQTT_NONBLOCK
+        /* for non-blocking return with code continue instead of waiting again
+         * if called with packet type and id of 'any' */
+        if (wait_type == MQTT_PACKET_TYPE_ANY && wait_packet_id == 0) {
+            return MQTT_CODE_CONTINUE;
+        }
+    #endif
         goto wait_again;
     }
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -35,11 +35,6 @@
 #include "wolfmqtt/mqtt_client.h"
 #include "wolfmqtt/mqtt_socket.h"
 
-/* Options */
-#ifdef WOLFMQTT_NO_STDIO
-    #undef WOLFMQTT_DEBUG_SOCKET
-#endif
-
 
 /* Public Functions */
 #ifdef ENABLE_MQTT_TLS
@@ -161,7 +156,7 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
 
     /* check for buffer position overflow */
     if (client->write.pos >= buf_len) {
-        return MQTT_CODE_ERROR_OUT_OF_BUFFER;
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
     }
 
 #ifdef WOLFMQTT_NONBLOCK
@@ -246,7 +241,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
 
     /* check for buffer position overflow */
     if (client->read.pos >= buf_len) {
-        return MQTT_CODE_ERROR_OUT_OF_BUFFER;
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
     }
 
 #ifdef WOLFMQTT_NONBLOCK
@@ -296,7 +291,7 @@ int MqttSocket_Peek(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
 
     /* check for buffer position overflow */
     if (client->read.pos >= buf_len) {
-        return MQTT_CODE_ERROR_OUT_OF_BUFFER;
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
     }
 
     rc = client->net->peek(client->net->context, buf, buf_len, timeout_ms);

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -183,6 +183,9 @@ typedef struct _MqttClient {
     struct _MqttPendResp* firstPendResp; /* protected with client lock */
     struct _MqttPendResp* lastPendResp;  /* protected with client lock */
 #endif
+#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_DEBUG_CLIENT)
+    int lastRc;
+#endif
 } MqttClient;
 
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -146,9 +146,10 @@ typedef struct _MqttClient {
     MqttTls      tls;   /* WolfSSL context for TLS */
 #endif
 
-    MqttPkRead   packet;
-    MqttSk       read;
-    MqttSk       write;
+    MqttPkRead   packet; /* publish packet state - protected by read lock */
+    MqttPublishResp packetAck; /* publish ACK - protected by write lock */
+    MqttSk       read;   /* read socket state - protected by read lock */
+    MqttSk       write;  /* write socket state - protected by write lock */
 
     MqttMsgCb    msg_cb;
     MqttObject   msg;   /* generic incoming message used by MqttClient_WaitType */
@@ -160,11 +161,11 @@ typedef struct _MqttClient {
     void*        ctx;   /* user supplied context for publish callbacks */
 
 #ifdef WOLFMQTT_V5
-    word32  packet_sz_max; /* Server property */
-    byte    max_qos;       /* Server property */
-    byte    retain_avail;  /* Server property */
-    byte    enable_eauth;  /* Enhanced authentication */
-    byte protocol_level;
+    word32 packet_sz_max; /* Server property */
+    byte   max_qos;       /* Server property */
+    byte   retain_avail;  /* Server property */
+    byte   enable_eauth;  /* Enhanced authentication */
+    byte   protocol_level;
 #endif
 
 #ifdef WOLFMQTT_DISCONNECT_CB
@@ -179,8 +180,8 @@ typedef struct _MqttClient {
     wm_Sem lockSend;
     wm_Sem lockRecv;
     wm_Sem lockClient;
-    struct _MqttPendResp* firstPendResp;
-    struct _MqttPendResp* lastPendResp;
+    struct _MqttPendResp* firstPendResp; /* protected with client lock */
+    struct _MqttPendResp* lastPendResp;  /* protected with client lock */
 #endif
 } MqttClient;
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -347,7 +347,7 @@ WOLFMQTT_API int MqttClient_Ping(
                 and can be used with non-blocking applications.
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
- *  \param      ping        Pointer to MqttPing structure 
+ *  \param      ping        Pointer to MqttPing structure
  *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
                 (see enum MqttPacketResponseCodes)
  */
@@ -437,6 +437,17 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
     MqttObject* msg,
     int timeout_ms);
 
+/*! \brief      In a multi-threaded and non-blocking mode this allows you to
+                cancel an MQTT object that was previously submitted.
+ *  \note This is a blocking function that will wait for MqttNet.read
+ *  \param      client      Pointer to MqttClient structure
+ *  \param      msg         Pointer to MqttObject structure
+ *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
+                (see enum MqttPacketResponseCodes)
+ */
+WOLFMQTT_API int MqttClient_CancelMessage(
+    MqttClient *client,
+    MqttObject* msg);
 
 /*! \brief      Performs network connect with TLS (if use_tls is non-zero value)
  *  Will perform the MqttTlsCb callback if use_tls is non-zero value
@@ -447,7 +458,7 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
                             encryption of data
  *  \param      cb          A function callback for configuration of the SSL
                             context certificate checking
- *  \param      timeout_ms  Milliseconds until read timeout 
+ *  \param      timeout_ms  Milliseconds until read timeout
  *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
                 (see enum MqttPacketResponseCodes)
  */

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -84,7 +84,11 @@
 
 #ifdef WOLFMQTT_MULTITHREAD
     /* Multi-threading uses binary semaphores */
-    #if defined(__MACH__)
+    #if defined(WOLFMQTT_USER_THREADING)
+        /* User provides API's and wm_Sem type.
+         * Add your wc_Sem into user_settings.h */
+
+    #elif defined(__MACH__)
         /* Apple Style Dispatch Semaphore */
         #include <dispatch/dispatch.h>
         typedef dispatch_semaphore_t wm_Sem;
@@ -111,9 +115,6 @@
         #include <ws2tcpip.h>
         #include <windows.h>
         typedef HANDLE wm_Sem;
-
-    #elif defined(WOLFMQTT_USER_THREADING)
-        /* User provides API's and wm_Sem type */
 
     #else
         #error "Multithreading requires binary semaphore implementation!"

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -91,7 +91,9 @@
     #elif defined(__MACH__)
         /* Apple Style Dispatch Semaphore */
         #include <dispatch/dispatch.h>
-        typedef dispatch_semaphore_t wm_Sem;
+        typedef struct {
+            dispatch_semaphore_t sem;
+        } wm_Sem;
 
     #elif defined(__FreeBSD__) || defined(__linux__) || defined(__QNX__)
         /* Posix Style Pthread Mutex and Conditional */

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -321,6 +321,20 @@ enum MqttPacketResponseCodes {
     #define WOLFMQTT_NORETURN
 #endif
 
+/* Logging / Tracing */
+#ifdef WOLFMQTT_NO_STDIO
+    #undef WOLFMQTT_DEBUG_CLIENT
+    #undef WOLFMQTT_DEBUG_SOCKET
+#endif
+
+#ifdef WOLFMQTT_DEBUG_TRACE
+#define MQTT_TRACE_ERROR(err) ({ PRINTF("ERROR: %d (%s:%d)", err, __FUNCTION__, __LINE__); err; })
+#define MQTT_TRACE_MSG(msg)      PRINTF("%s: (%s:%d)", msg, __FUNCTION__, __LINE__);
+#else
+#define MQTT_TRACE_ERROR(err) err
+#define MQTT_TRACE_MSG(msg)
+#endif /* WOLFMQTT_DEBUG_TRACE */
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
* Add non-blocking support to multi-threaded example.
* Fixes for multi-threading with non-blocking. Message state needs to be tracked separately for read and write.
* Refactor of the ACK handling to release read lock during processing ACK.
* Fixed bug where the reset of the shared object was clearing state.
* Fix to only keep read locked if started reading packet.
* Fix to always build all examples (unless `--disable-examples` is set).
* Fix for `WOLFMQTT_USER_THREADING`.
* Added new `--enable-debug=trace` support to provide function/line for error codes and reduced verbosity in non-blocking mode.
ZD 12793