### PR TITLE
Fix MQTTv5 disconnect with props

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -605,8 +605,28 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
 disconn:
     /* Disconnect */
-    rc = MqttClient_Disconnect_ex(&mqttCtx->client,
-           &mqttCtx->disconnect);
+    XMEMSET(&mqttCtx->disconnect, 0, sizeof(mqttCtx->disconnect));
+#ifdef WOLFMQTT_V5
+    {
+        /* Session expiry interval */
+        MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->disconnect.props);
+        prop->type = MQTT_PROP_SESSION_EXPIRY_INTERVAL;
+        prop->data_int = 0;
+    }
+    #if 0 /* enable to test sending a disconnect reason code */
+    if (mqttCtx->enable_lwt) {
+        /* Disconnect with Will Message */
+        mqttCtx->disconnect.reason_code = MQTT_REASON_DISCONNECT_W_WILL_MSG;
+    }
+    #endif
+#endif
+    rc = MqttClient_Disconnect_ex(&mqttCtx->client, &mqttCtx->disconnect);
+#ifdef WOLFMQTT_V5
+    if (mqttCtx->disconnect.props != NULL) {
+        /* Release the allocated properties */
+        MqttClient_PropsFree(mqttCtx->disconnect.props);
+    }
+#endif
 
     PRINTF("MQTT Disconnect: %s (%d)",
         MqttClient_ReturnCodeToString(rc), rc);

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -116,7 +116,7 @@ static int check_response(MQTTCtx* mqttCtx, int rc, word32* startSec, int packet
     }
     else
 #else
-    (void)packet_type;
+        (void)packet_type;
 #endif
     /* Track elapsed time with no activity and trigger timeout */
     rc = mqtt_check_timeout(rc, startSec, mqttCtx->cmd_timeout_ms/1000);
@@ -129,6 +129,7 @@ static int check_response(MQTTCtx* mqttCtx, int rc, word32* startSec, int packet
     #endif
     }
 #else
+    (void)packet_type;
     (void)startSec;
     (void)mqttCtx;
 #endif

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1536,10 +1536,6 @@ int MqttEncode_Disconnect(byte *tx_buf, int tx_buf_len,
     if ((disconnect != NULL) &&
         (disconnect->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5)) {
 
-        if (disconnect->reason_code != MQTT_REASON_SUCCESS) {
-            /* Length of Reason Code */
-            remain_len++;
-        }
         if (disconnect->props != NULL) {
             /* Determine length of properties */
             remain_len += props_len = MqttEncode_Props(
@@ -1548,6 +1544,11 @@ int MqttEncode_Disconnect(byte *tx_buf, int tx_buf_len,
 
             /* Determine the length of the "property length" */
             remain_len += MqttEncode_Vbi(NULL, props_len);
+        }
+        if ((remain_len != 0) ||
+            (disconnect->reason_code != MQTT_REASON_SUCCESS)) {
+            /* Length of Reason Code */
+            remain_len++;
         }
     }
 #endif
@@ -1567,8 +1568,8 @@ int MqttEncode_Disconnect(byte *tx_buf, int tx_buf_len,
     if ((disconnect != NULL) &&
         (disconnect->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5)) {
         byte* tx_payload = &tx_buf[header_len];
-        if (disconnect->reason_code != MQTT_REASON_SUCCESS) {
-
+        if ((remain_len != 0) ||
+            (disconnect->reason_code != MQTT_REASON_SUCCESS)) {
             /* Encode the Reason Code */
             *tx_payload++ = disconnect->reason_code;
         }
@@ -1578,7 +1579,7 @@ int MqttEncode_Disconnect(byte *tx_buf, int tx_buf_len,
             tx_payload += MqttEncode_Vbi(tx_payload, props_len);
 
             /* Encode properties */
-            tx_payload += MqttEncode_Props(MQTT_PACKET_TYPE_CONNECT,
+            tx_payload += MqttEncode_Props(MQTT_PACKET_TYPE_DISCONNECT,
                             disconnect->props, tx_payload);
         }
         (void)tx_payload;


### PR DESCRIPTION
Fixed issue with encoding disconnect packet that includes properties. Also adds tests in mqttclient example.

Fixed build error with `./configure --enable-mt`.

This addresses a reported issue from ZD13618