### PR TITLE
Return correct error code in SN_Client_Connect

### DIFF
--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -178,12 +178,15 @@ int sn_test(MQTTCtx *mqttCtx)
         /* Send Connect and wait for Connect Ack */
         rc = SN_Client_Connect(&mqttCtx->client, connect);
 
+        if (rc != MQTT_CODE_SUCCESS) {                                          
+            PRINTF("MQTT-SN Connect: %s (%d)",                                  
+                MqttClient_ReturnCodeToString(rc), rc);                         
+            goto disconn;                                                       
+        }    
+
         /* Validate Connect Ack info */
         PRINTF("....MQTT-SN Connect Ack: Return Code %u",
                 connect->ack.return_code);
-        if (rc != MQTT_CODE_SUCCESS) {
-            goto disconn;
-        }
     }
 
     /* Either the register or the subscribe block could be used to get the


### PR DESCRIPTION
Preventing the  SN_ConnectAck `return_code` from being 0 when an early error occurs.

This PR sets the SN_ConnectAck return code in `SN_Client_Connect()` to the rc error code if rc isn't 0, in case the switch statement in the function breaks before `SN_Client_HandlePacket()` is called.  