### PR TITLE
Add new publish write only API for multi-threading

### DIFF
--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -586,7 +586,7 @@ static void *publish_task(void *param)
     publish.total_len = (word16)XSTRLEN(buf);
 
     do {
-        rc = MqttClient_Publish(&mqttCtx->client, &publish);
+        rc = MqttClient_Publish_WriteOnly(&mqttCtx->client, &publish, NULL);
         rc = check_response(mqttCtx, rc, &startSec, MQTT_PACKET_TYPE_PUBLISH);
     } while (rc == MQTT_CODE_CONTINUE);
     if (rc != MQTT_CODE_SUCCESS) {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1780,6 +1780,7 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 else
             #endif
                 {
+                    (void)writeOnly; /* not used */
                     /* Wait for publish response packet */
                     rc = MqttClient_WaitType(client, &publish->resp, resp_type,
                         publish->packet_id, client->cmd_timeout_ms);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -832,7 +832,7 @@ wait_again:
         #ifdef WOLFMQTT_MULTITHREAD
             /* Check to see if packet type and id have already completed */
             rc = MqttClient_CheckPendResp(client, wait_type, wait_packet_id);
-            if (rc != MQTT_CODE_CONTINUE) {
+            if ((rc != MQTT_CODE_SUCCESS) && (rc != MQTT_CODE_CONTINUE)) {
                 return rc;
             }
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -268,17 +268,20 @@ WOLFMQTT_API int MqttClient_Connect(
                 payload is larger than the buffer size, it can be called
                 successively to transmit the full payload.
                 (if QoS > 0)
- *  \note This is a blocking function that will wait for MqttNet.read
- *              If QoS level = 1 then will wait for PUBLISH_ACK.
- *              If QoS level = 2 then will wait for PUBLISH_REC then send
-                    PUBLISH_REL and wait for PUBLISH_COMP.
+ *  \note       This function that will wait for MqttNet.read to complete,
+                timeout or MQTT_CODE_CONTINUE if non-blocking.
+                    If QoS level = 1 then will wait for PUBLISH_ACK.
+                    If QoS level = 2 then will wait for PUBLISH_REC then send
+                        PUBLISH_REL and wait for PUBLISH_COMP.
  *  \param      client      Pointer to MqttClient structure
  *  \param      publish     Pointer to MqttPublish structure initialized
                             with message data
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or 
+                MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
+    \sa         MqttClient_Publish_WriteOnly
+    \sa         MqttClient_Publish_ex
  */
 WOLFMQTT_API int MqttClient_Publish(
     MqttClient *client,
@@ -288,10 +291,11 @@ WOLFMQTT_API int MqttClient_Publish(
                 Publish response (if QoS > 0). The callback function is used to
                 copy the payload data, allowing the use of transmit buffers
                 smaller than the total size of the payload.
- *  \note This is a blocking function that will wait for MqttNet.read
- *              If QoS level = 1 then will wait for PUBLISH_ACK.
- *              If QoS level = 2 then will wait for PUBLISH_REC then send
-                    PUBLISH_REL and wait for PUBLISH_COMP.
+ *  \note       This function that will wait for MqttNet.read to complete,
+                timeout or MQTT_CODE_CONTINUE if non-blocking.
+                    If QoS level = 1 then will wait for PUBLISH_ACK.
+                    If QoS level = 2 then will wait for PUBLISH_REC then send
+                        PUBLISH_REL and wait for PUBLISH_COMP.
  *  \param      client      Pointer to MqttClient structure
  *  \param      publish     Pointer to MqttPublish structure initialized
                             with message data
@@ -305,6 +309,33 @@ WOLFMQTT_API int MqttClient_Publish_ex(
     MqttClient *client,
     MqttPublish *publish,
     MqttPublishCb pubCb);
+
+
+#ifdef WOLFMQTT_MULTITHREAD
+/*! \brief      Same as MqttClient_Publish_ex, however this API will only 
+                perform writes and requires another thread to handle the read
+                ACK processing using MqttClient_WaitMessage_ex
+ *  \note       This function that will wait for MqttNet.read to complete,
+                timeout or MQTT_CODE_CONTINUE if non-blocking.
+                    If QoS level = 1 then will wait for PUBLISH_ACK.
+                    If QoS level = 2 then will wait for PUBLISH_REC then send
+                        PUBLISH_REL and wait for PUBLISH_COMP.
+ *  \param      client      Pointer to MqttClient structure
+ *  \param      publish     Pointer to MqttPublish structure initialized
+                            with message data
+ *                          Note: MqttPublish and MqttMessage are same
+                            structure.
+ *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or 
+                MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
+    \sa         MqttClient_Publish
+    \sa         MqttClient_Publish_ex
+    \sa         MqttClient_WaitMessage_ex
+ */
+WOLFMQTT_API int MqttClient_Publish_WriteOnly(
+    MqttClient *client,
+    MqttPublish *publish,
+    MqttPublishCb pubCb);
+#endif
 
 /*! \brief      Encodes and sends the MQTT Subscribe packet and waits for the
                 Subscribe Acknowledgment packet


### PR DESCRIPTION
Adds new API `MqttClient_Publish_WriteOnly` for multi-threading to allow a publish thread with write only. Requires having another read thread calling `MqttClient_WaitMessage_ex` to handle any ACK processing. Supported only with `--enable-mt` or `WOLFMQTT_MULTITHREAD`. ZD12793.