### PR TITLE
Fixes for non-blocking state and large payload

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -44,3 +44,15 @@ jobs:
       run: make
     - name: make check
       run: make check
+    - name: configure with Non-Block
+      run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: configure with Non-Block and Multi-threading
+      run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+    - name: make
+      run: make
+    - name: make check
+      run: make check

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -43,3 +43,15 @@ jobs:
       run: make
     - name: make check
       run: make check
+    - name: configure with Non-Block
+      run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: configure with Non-Block and Multi-threading
+      run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+    - name: make
+      run: make
+    - name: make check
+      run: make check

--- a/commit-tests.sh
+++ b/commit-tests.sh
@@ -63,7 +63,7 @@ RESULT=$?
 
 # make sure multithread with non-blocking is okay
 echo -e "\n\nTesting multithread with non-block config...\n\n"
-./configure --enable-mt;
+./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK";
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-mt --enable-nonblock' failed" && exit 1
 
@@ -73,7 +73,7 @@ RESULT=$?
 
 # make sure non-blocking plus TLS is okay
 echo -e "\n\nTesting Non-Blocking TLS config as well...\n\n"
-./configure --enable-nonblock --enable-tls;
+./configure --enable-nonblock --enable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK";
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --enable-tls' failed" && exit 1
 
@@ -83,7 +83,7 @@ RESULT=$?
 
 # make sure non-blocking is okay
 echo -e "\n\nTesting Non-Blocking config too...\n\n"
-./configure --enable-nonblock --disable-tls;
+./configure --enable-nonblock --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK";
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nTest './configure --enable-nonblock --disable-tls' failed" && exit 1
 

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -259,8 +259,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -155,8 +155,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -95,8 +95,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     #ifdef WOLFMQTT_V5
     {

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -136,19 +136,18 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
     }
     mqttCtx = (MQTTCtx*)client->ctx;
 
