### PR TITLE
Microchip XC32 no longer supports sys/errno.h from V4.0

### DIFF
--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -26,7 +26,8 @@
 
 #ifdef WOLFMQTT_NONBLOCK
     /* need EWOULDBLOCK and EAGAIN */
-    #ifdef MICROCHIP_MPLAB_HARMONY
+    #if defined(MICROCHIP_MPLAB_HARMONY) && ((__XC32_VERSION < 4000) || (__XC32_VERSION == 243739000))
+        // xc32 versions >= v4.0 no longer have sys/errno.h
         #include <sys/errno.h>
     #endif
     #include <errno.h>


### PR DESCRIPTION
Pre-processor compiler version flags for this change come from ( https://github.com/Microchip-MPLAB-Harmony/net/blob/2dd23ebaccec29104b8c9ab5614dbb0112f2bf8c/tcpip/src/berkeley_api.c#L53 ).