### PR TITLE
Add MqttClient_PropsAdd_ex for multithreaded apps

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1502,7 +1502,7 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             mc_connect->stat.write == MQTT_MSG_AUTH)
     {
         MqttAuth auth, *p_auth = &auth;
-        MqttProp* prop, *conn_prop;
+        MqttProp prop, *conn_prop;
 
         /* Find the AUTH property in the connect structure */
         for (conn_prop = mc_connect->props;
@@ -1526,14 +1526,14 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         p_auth->reason_code = MQTT_REASON_CONT_AUTH;
 
         /* Use the same authentication method property from connect */
-        prop = MqttProps_Add(&p_auth->props);
-        prop->type = MQTT_PROP_AUTH_METHOD;
-        prop->data_str.str = conn_prop->data_str.str;
-        prop->data_str.len = conn_prop->data_str.len;
+        XMEMSET(&prop, 0, sizeof(MqttProp));
+        rc = MqttProps_Add_ex(&p_auth->props, &prop);
+        prop.type = MQTT_PROP_AUTH_METHOD;
+        prop.data_str.str = conn_prop->data_str.str;
+        prop.data_str.len = conn_prop->data_str.len;
 
         /* Send the AUTH packet */
         rc = MqttClient_Auth(client, p_auth);
-        MqttClient_PropsFree(p_auth->props);
     #ifdef WOLFMQTT_NONBLOCK
         if (rc == MQTT_CODE_CONTINUE)
             return rc;
@@ -2469,6 +2469,11 @@ MqttProp* MqttClient_PropsAdd(MqttProp **head)
 int MqttClient_PropsFree(MqttProp *head)
 {
     return MqttProps_Free(head);
+}
+
+int MqttClient_PropsAdd_ex(MqttProp **head, MqttProp *new_prop)
+{
+    return MqttProps_Add_ex(head, new_prop);
 }
 
 #endif /* WOLFMQTT_V5 */

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -395,7 +395,7 @@ WOLFMQTT_API int MqttClient_Ping_ex(MqttClient *client, MqttPing* ping);
 
 #ifdef WOLFMQTT_V5
 /*! \brief      Encodes and sends the MQTT Authentication Request packet and
-                waits for the Ping Response packet
+                waits for the broker AUTH packet
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
  *  \param      auth        Pointer to MqttAuth structure
@@ -410,8 +410,10 @@ WOLFMQTT_API int MqttClient_Auth(
 /*! \brief      Add a new property.
  *  Allocate a property structure and add it to the head of the list
     pointed to by head. To be used prior to calling packet command.
+    Properties added using this method use the internal stack, and must be
+    freed using MqttClient_PropsFree after the operation is complete.
  *  \param      head        Pointer-pointer to a property structure
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_BAD_ARG
+ *  \return     pointer to new MqttProp or NULL
  */
 WOLFMQTT_API MqttProp* MqttClient_PropsAdd(
     MqttProp **head);
@@ -424,8 +426,19 @@ WOLFMQTT_API MqttProp* MqttClient_PropsAdd(
  */
 WOLFMQTT_API int MqttClient_PropsFree(
     MqttProp *head);
-#endif
 
+/*! \brief      Add a new property.
+ *  Pass in a pointer to a locally allocated property structure and add it to
+    the head of the list pointed to by head. To be used prior to calling packet
+    command.
+ *  \param      head        Pointer-pointer to a property structure
+ *  \param      new_prop    Pointer to new property structure to be added.
+ *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_BAD_ARG
+ */
+WOLFMQTT_API int MqttClient_PropsAdd_ex(
+    MqttProp **head, MqttProp *new_prop);
+
+#endif
 
 /*! \brief      Encodes and sends the MQTT Disconnect packet (no response)
  *  \note This is a non-blocking function that will try and send using

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -709,6 +709,7 @@ WOLFMQTT_LOCAL int MqttDecode_Props(MqttPacketType packet, MqttProp** props,
 WOLFMQTT_LOCAL int MqttProps_Init(void);
 WOLFMQTT_LOCAL int MqttProps_ShutDown(void);
 WOLFMQTT_LOCAL MqttProp* MqttProps_Add(MqttProp **head);
+WOLFMQTT_LOCAL int MqttProps_Add_ex(MqttProp **head, MqttProp *new_prop);
 WOLFMQTT_LOCAL int MqttProps_Free(MqttProp *head);
 WOLFMQTT_LOCAL MqttProp* MqttProps_FindType(MqttProp *head,
     MqttPropertyType type);


### PR DESCRIPTION
- Multithreaded apps will need to use `MqttClient_PropsAdd_ex` for manipulating properties add to V5 commands. This differs in that the properties are not allocated from the internal property stack. As a result, when `MqttClient_PropsAdd_ex` is used, `MqttClient_PropsFree` will not be used after the command.
- Added mutex protection in `MqttDecode_Props` to fix a possible race condition.
- Added sleep in wait task of multithread example to allow ping task to execute more than once.