### PR TITLE
Fix decoding user property and add example

### DIFF
--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -189,7 +189,14 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
                 break;
 
             case MQTT_PROP_REASON_STR:
-                PRINTF("Reason String: %s", prop->data_str.str);
+                PRINTF("Reason String: %.*s",
+                        prop->data_str.len, prop->data_str.str);
+                break;
+
+            case MQTT_PROP_USER_PROP:
+                PRINTF("User property: key=\"%.*s\", value=\"%.*s\"",
+                        prop->data_str.len, prop->data_str.str,
+                        prop->data_str2.len, prop->data_str2.str);
                 break;
 
             case MQTT_PROP_PAYLOAD_FORMAT_IND:
@@ -202,7 +209,6 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
             case MQTT_PROP_TOPIC_ALIAS:
             case MQTT_PROP_TYPE_MAX:
             case MQTT_PROP_RECEIVE_MAX:
-            case MQTT_PROP_USER_PROP:
             case MQTT_PROP_WILDCARD_SUB_AVAIL:
             case MQTT_PROP_SHARED_SUBSCRIPTION_AVAIL:
             case MQTT_PROP_RESP_INFO:

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -598,7 +598,7 @@ int MqttDecode_Props(MqttPacketType packet, MqttProp** props, byte* pbuf,
                         (const char**)&cur_prop->data_str.str,
                         &cur_prop->data_str.len);
                 if (cur_prop->data_str.len <=
-                    (buf_len - (buf + tmp - pbuf))) {
+                    (buf_len - (buf - pbuf))) {
                     buf += tmp;
                     total += tmp;
                     prop_len -= (word32)tmp;
@@ -607,7 +607,7 @@ int MqttDecode_Props(MqttPacketType packet, MqttProp** props, byte* pbuf,
                             (const char**)&cur_prop->data_str2.str,
                             &cur_prop->data_str2.len);
                     if (cur_prop->data_str2.len <=
-                        (buf_len - (buf + tmp - pbuf))) {
+                        (buf_len - (buf - pbuf))) {
                         buf += tmp;
                         total += tmp;
                         prop_len -= (word32)tmp;


### PR DESCRIPTION
Fix parsing MQTTv5 user property strings.

This fixes an issue from ZD13738