### PR TITLE
Add WOLFMQTT_USE_CB_ON_DISCONNECT for CB on client disconnect

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2347,9 +2347,17 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *disconnect)
         return rc;
     }
 
+    rc = MQTT_CODE_SUCCESS;
+
+#if defined(WOLFMQTT_DISCONNECT_CB) && defined(WOLFMQTT_USE_CB_ON_DISCONNECT)
+    /* Trigger disconnect callback */
+    if (client->disconnect_cb)
+        client->disconnect_cb(client, rc, client->disconnect_ctx);
+#endif
+
     /* No response for MQTT disconnect packet */
 
-    return MQTT_CODE_SUCCESS;
+    return rc;
 }
 
 #ifdef WOLFMQTT_V5

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -42,6 +42,15 @@
 #include "wolfmqtt/mqtt_packet.h"
 #include "wolfmqtt/mqtt_socket.h"
 
+/* This macro allows the disconnect callback to be triggered when
+ * MqttClient_Disconnect_ex is called. Normally the CB is only used to handle
+ * errors from MqttPacket_HandleNetError.
+ */
+#ifndef WOLFMQTT_USE_CB_ON_DISCONNECT
+    #undef WOLFMQTT_USE_CB_ON_DISCONNECT
+    /* #define WOLFMQTT_USE_CB_ON_DISCONNECT */
+#endif
+
 #if defined(WOLFMQTT_PROPERTY_CB) && !defined(WOLFMQTT_V5)
     #error "WOLFMQTT_V5 must be defined to use WOLFMQTT_PROPERTY_CB"
 #endif


### PR DESCRIPTION
Adds a new macro `WOLFMQTT_USE_CB_ON_DISCONNECT` that allows the client's registered disconnect callback to be triggered when `MqttClient_Disconnect_ex` is called. The CB is normally only used to process an error condition when `MqttPacket_HandleNetError` is called.

This addresses a feature request from ZD14399

Test with 
```
./configure CFLAGS="-DWOLFMQTT_USE_CB_ON_DISCONNECT"
make
./examples/mqttclient/mqttclient
```

Observe disconnect CB is executed:

```
MQTT Message: Done
^CReceived SIGINT
Network Error Callback: Error (Network) (error -8)
MQTT Exiting...
MQTT Unsubscribe: Success (0)
Network Error Callback: Success (error 0)
MQTT Disconnect: Success (0)
MQTT Socket Disconnect: Success (0)
```