-    while (prop != NULL)
-    {
-        switch (prop->type)
-        {
+    while (prop != NULL) {
+        PRINTF("Property CB: Type %d", prop->type);
+        switch (prop->type) {
             case MQTT_PROP_ASSIGNED_CLIENT_ID:
                 /* Store client ID in global */
                 mqttCtx->client_id = &gClientId[0];
 
                 /* Store assigned client ID from CONNACK*/
-                XSTRNCPY((char*)mqttCtx->client_id,
-                        prop->data_str.str,
-                        MAX_CLIENT_ID_LEN-1);
-                ((char*)mqttCtx->client_id)[MAX_CLIENT_ID_LEN-1] = 0; /* really want strlcpy() semantics, but that's non-portable. */
+                XSTRNCPY((char*)mqttCtx->client_id, prop->data_str.str,
+                         MAX_CLIENT_ID_LEN - 1);
+                /* should use strlcpy() semantics, but non-portable */
+                ((char*)mqttCtx->client_id)[MAX_CLIENT_ID_LEN - 1] = '\0';
                 break;
 
             case MQTT_PROP_SUBSCRIPTION_ID_AVAIL:
@@ -232,7 +231,7 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
 
     return rc;
 }
-#endif
+#endif /* WOLFMQTT_PROPERTY_CB */
 
 int mqttclient_test(MQTTCtx *mqttCtx)
 {
@@ -536,7 +535,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         /* check for test mode */
         if (mqttCtx->test_mode) {
             PRINTF("MQTT Test mode, exit now");
-            break;            
+            break;
         }
 
         /* Try and read packet */

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -107,8 +107,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -190,8 +190,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -577,6 +577,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
         case WMQ_DISCONNECT:
         {
+            mqttCtx->stat = WMQ_DISCONNECT;
+
             /* Disconnect */
             rc = MqttClient_Disconnect_ex(&mqttCtx->client,
                    &mqttCtx->disconnect);

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -92,8 +92,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -38,7 +38,11 @@ static int mStopRead = 0;
 
 /* Maximum size for network read/write callbacks. */
 #define MAX_BUFFER_SIZE 1024
-#define TEST_MESSAGE    "test"
+
+#ifdef WOLFMQTT_PROPERTY_CB
+#define MAX_CLIENT_ID_LEN 64
+char gClientId[MAX_CLIENT_ID_LEN] = {0};
+#endif
 
 #ifdef WOLFMQTT_DISCONNECT_CB
 /* callback indicates a network error occurred */
@@ -74,10 +78,10 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         PRINTF("MQTT Message: Topic %s, Qos %d, Len %u",
             buf, msg->qos, msg->total_len);
 
-        /* for test mode: check if TEST_MESSAGE was received */
+        /* for test mode: check if DEFAULT_MESSAGE was received */
         if (mqttCtx->test_mode) {
-            if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
-                XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer,
+            if (XSTRLEN(DEFAULT_MESSAGE) == msg->buffer_len &&
+                XSTRNCMP(DEFAULT_MESSAGE, (char*)msg->buffer,
                          msg->buffer_len) == 0)
             {
                 mStopRead = 1;
@@ -102,6 +106,118 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     /* Return negative to terminate publish processing */
     return MQTT_CODE_SUCCESS;
 }
+
+#ifdef WOLFMQTT_PROPERTY_CB
+/* The property callback is called after decoding a packet that contains at
+   least one property. The property list is deallocated after returning from
+   the callback. */
+static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
+{
+    MqttProp *prop = head;
+    int rc = 0;
+    MQTTCtx* mqttCtx;
+
+    if ((client == NULL) || (client->ctx == NULL)) {
+        return MQTT_CODE_ERROR_BAD_ARG;
+    }
+    mqttCtx = (MQTTCtx*)client->ctx;
+
+    while (prop != NULL) {
+        PRINTF("Property CB: Type %d", prop->type);
+        switch (prop->type) {
+            case MQTT_PROP_ASSIGNED_CLIENT_ID:
+                /* Store client ID in global */
+                mqttCtx->client_id = &gClientId[0];
+
+                /* Store assigned client ID from CONNACK*/
+                XSTRNCPY((char*)mqttCtx->client_id, prop->data_str.str,
+                         MAX_CLIENT_ID_LEN - 1);
+                /* should use strlcpy() semantics, but non-portable */
+                ((char*)mqttCtx->client_id)[MAX_CLIENT_ID_LEN - 1] = '\0';
+                break;
+
+            case MQTT_PROP_SUBSCRIPTION_ID_AVAIL:
+                mqttCtx->subId_not_avail =
+                        prop->data_byte == 0;
+                break;
+
+            case MQTT_PROP_TOPIC_ALIAS_MAX:
+                mqttCtx->topic_alias_max =
+                 (mqttCtx->topic_alias_max < prop->data_short) ?
+                 mqttCtx->topic_alias_max : prop->data_short;
+                break;
+
+            case MQTT_PROP_MAX_PACKET_SZ:
+                if ((prop->data_int > 0) &&
+                    (prop->data_int <= MQTT_PACKET_SZ_MAX))
+                {
+                    client->packet_sz_max =
+                        (client->packet_sz_max < prop->data_int) ?
+                         client->packet_sz_max : prop->data_int;
+                }
+                else {
+                    /* Protocol error */
+                    rc = MQTT_CODE_ERROR_PROPERTY;
+                }
+                break;
+
+            case MQTT_PROP_SERVER_KEEP_ALIVE:
+                mqttCtx->keep_alive_sec = prop->data_short;
+                break;
+
+            case MQTT_PROP_MAX_QOS:
+                client->max_qos = prop->data_byte;
+                break;
+
+            case MQTT_PROP_RETAIN_AVAIL:
+                client->retain_avail = prop->data_byte;
+                break;
+
+            case MQTT_PROP_REASON_STR:
+                PRINTF("Reason String: %.*s",
+                        prop->data_str.len, prop->data_str.str);
+                break;
+
+            case MQTT_PROP_USER_PROP:
+                PRINTF("User property: key=\"%.*s\", value=\"%.*s\"",
+                        prop->data_str.len, prop->data_str.str,
+                        prop->data_str2.len, prop->data_str2.str);
+                break;
+
+            case MQTT_PROP_PAYLOAD_FORMAT_IND:
+            case MQTT_PROP_MSG_EXPIRY_INTERVAL:
+            case MQTT_PROP_CONTENT_TYPE:
+            case MQTT_PROP_RESP_TOPIC:
+            case MQTT_PROP_CORRELATION_DATA:
+            case MQTT_PROP_SUBSCRIPTION_ID:
+            case MQTT_PROP_SESSION_EXPIRY_INTERVAL:
+            case MQTT_PROP_TOPIC_ALIAS:
+            case MQTT_PROP_TYPE_MAX:
+            case MQTT_PROP_RECEIVE_MAX:
+            case MQTT_PROP_WILDCARD_SUB_AVAIL:
+            case MQTT_PROP_SHARED_SUBSCRIPTION_AVAIL:
+            case MQTT_PROP_RESP_INFO:
+            case MQTT_PROP_SERVER_REF:
+            case MQTT_PROP_AUTH_METHOD:
+            case MQTT_PROP_AUTH_DATA:
+            case MQTT_PROP_NONE:
+                break;
+            case MQTT_PROP_REQ_PROB_INFO:
+            case MQTT_PROP_WILL_DELAY_INTERVAL:
+            case MQTT_PROP_REQ_RESP_INFO:
+            default:
+                /* Invalid */
+                rc = MQTT_CODE_ERROR_PROPERTY;
+                break;
+        }
+        prop = prop->next;
+    }
+
+    (void)ctx;
+
+    return rc;
+}
+#endif /* WOLFMQTT_PROPERTY_CB */
 
 int mqttclient_test(MQTTCtx *mqttCtx)
 {
@@ -162,6 +278,13 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             /* setup disconnect callback */
             rc = MqttClient_SetDisconnectCallback(&mqttCtx->client,
                 mqtt_disconnect_cb, NULL);
+            if (rc != MQTT_CODE_SUCCESS) {
+                goto exit;
+            }
+        #endif
+        #ifdef WOLFMQTT_PROPERTY_CB
+            rc = MqttClient_SetPropertyCallback(&mqttCtx->client,
+                    mqtt_property_cb, NULL);
             if (rc != MQTT_CODE_SUCCESS) {
                 goto exit;
             }
@@ -307,15 +430,16 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_PUB;
 
             if ((rc == MQTT_CODE_SUCCESS) || (rc == MQTT_CODE_CONTINUE)) {
-                /* This loop allows payloads larger than the buffer to be sent by
-                   repeatedly calling publish.
-                */
+                /* This loop allows payloads larger than the buffer to be sent
+                 * by repeatedly calling publish.
+                 */
                 do {
-                    rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
+                    rc = MqttClient_Publish(&mqttCtx->client,
+                                            &mqttCtx->publish);
                     if (rc == MQTT_CODE_CONTINUE) {
                         return rc;
                     }
-                } while(rc == MQTT_CODE_PUB_CONTINUE);
+                } while (rc == MQTT_CODE_PUB_CONTINUE);
 
                 if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
                     WOLFMQTT_FREE(mqttCtx->publish.buffer);
@@ -339,9 +463,9 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->stat = WMQ_WAIT_MSG;
 
             do {
-                /* Try and read packet */
+                /* Try and read packet (any type) */
                 rc = MqttClient_WaitMessage(&mqttCtx->client,
-                                                mqttCtx->cmd_timeout_ms);
+                                            mqttCtx->cmd_timeout_ms);
 
                 /* check for test mode */
                 if (mStopRead) {
@@ -365,8 +489,15 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                             stdin) != NULL)
                     {
                         PRINTF("STDIN Wake to Publish");
+                        XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
+                        mqttCtx->publish.retain = 0;
+                        mqttCtx->publish.qos = mqttCtx->qos;
+                        mqttCtx->publish.duplicate = 0;
+                        mqttCtx->publish.topic_name = mqttCtx->topic_name;
+                        mqttCtx->publish.packet_id = mqtt_get_packetid();
                         mqttCtx->publish.buffer = (byte*)mqttCtx->rx_buf;
-                        mqttCtx->publish.total_len = (int)XSTRLEN((char*)mqttCtx->rx_buf);
+                        mqttCtx->publish.total_len =
+                            (int)XSTRLEN((char*)mqttCtx->rx_buf);
 
                         rc = MQTT_CODE_CONTINUE;
                         mqttCtx->stat = WMQ_PUB;

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -358,6 +358,22 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 if (rc == MQTT_CODE_CONTINUE) {
                     return rc;
                 }
+            #ifdef WOLFMQTT_ENABLE_STDIN_CAP
+                else if (rc == MQTT_CODE_STDIN_WAKE) {
+                    XMEMSET(mqttCtx->rx_buf, 0, MAX_BUFFER_SIZE);
+                    if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE - 1,
+                            stdin) != NULL)
+                    {
+                        PRINTF("STDIN Wake to Publish");
+                        mqttCtx->publish.buffer = (byte*)mqttCtx->rx_buf;
+                        mqttCtx->publish.total_len = (int)XSTRLEN((char*)mqttCtx->rx_buf);
+
+                        rc = MQTT_CODE_CONTINUE;
+                        mqttCtx->stat = WMQ_PUB;
+                        return rc;
+                    }
+                }
+            #endif
                 else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
                     /* Need to send keep-alive ping */
                     PRINTF("Keep-alive timeout, sending ping");

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -48,8 +48,6 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
     word16 topicId;
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
 
-    (void)mqttCtx;
-
     if (msg_new) {
         /* Topic ID or short topic name */
         topicId = (word16)(msg->topic_name[0] << 8 | msg->topic_name[1]);
@@ -59,7 +57,7 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
                 topicId, msg->qos, msg->packet_id, msg->total_len);
 
         /* for test mode: check if TEST_MESSAGE was received */
-        if (mqttCtx->test_mode) {
+        if (mqttCtx != NULL && mqttCtx->test_mode) {
             if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
                 XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer,
                          msg->buffer_len) == 0)

--- a/examples/sn-client/sn-multithread.c
+++ b/examples/sn-client/sn-multithread.c
@@ -104,8 +104,6 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
     word16 topicId;
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
 
-    (void)mqttCtx;
-
     if (msg_new) {
         /* Topic ID or short topic name */
         topicId = (word16)(msg->topic_name[0] << 8 | msg->topic_name[1]);
@@ -115,7 +113,7 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
                 topicId, msg->qos, msg->packet_id, msg->total_len);
 
         /* for test mode: count the number of TEST_MESSAGE matches received */
-        if (mqttCtx->test_mode) {
+        if (mqttCtx != NULL && mqttCtx->test_mode) {
             if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
                 /* Only compare the "test" part */
                 XSTRNCMP(TEST_MESSAGE, (char*)msg->buffer,

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -113,8 +113,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d): %s",
-        msg->buffer_pos, msg->buffer_pos + len, buf);
+    PRINTF("Payload (%d - %d) printing %d bytes:"LINE_END"%s",
+        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
 
     if (msg_done) {
         PRINTF("MQTT Message: Done");

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -981,6 +981,10 @@ wait_again:
             }
         #endif /* WOLFMQTT_MULTITHREAD */
 
+            /* for payload state packet type is always publish */
+            if (mms_stat->read == MQTT_MSG_PAYLOAD) {
+                use_packet_type = MQTT_PACKET_TYPE_PUBLISH;
+            }
             /* cache publish packet id and qos for MqttClient_HandlePacket payload */
             if (use_packet_type == MQTT_PACKET_TYPE_PUBLISH &&
                   mms_stat->read == MQTT_MSG_HEADER && use_packet_obj != NULL) {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1151,7 +1151,9 @@ wait_again:
 #endif
 
     /* no data read or ack done, then reset state */
-    if (mms_stat->read == MQTT_MSG_WAIT || mms_stat->read == MQTT_MSG_ACK) {
+    if ((mms_stat->read == MQTT_MSG_WAIT &&
+            client->packet.stat == MQTT_PK_BEGIN) ||
+         mms_stat->read == MQTT_MSG_ACK) {
         mms_stat->read = MQTT_MSG_BEGIN;
     }
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -854,9 +854,9 @@ wait_again:
     if (client->lastRc != MQTT_CODE_CONTINUE)
     #endif
     {
-        PRINTF("MqttClient_WaitType: Type %s (%d), ID %d, State %d",
+        PRINTF("MqttClient_WaitType: Type %s (%d), ID %d, State %d-%d",
             MqttPacket_TypeDesc((MqttPacketType)wait_type),
-                wait_type, wait_packet_id, mms_stat->read);
+                wait_type, wait_packet_id, mms_stat->read, mms_stat->write);
     }
 #endif
 
@@ -1141,12 +1141,13 @@ wait_again:
 
 #ifdef WOLFMQTT_DEBUG_CLIENT
     if (rc != MQTT_CODE_CONTINUE) {
-        PRINTF("MqttClient_WaitType: rc %d, state %d", rc, mms_stat->read);
+        PRINTF("MqttClient_WaitType: rc %d, state %d-%d",
+            rc, mms_stat->read, mms_stat->write);
     }
 #endif
 
-    /* no data read, reset state */
-    if (mms_stat->read == MQTT_MSG_WAIT) {
+    /* no data read or ack done, then reset state */
+    if (mms_stat->read == MQTT_MSG_WAIT || mms_stat->read == MQTT_MSG_ACK) {
         mms_stat->read = MQTT_MSG_BEGIN;
     }
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1461,10 +1461,6 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     return rc;
 }
 
-#ifdef WOLFMQTT_TEST_NONBLOCK
-static int testNbAlt = 0;
-#endif
-
 static int MqttClient_Publish_ReadPayload(MqttClient* client,
     MqttPublish* publish, int timeout_ms)
 {
@@ -1517,7 +1513,8 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
 
             /* make sure there is something to read */
             if (msg_len > 0) {
-                #ifdef WOLFMQTT_TEST_NONBLOCK
+                #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+                    static int testNbAlt = 0;
                     if (!testNbAlt) {
                         testNbAlt = 1;
                         return MQTT_CODE_CONTINUE;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1033,6 +1033,8 @@ wait_again:
                 break;
             }
         #endif
+            /* Make sure shared packet object is reset */
+            XMEMSET(&client->msg, 0, sizeof(client->msg));
 
             /* handle success case */
             if (rc >= 0) {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1926,7 +1926,7 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
         case MQTT_PK_BEGIN:
         {
             client->read.pos = 0;
-            client->packet.header_len = 2;
+            client->packet.header_len = MQTT_PACKET_HEADER_MIN_SIZE;
             client->packet.remain_len = 0;
 
             /* Read fix header portion */

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -639,6 +639,7 @@ int MqttDecode_Props(MqttPacketType packet, MqttProp** props, byte* pbuf,
     if (rc < 0) {
         /* Free the property */
         MqttProps_Free(*props);
+        *props = NULL;
     }
     else {
         rc = total;

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -207,6 +207,15 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
 {
     int rc;
 
+#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+    static int testNbAlt = 0;
+    if (!testNbAlt) {
+        testNbAlt = 1;
+        return MQTT_CODE_CONTINUE;
+    }
+    testNbAlt = 0;
+#endif
+
 #ifdef ENABLE_MQTT_TLS
     if (client->flags & MQTT_CLIENT_FLAG_IS_TLS) {
         client->tls.timeout_ms = timeout_ms;

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -245,12 +245,24 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
     else
 #endif /* ENABLE_MQTT_TLS */
     {
+    #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+        static int testSmallerRead = 0;
+        if (!testSmallerRead) {
+            if (buf_len > 100) {
+                buf_len /= 2;
+            }
+            testSmallerRead = 1;
+        }
+        else {
+            testSmallerRead = 0;
+        }
+    #endif
         rc = client->net->read(client->net->context, buf, buf_len, timeout_ms);
     }
 
 #ifdef WOLFMQTT_DEBUG_SOCKET
     if (rc != 0 && rc != MQTT_CODE_CONTINUE) { /* hide in non-blocking case */
-        PRINTF("MqttSocket_Read: Len=%d, Rc=%d", buf_len, rc);
+        PRINTF("MqttSocket_ReadDo: Len=%d, Rc=%d", buf_len, rc);
     }
 #endif
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -283,6 +283,7 @@ typedef enum _MqttMsgState {
     MQTT_MSG_AUTH,
     MQTT_MSG_HEADER,
     MQTT_MSG_PAYLOAD,
+    MQTT_MSG_PAYLOAD2,
     MQTT_MSG_ACK,
 } MqttMsgState;
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -259,7 +259,7 @@ enum MqttPacketFlags {
 
 /* Packet Header: Size is variable 2 - 5 bytes */
 #define MQTT_PACKET_MAX_LEN_BYTES   4
-#define MQTT_PACKET_LEN_ENCODE_MASK 0x80
+#define MQTT_PACKET_LEN_ENCODE_MASK 0x80UL
 typedef struct _MqttPacket {
     /* Type = bits 4-7, Flags = 0-3 are flags */
     byte        type_flags; /* MqttPacketType and MqttPacketFlags */


### PR DESCRIPTION
* Fix for incomplete packet read with non-blocking continue loosing already read packet data.
* Fix for non-blocking with large payload.
* Fix for read state not getting reset if processing a QOS >= 1.
* Fix variable length decode. Was incorrectly erroring for sizes over 2,097,152.
* Fix to make sure property list heads are cleared on free.
* Fix to not issue property callbacks until the packet type/id have been decoded, since the incoming packet object may not be properly initialized yet.
* Fix to ensure the generic packet object is initialized.
* Fix for non-blocking write cases.
* Added non-blocking STDIN support.
* Added test case for read asking for X bytes, but returning smaller.
* Added MQTT v5 properties support to non-blocking example.
* Improved variable length encode code.
* Improved the publish callback printing to clarify range received vs what is printed.
* Enable testing of non-blocking using the `WOLFMQTT_TEST_NONBLOCK` macro.
 
ZD13880