### PR TITLE
cmake: add example option and fixes for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(wolfMQTT VERSION 11.0.0 LANGUAGES C)
+project(wolfMQTT VERSION 1.12.0 LANGUAGES C)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(MQTT_SOURCES
     src/mqtt_client.c
@@ -33,7 +34,7 @@ add_library(wolfmqtt ${MQTT_SOURCES})
 
 
 if (WITH_WOLFSSL)
-    target_link_libraries(wolfmqtt wolfssl)
+    target_link_libraries(wolfmqtt PUBLIC wolfssl)
     target_include_directories(wolfmqtt PUBLIC ${WITH_WOLFSSL}/include)
     target_link_directories(wolfmqtt PUBLIC ${WITH_WOLFSSL}/lib)
     target_compile_definitions(wolfmqtt PUBLIC
@@ -41,7 +42,7 @@ if (WITH_WOLFSSL)
         )
 elseif (WITH_WOLFSSL_TREE)
     add_subdirectory(${WITH_WOLFSSL_TREE} wolfssl)
-    target_link_libraries(wolfmqtt wolfssl)
+    target_link_libraries(wolfmqtt PUBLIC wolfssl)
     target_compile_definitions(wolfmqtt PUBLIC
         "ENABLE_MQTT_TLS"
         )
@@ -53,10 +54,19 @@ else()
         target_compile_definitions(wolfmqtt PUBLIC
             "ENABLE_MQTT_TLS"
             )
-        target_link_libraries(wolfmqtt ${WOLFSSL_LIBRARIES})
+        target_link_libraries(wolfmqtt PUBLIC ${WOLFSSL_LIBRARIES})
         target_include_directories(wolfmqtt PUBLIC ${WOLFSSL_INCLUDE_DIRS})
         target_link_directories(wolfmqtt PUBLIC ${WOLFSSL_LIBRARY_DIRS})
         target_compile_options(wolfmqtt PUBLIC ${WOLFSSL_CFLAGS_OTHER})
+    else()
+        # For support with vcpkg
+        find_package(wolfssl CONFIG)
+        if (wolfssl_FOUND)
+            target_compile_definitions(wolfmqtt PUBLIC
+                "ENABLE_MQTT_TLS"
+                )
+            target_link_libraries(wolfmqtt PUBLIC wolfssl)
+        endif()
     endif()
 endif()
 
@@ -66,19 +76,21 @@ endif()
 # * sn
 # * nonblock
 # * timeout
-# * examples
 # * errorstrings
 # * stdincap
 # * v5
 # * discb
 # * mt
 
+set(WOLFMQTT_EXAMPLES "yes" CACHE BOOL
+    "Build examples")
+
 target_compile_definitions(wolfmqtt PRIVATE
     "BUILDING_WOLFMQTT"
     )
 
+#TODO generate options file
 configure_file(wolfmqtt/options.h.in wolfmqtt/options.h)
-
 
 if(WIN32)
     target_compile_definitions(wolfmqtt PRIVATE
@@ -88,46 +100,64 @@ endif(WIN32)
 
 target_include_directories(wolfmqtt
     PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}
-    $<INSTALL_INTERFACE:wolfmqtt>
+    $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
 
-add_library(mqtt_test_lib STATIC
-    examples/mqttexample.c
-    examples/mqttnet.c
-    )
-target_link_libraries(mqtt_test_lib wolfmqtt)
 
-function(add_mqtt_example name src)
-    add_executable(${name}
-        examples/${src}
+if (${WOLFMQTT_EXAMPLES})
+    add_library(mqtt_test_lib STATIC
+        examples/mqttexample.c
+        examples/mqttnet.c
         )
-    target_link_libraries(${name} wolfmqtt mqtt_test_lib)
-endfunction()
+    target_link_libraries(mqtt_test_lib wolfmqtt)
 
-#TODO generate options file
+    function(add_mqtt_example name src)
+        add_executable(${name}
+            examples/${src}
+            )
+        target_link_libraries(${name} wolfmqtt mqtt_test_lib)
+    endfunction()
 
 
-add_mqtt_example(mqttclient mqttclient/mqttclient.c)
-add_mqtt_example(mqttsimple mqttsimple/mqttsimple.c)
-add_mqtt_example(nbclient nbclient/nbclient.c)
-#add_mqtt_example(mqttuart mqttuart.c)
-add_mqtt_example(multithread multithread/multithread.c)
-add_mqtt_example(sn-client sn-client/sn-client.c)
-add_mqtt_example(sn-client_qos-1 sn-client/sn-client_qos-1.c)
-add_mqtt_example(sn-multithread sn-client/sn-multithread.c)
-add_mqtt_example(awsiot aws/awsiot.c)
-add_mqtt_example(wiot wiot/wiot.c)
-add_mqtt_example(azureiothub azure/azureiothub.c)
-add_mqtt_example(fwpush firmware/fwpush.c)
-add_mqtt_example(fwclient firmware/fwclient.c)
+    add_mqtt_example(mqttclient mqttclient/mqttclient.c)
+    add_mqtt_example(mqttsimple mqttsimple/mqttsimple.c)
+    add_mqtt_example(nbclient nbclient/nbclient.c)
+    #add_mqtt_example(mqttuart mqttuart.c)
+    add_mqtt_example(multithread multithread/multithread.c)
+    add_mqtt_example(sn-client sn-client/sn-client.c)
+    add_mqtt_example(sn-client_qos-1 sn-client/sn-client_qos-1.c)
+    add_mqtt_example(sn-multithread sn-client/sn-multithread.c)
+    add_mqtt_example(awsiot aws/awsiot.c)
+    add_mqtt_example(wiot wiot/wiot.c)
+    add_mqtt_example(azureiothub azure/azureiothub.c)
+    add_mqtt_example(fwpush firmware/fwpush.c)
+    add_mqtt_example(fwclient firmware/fwclient.c)
+endif()
 
+####################################################
+# Installation
+####################################################
+
+include(GNUInstallDirs)
 
 install(TARGETS wolfmqtt
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY)
+        EXPORT  wolfmqtt-targets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        )
+
+# Install the export set
+install(EXPORT wolfmqtt-targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wolfmqtt
+        FILE wolfmqtt-config.cmake)
+
 # Install the headers
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/wolfmqtt/
+        DESTINATION include/wolfmqtt
+        FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wolfmqtt/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolfmqtt
+        DESTINATION include/wolfmqtt
         FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
 * Fix version
 * look for wolfSSL for vcpkg
 * Add WOLFMQTT_EXAMPLES option (defaults to on)
 * Fix library install locations for windows and vcpkg