### PR TITLE
Update the broker compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ wolfMQTT client library has been tested with the following brokers:
 * Mosquitto by Eclipse
 * Paho MQTT-SN Gateway by Eclipse
 * VerneMQ by VerneMQ/Erlio
+* EMQX by EMQ
 
 ## Specification Support
 
@@ -247,6 +248,11 @@ The v5 enabled wolfMQTT client was tested with the following MQTT v5 brokers:
 * Mosquitto
 ** Runs locally.
 ** `./examples/mqttclient/mqttclient -h localhost`
+* EMQX
+** Runs locally.
+** `./examples/mqttclient/mqttclient -h localhost`
+** Runs free public [mqtt broker](https://www.emqx.com/en/mqtt/public-mqtt5-broker).
+** `./examples/mqttclient/mqttclient -h "broker.emqx.io"`
 * Flespi
 ** Requires an account tied token that is regenerated hourly.
 ** `./examples/mqttclient/mqttclient -h "mqtt.flespi.io" -u "<your-flespi-token>"`


### PR DESCRIPTION
We have tested that wolfMQTT client connect to [emqx broker](https://www.emqx.com/en/mqtt/public-mqtt5-broker) successfully, also publish & subscribe message are working fine.

MQTT v3.1.1
```bash
./examples/mqttclient/mqttclient -h "broker.emqx.io" 
MQTT Client: QoS 0, Use TLS 0
MQTT Net Init: Success (0)
MQTT Init: Success (0)
NetConnect: Host broker.emqx.io, Port 1883, Timeout 5000 ms, Use TLS 0
MQTT Socket Connect: Success (0)
MQTT Connect: Proto (v3.1.1), Success (0)
MQTT Connect Ack: Return Code 0, Session Present 0
MQTT Subscribe: Success (0)
  Topic wolfMQTT/example/testTopic, Qos 0, Return Code 0
MQTT Publish: Topic wolfMQTT/example/testTopic, Success (0)
MQTT Waiting for message...
MQTT Message: Topic wolfMQTT/example/testTopic, Qos 0, Len 4
Payload (0 - 4): test
MQTT Message: Done
```

MQTT v5
```bash
./examples/mqttclient/mqttclient -h "broker.emqx.io"
MQTT Client: QoS 0, Use TLS 0
MQTT Net Init: Success (0)
MQTT Init: Success (0)
NetConnect: Host broker.emqx.io, Port 1883, Timeout 5000 ms, Use TLS 0
MQTT Socket Connect: Success (0)
MQTT Connect: Proto (v5), Success (0)
MQTT Connect Ack: Return Code 0, Session Present 0
MQTT Connect Ack: Assigned Client ID: WolfMQTTClient
MQTT Subscribe: Success (0)
  Topic wolfMQTT/example/testTopic, Qos 0, Return Code 0
MQTT Publish: Topic wolfMQTT/example/testTopic, Success (0)
MQTT Waiting for message...
MQTT Message: Topic wolfMQTT/example/testTopic, Qos 0, Len 4
Payload (0 - 4): test
MQTT Message: Done
```