### PR TITLE
Add missing sem unlock for nonblocking + threaded

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1285,6 +1285,10 @@ wait_again:
     client->lastRc = rc;
     #endif
     if (rc == MQTT_CODE_CONTINUE) {
+    #ifdef WOLFMQTT_MULTITHREAD
+    /* if nonblocking and no data has been read, release read lock */
+        wm_SemUnlock(&client->lockRecv);
+    #endif
         return rc;
     }
 #endif


### PR DESCRIPTION
wolfMQTT's mutithreaded.unit test is always getting stuck with `--enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK -DWOLFMQTT_DEBUG_CLIENT"` on macOS.