### PR TITLE
Fix to release connect ack props

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -335,6 +335,7 @@ static int Handle_Props(MqttClient* client, MqttProp* props, byte use_cb,
  *  \param      ppacket_type Decoded packet type
  *  \param      ppacket_qos  Decoded QoS level
  *  \param      ppacket_id   Decoded packet id
+ *  \param      doProps      True: Call Handle_Props to free prop struct
 
  *  \return     Returns length decoded or error (as negative) MQTT_CODE_ERROR_*
                 (see enum MqttPacketResponseCodes)
@@ -987,7 +988,7 @@ wait_again:
             /* Decode Packet - get type, qos and id */
             rc = MqttClient_DecodePacket(client, client->rx_buf,
                 client->packet.buf_len, NULL, &packet_type, &packet_qos,
-                &packet_id, 0);
+                &packet_id, 1);
             if (rc < 0) {
                 break;
             }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1851,6 +1851,10 @@ MqttProp* MqttProps_Add(MqttProp **head)
             prev->next = new_prop;
         }
     }
+    else {
+        /* Could not allocate property */
+        (void)MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PROPERTY);
+    }
 
 #ifdef WOLFMQTT_MULTITHREAD
     (void)wm_SemUnlock(&clientPropStack_lock);


### PR DESCRIPTION
Use `do_props` = 1 when calling `MqttClient_DecodePacket` from `MqttClient_WaitType` to free property list allocated for temp `packet_obj` when decoding packet.

This fixes ZD14434

Tested with this modified mqttsimple test (in ZD ticket).
`./configure --disable-tls --enable-v5 --disable-shared --enable-debug CFLAGS="-DMQTT_MAX_PROPS 10"`