### PR TITLE
Fix bug in test scripts

### DIFF
--- a/scripts/client.test
+++ b/scripts/client.test
@@ -10,6 +10,11 @@ do_cleanup() {
     then
         kill -6 $broker_pid
     fi
+    
+    if  [ $1 -ne 0 ]
+    then
+        exit 1
+    fi
 }
 
 # Check for application
@@ -33,30 +38,30 @@ fi
 
 ./examples/mqttclient/mqttclient $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
 
 ./examples/mqttclient/mqttclient $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=1" && do_cleanup "-1"
 
 ./examples/mqttclient/mqttclient $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
 ./examples/mqttclient/mqttclient $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
 ./examples/mqttclient/mqttclient $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && do_cleanup "-1" 
 
 ./examples/mqttclient/mqttclient $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && do_cleanup "-1"
 
 # End broker
-do_cleanup
+do_cleanup "0"
  
 echo -e "\n\nMQTT Client Tests Passed"
 

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -10,6 +10,11 @@ do_cleanup() {
     then
         kill -6 $broker_pid
     fi
+
+    if  [ $1 -ne 0 ]
+    then
+        exit 1
+    fi
 }
 
 # Check for application
@@ -35,23 +40,23 @@ fi
 # Start firmware push
 ./examples/firmware/fwpush $def_args -r -f $filein $1
 server_result=$?
-[ $server_result -ne 0 ] && echo -e "\n\nMQTT Example fwpush failed!" && do_cleanup && exit 1
+[ $server_result -ne 0 ] && echo -e "\n\nMQTT Example fwpush failed!" && do_cleanup "-1"
 
 # Start firmware client
 ./examples/firmware/fwclient $def_args -f $fileout $1
 client_result=$?
-[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && do_cleanup && exit 1
+[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && do_cleanup "-1"
 
 # Compare files
 md5sum -b $filein $fileout
 compare_result=$?
-[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && do_cleanup && exit 1
+[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && do_cleanup "-1"
 
 # Delete file
 rm $fileout
 
 # End broker
-do_cleanup
+do_cleanup "0"
  
 echo -e "\n\nFirmware Example MQTT Client Tests Passed"
 

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -10,6 +10,11 @@ do_cleanup() {
     then
         kill -6 $broker_pid
     fi
+
+    if  [ $1 -ne 0 ]
+    then
+        exit 1
+    fi
 }
 
 # Check for application
@@ -33,30 +38,30 @@ fi
 
 ./examples/multithread/multithread $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
 
 ./examples/multithread/multithread $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=1" && do_cleanup "-1"
 
 ./examples/multithread/multithread $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
 ./examples/multithread/multithread $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
 ./examples/multithread/multithread $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && do_cleanup "-1"
 
 ./examples/multithread/multithread $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && do_cleanup "-1"
 
 # End broker
-do_cleanup
+do_cleanup "0"
  
 echo -e "\n\nMultithread MQTT Client Tests Passed"
 

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -10,6 +10,11 @@ do_cleanup() {
     then
         kill -6 $broker_pid
     fi
+
+    if  [ $1 -ne 0 ]
+    then
+        exit 1
+    fi
 }
 
 # Check for application
@@ -35,30 +40,30 @@ fi
 
 ./examples/nbclient/nbclient $def_args -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
 
 ./examples/nbclient/nbclient $def_args -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=1" && do_cleanup "-1"
 
 ./examples/nbclient/nbclient $def_args -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
 ./examples/nbclient/nbclient $def_args -t -q 0 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
 ./examples/nbclient/nbclient $def_args -t -q 1 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && do_cleanup "-1"
 
 ./examples/nbclient/nbclient $def_args -t -q 2 $1
 RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && do_cleanup && exit 1
+[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && do_cleanup "-1"
 
 # End broker
-do_cleanup
+do_cleanup "0"
  
 echo -e "\n\nNon-blocking MQTT Client Tests Passed"
 


### PR DESCRIPTION
Currently, the scripts exit out pending cleanup in a similar format as shown below
```
[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && do_cleanup && exit 1
```

But `exit 1` only executes if `do_cleanup` returns 0, which it won't do if it can't find the pid it's trying to kill. So even if certain tests fail, if `do_cleanup` doesn't return 0, the test doesn't exit out and eventually exits with 0 (test passes). These changes should fix that.
