### PR TITLE
Adding publish and subscribe atomic client examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ examples/sn-client/sn-client_qos-1
 examples/sn-client/sn-multithread
 examples/multithread/multithread
 examples/wiot/wiot
+examples/pub-sub/mqtt-pub
+examples/pub-sub/mqtt-sub
 
 # eclipse
 .cproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ if (WOLFMQTT_EXAMPLES)
     add_mqtt_example(azureiothub azure/azureiothub.c)
     add_mqtt_example(fwpush firmware/fwpush.c)
     add_mqtt_example(fwclient firmware/fwclient.c)
+    add_mqtt_example(mqtt-pub pub-sub/mqtt-pub.c)
+    add_mqtt_example(mqtt-pub pub-sub/mqtt-sub.c)
 endif()
 
 ####################################################

--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ WolfGatewayQoS-1,wolfMQTT/example/testTopic, 1
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 
+### Atomic publish and subscribe examples
+In the `examples/pub-sub` folder, there are two simple client examples:
+* mqtt-pub - publishes to a topic
+* mqtt-sub - subscribes to a topic and waits for messages
+
+These examples are useful for quickly testing or scripting.
+
 ## Example Options
 The command line examples can be executed with optional parameters. To see a list of the available parameters, add the `-?`
 

--- a/examples/include.am
+++ b/examples/include.am
@@ -13,7 +13,9 @@ noinst_PROGRAMS += examples/mqttclient/mqttclient \
                    examples/multithread/multithread \
                    examples/sn-client/sn-client \
                    examples/sn-client/sn-client_qos-1 \
-                   examples/sn-client/sn-multithread
+                   examples/sn-client/sn-multithread \
+                   examples/pub-sub/mqtt-pub \
+                   examples/pub-sub/mqtt-sub
 
 noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
                    examples/mqttsimple/mqttsimple.h \
@@ -28,7 +30,8 @@ noinst_HEADERS +=  examples/mqttclient/mqttclient.h \
                    examples/mqttport.h \
                    examples/nbclient/nbclient.h \
                    examples/multithread/multithread.h \
-                   examples/sn-client/sn-client.h
+                   examples/sn-client/sn-client.h \
+                   examples/pub-sub/mqtt-pub-sub.h
 
 # MQTT Client Example
 examples_mqttclient_mqttclient_SOURCES      = examples/mqttclient/mqttclient.c \
@@ -127,6 +130,21 @@ examples_sn_client_sn_multithread_SOURCES       = examples/sn-client/sn-multithr
 examples_sn_client_sn_multithread_LDADD         = src/libwolfmqtt.la
 examples_sn_client_sn_multithread_DEPENDENCIES  = src/libwolfmqtt.la
 examples_sn_client_sn_multithread_CPPFLAGS      = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
+
+# MQTT pub and sub clients
+examples_pub_sub_mqtt_pub_SOURCES      = examples/pub-sub/mqtt-pub.c \
+                                         examples/mqttnet.c \
+                                         examples/mqttexample.c
+examples_pub_sub_mqtt_pub_LDADD        = src/libwolfmqtt.la
+examples_pub_sub_mqtt_pub_DEPENDENCIES = src/libwolfmqtt.la
+examples_pub_sub_mqtt_pub_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
+
+examples_pub_sub_mqtt_sub_SOURCES      = examples/pub-sub/mqtt-sub.c \
+                                         examples/mqttnet.c \
+                                         examples/mqttexample.c
+examples_pub_sub_mqtt_sub_LDADD        = src/libwolfmqtt.la
+examples_pub_sub_mqtt_sub_DEPENDENCIES = src/libwolfmqtt.la
+examples_pub_sub_mqtt_sub_CPPFLAGS     = -I$(top_srcdir)/examples $(AM_CPPFLAGS)
 endif
 
 
@@ -145,6 +163,8 @@ dist_example_DATA+= examples/multithread/multithread.c
 dist_example_DATA+= examples/sn-client/sn-client.c
 dist_example_DATA+= examples/sn-client/sn-client_qos-1.c
 dist_example_DATA+= examples/sn-client/sn-multithread.c
+dist_example_DATA+= examples/pub-sub/mqtt-pub.c
+dist_example_DATA+= examples/pub-sub/mqtt-sub.c
 
 DISTCLEANFILES+=   examples/mqttclient/.libs/mqttclient \
                    examples/firmware/.libs/fwpush \
@@ -156,7 +176,9 @@ DISTCLEANFILES+=   examples/mqttclient/.libs/mqttclient \
                    examples/multithread/.libs/multithread \
                    examples/sn-client/.libs/sn-client \
                    examples/sn-client/.libs/sn-client_qos-1 \
-                   examples/sn-client/.libs/sn-multithread
+                   examples/sn-client/.libs/sn-multithread \
+                   examples/pub-sub/mqtt-pub \
+                   examples/pub-sub/mqtt-sub
 
 EXTRA_DIST+=       examples/mqttuart.c \
                    examples/publish.dat \

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -247,6 +247,9 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
 #endif
     PRINTF("-T          Test mode");
     PRINTF("-f <file>   Use file contents for publish");
+    if (!mqttCtx->debug_on) {
+        PRINTF("-d          Enable example debug messages");
+    }
 }
 
 void mqtt_init_ctx(MQTTCtx* mqttCtx)
@@ -259,6 +262,7 @@ void mqtt_init_ctx(MQTTCtx* mqttCtx)
     mqttCtx->client_id = kDefClientId;
     mqttCtx->topic_name = kDefTopicName;
     mqttCtx->cmd_timeout_ms = DEFAULT_CMD_TIMEOUT_MS;
+    mqttCtx->debug_on = 1;
 #ifdef WOLFMQTT_V5
     mqttCtx->max_packet_size = DEFAULT_MAX_PKT_SZ;
     mqttCtx->topic_alias = 1;
@@ -286,7 +290,7 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
         #define MQTT_V5_ARGS ""
     #endif
 
-    while ((rc = mygetopt(argc, argv, "?h:p:q:sk:i:lu:w:m:n:C:Tf:rt" \
+    while ((rc = mygetopt(argc, argv, "?h:p:q:sk:i:lu:w:m:n:C:Tf:rtd" \
             MQTT_TLS_ARGS MQTT_V5_ARGS)) != -1) {
         switch ((char)rc) {
         case '?' :
@@ -362,6 +366,10 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv)
 
         case 't':
             mqttCtx->use_tls = 1;
+            break;
+
+        case 'd':
+            mqttCtx->debug_on = 1;
             break;
 
     #ifdef ENABLE_MQTT_TLS

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -168,6 +168,7 @@ typedef struct _MQTTCtx {
 #endif
     byte    clean_session;
     byte    test_mode;
+    byte    debug_on:1; /* enable debug messages in example */
 #ifdef WOLFMQTT_V5
     byte    subId_not_avail; /* Server property */
     byte    enable_eauth; /* Enhanced authentication */

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -76,8 +76,10 @@ static int NetConnect(void *context, const char* host, word16 port,
 
     switch (sock->stat) {
     case SOCK_BEGIN:
-        PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use TLS %d",
-            host, port, timeout_ms, mqttCtx->use_tls);
+        if (mqttCtx->debug_on) {
+            PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use TLS %d",
+                host, port, timeout_ms, mqttCtx->use_tls);
+        }
 
         hostIp = FreeRTOS_gethostbyname_a(host, NULL, 0, 0);
         if (hostIp == 0)
@@ -255,9 +257,10 @@ static int NetConnect(void *context, const char* host, word16 port,
     switch(sock->stat) {
         case SOCK_BEGIN:
         {
-            PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use TLS %d",
-                host, port, timeout_ms, mqttCtx->use_tls);
-
+            if (mqttCtx->debug_on) {
+                PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, "
+                        "Use TLS %d", host, port, timeout_ms, mqttCtx->use_tls);
+            }
             XMEMSET(&hints, 0, sizeof(hints));
             hints.ai_family = AF_INET;
             hints.ai_socktype = SOCK_STREAM;
@@ -446,8 +449,10 @@ static int NetConnect(void *context, const char* host, word16 port,
     switch(sock->stat) {
         case SOCK_BEGIN:
         {
-            PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use TLS %d",
-                host, port, timeout_ms, mqttCtx->use_tls);
+            if (mqttCtx->debug_on) {
+                PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, "
+                        "Use TLS %d", host, port, timeout_ms, mqttCtx->use_tls);
+            }
 
             XMEMSET(&hints, 0, sizeof(hints));
             hints.ai_family = AF_INET;

--- a/examples/pub-sub/mqtt-pub-sub.h
+++ b/examples/pub-sub/mqtt-pub-sub.h
@@ -1,0 +1,43 @@
+/* mqtt-pub-sub
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfMQTT.
+ *
+ * wolfMQTT is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfMQTT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFMQTT_PUB_SUB_H
+#define WOLFMQTT_PUB_SUB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Exposed functions */
+int pub_client(MQTTCtx *mqttCtx);
+int sub_client(MQTTCtx *mqttCtx);
+
+#if defined(NO_MAIN_DRIVER)
+int mqttPub_main(int argc, char** argv);
+int mqttSub_main(int argc, char** argv);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFMQTT_PUB_SUB_H */

--- a/examples/pub-sub/mqtt-sub.c
+++ b/examples/pub-sub/mqtt-sub.c
@@ -1,4 +1,4 @@
-/* mqttclient.c
+/* mqtt-sub.c
  *
  * Copyright (C) 2006-2023 wolfSSL Inc.
  *
@@ -24,8 +24,8 @@
     #include <config.h>
 #endif
 
-#include "mqttclient.h"
 #include "examples/mqttnet.h"
+#include "examples/pub-sub/mqtt-pub-sub.h"
 
 /* Locals */
 static int mStopRead = 0;
@@ -45,10 +45,13 @@ char gClientId[MAX_CLIENT_ID_LEN] = {0};
 /* callback indicates a network error occurred */
 static int mqtt_disconnect_cb(MqttClient* client, int error_code, void* ctx)
 {
-    (void)client;
+    MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
     (void)ctx;
-    PRINTF("Network Error Callback: %s (error %d)",
-        MqttClient_ReturnCodeToString(error_code), error_code);
+
+    if (mqttCtx->debug_on) {
+        PRINTF("Network Error Callback: %s (error %d)",
+            MqttClient_ReturnCodeToString(error_code), error_code);
+    }
     return 0;
 }
 #endif
@@ -71,18 +74,10 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         XMEMCPY(buf, msg->topic_name, len);
         buf[len] = '\0'; /* Make sure its null terminated */
 
-        /* Print incoming message */
-        PRINTF("MQTT Message: Topic %s, Qos %d, Len %u",
-            buf, msg->qos, msg->total_len);
-
-        /* for test mode: check if DEFAULT_MESSAGE was received */
-        if (mqttCtx->test_mode) {
-            if (XSTRLEN(DEFAULT_MESSAGE) == msg->buffer_len &&
-                XSTRNCMP(DEFAULT_MESSAGE, (char*)msg->buffer,
-                         msg->buffer_len) == 0)
-            {
-                mStopRead = 1;
-            }
+        if (mqttCtx->debug_on) {
+            /* Print incoming message */
+            PRINTF("MQTT Message: Topic %s, Qos %d, Len %u",
+                buf, msg->qos, msg->total_len);
         }
     }
 
@@ -93,8 +88,13 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     XMEMCPY(buf, msg->buffer, len);
     buf[len] = '\0'; /* Make sure its null terminated */
-    PRINTF("Payload (%d - %d) printing %d bytes:" LINE_END "%s",
-        msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
+    if (mqttCtx->debug_on) {
+        PRINTF("Payload (%d - %d) printing %d bytes:" LINE_END "%s",
+            msg->buffer_pos, msg->buffer_pos + msg->buffer_len, len, buf);
+    }
+    else {
+        PRINTF("%s", buf);
+    }
 
     #ifdef WOLFMQTT_V5
     {
@@ -111,7 +111,7 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
     }
     #endif
 
-    if (msg_done) {
+    if (msg_done && mqttCtx->debug_on) {
         PRINTF("MQTT Message: Done");
     }
 
@@ -231,17 +231,20 @@ static int mqtt_property_cb(MqttClient *client, MqttProp *head, void *ctx)
 }
 #endif /* WOLFMQTT_PROPERTY_CB */
 
-int mqttclient_test(MQTTCtx *mqttCtx)
+int sub_client(MQTTCtx *mqttCtx)
 {
     int rc = MQTT_CODE_SUCCESS, i;
 
-    PRINTF("MQTT Client: QoS %d, Use TLS %d", mqttCtx->qos,
-            mqttCtx->use_tls);
-
+    if (mqttCtx->debug_on) {
+        PRINTF("Subscribe Client: QoS %d, Use TLS %d", mqttCtx->qos,
+                mqttCtx->use_tls);
+    }
     /* Initialize Network */
     rc = MqttClientNet_Init(&mqttCtx->net, mqttCtx);
-    PRINTF("MQTT Net Init: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Net Init: %s (%d)",
+                MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto exit;
     }
@@ -257,8 +260,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         mqttCtx->rx_buf, MAX_BUFFER_SIZE,
         mqttCtx->cmd_timeout_ms);
 
-    PRINTF("MQTT Init: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Init: %s (%d)",
+                MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto exit;
     }
@@ -287,8 +292,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
            mqttCtx->port,
         DEFAULT_CON_TIMEOUT_MS, mqttCtx->use_tls, mqtt_tls_cb);
 
-    PRINTF("MQTT Socket Connect: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Socket Connect: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto exit;
     }
@@ -326,16 +333,7 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     mqttCtx->connect.password = mqttCtx->password;
 #ifdef WOLFMQTT_V5
     mqttCtx->client.packet_sz_max = mqttCtx->max_packet_size;
-    mqttCtx->client.enable_eauth = mqttCtx->enable_eauth;
 
-    if (mqttCtx->client.enable_eauth == 1) {
-        /* Enhanced authentication */
-        /* Add property: Authentication Method */
-        MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->connect.props);
-        prop->type = MQTT_PROP_AUTH_METHOD;
-        prop->data_str.str = (char*)DEFAULT_AUTH_METHOD;
-        prop->data_str.len = (word16)XSTRLEN(prop->data_str.str);
-    }
     {
         /* Request Response Information */
         MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->connect.props);
@@ -371,9 +369,11 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     /* Send Connect and wait for Connect Ack */
     rc = MqttClient_Connect(&mqttCtx->client, &mqttCtx->connect);
 
-    PRINTF("MQTT Connect: Proto (%s), %s (%d)",
-        MqttClient_GetProtocolVersionString(&mqttCtx->client),
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Connect: Proto (%s), %s (%d)",
+            MqttClient_GetProtocolVersionString(&mqttCtx->client),
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto disconn;
     }
@@ -389,19 +389,20 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     }
 #endif
 
-    /* Validate Connect Ack info */
-    PRINTF("MQTT Connect Ack: Return Code %u, Session Present %d",
-        mqttCtx->connect.ack.return_code,
-        (mqttCtx->connect.ack.flags &
-            MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT) ?
-            1 : 0
-    );
-
+    if (mqttCtx->debug_on) {
+        /* Validate Connect Ack info */
+        PRINTF("MQTT Connect Ack: Return Code %u, Session Present %d",
+            mqttCtx->connect.ack.return_code,
+            (mqttCtx->connect.ack.flags &
+                MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT) ?
+                1 : 0
+        );
 #ifdef WOLFMQTT_PROPERTY_CB
         /* Print the acquired client ID */
         PRINTF("MQTT Connect Ack: Assigned Client ID: %s",
                 mqttCtx->client_id);
 #endif
+    }
 
     /* Build list of topics */
     XMEMSET(&mqttCtx->subscribe, 0, sizeof(MqttSubscribe));
@@ -435,107 +436,29 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     }
 #endif
 
-    PRINTF("MQTT Subscribe: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Subscribe: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto disconn;
     }
 
-    /* show subscribe results */
-    for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
-        MqttTopic *topic = &mqttCtx->subscribe.topics[i];
-        PRINTF("  Topic %s, Qos %u, Return Code %u",
-            topic->topic_filter,
-            topic->qos, topic->return_code);
-    }
-
-    /* Publish Topic */
-    XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
-    mqttCtx->publish.retain = 0;
-    mqttCtx->publish.qos = mqttCtx->qos;
-    mqttCtx->publish.duplicate = 0;
-    mqttCtx->publish.topic_name = mqttCtx->topic_name;
-    mqttCtx->publish.packet_id = mqtt_get_packetid();
-
-    if (mqttCtx->pub_file) {
-        /* If a file is specified, then read into the allocated buffer */
-        rc = mqtt_file_load(mqttCtx->pub_file, &mqttCtx->publish.buffer,
-                (int*)&mqttCtx->publish.total_len);
-        if (rc != MQTT_CODE_SUCCESS) {
-            /* There was an error loading the file */
-            PRINTF("MQTT Publish file error: %d", rc);
+    if (mqttCtx->debug_on) {
+        /* show subscribe results */
+        for (i = 0; i < mqttCtx->subscribe.topic_count; i++) {
+            MqttTopic *topic = &mqttCtx->subscribe.topics[i];
+            PRINTF("  Topic %s, Qos %u, Return Code %u",
+                topic->topic_filter,
+                topic->qos, topic->return_code);
         }
     }
-    else {
-        mqttCtx->publish.buffer = (byte*)mqttCtx->message;
-        mqttCtx->publish.total_len = (word16)XSTRLEN(mqttCtx->message);
-    }
-
-    if (rc == MQTT_CODE_SUCCESS) {
-    #ifdef WOLFMQTT_V5
-        {
-            /* Payload Format Indicator */
-            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-            prop->type = MQTT_PROP_PAYLOAD_FORMAT_IND;
-            prop->data_byte = 1;
-        }
-        {
-            /* Content Type */
-            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-            prop->type = MQTT_PROP_CONTENT_TYPE;
-            prop->data_str.str = (char*)"wolf_type";
-            prop->data_str.len = (word16)XSTRLEN(prop->data_str.str);
-        }
-        if ((mqttCtx->topic_alias_max > 0) &&
-            (mqttCtx->topic_alias > 0) &&
-            (mqttCtx->topic_alias < mqttCtx->topic_alias_max)) {
-            /* Topic Alias */
-            MqttProp* prop = MqttClient_PropsAdd(&mqttCtx->publish.props);
-            prop->type = MQTT_PROP_TOPIC_ALIAS;
-            prop->data_short = mqttCtx->topic_alias;
-        }
-    #endif
-
-        /* This loop allows payloads larger than the buffer to be sent by
-           repeatedly calling publish.
-        */
-        do {
-            rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-        } while(rc == MQTT_CODE_PUB_CONTINUE);
-
-        if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
-            WOLFMQTT_FREE(mqttCtx->publish.buffer);
-        }
-
-        PRINTF("MQTT Publish: Topic %s, %s (%d)",
-            mqttCtx->publish.topic_name,
-            MqttClient_ReturnCodeToString(rc), rc);
-    #ifdef WOLFMQTT_V5
-        if (mqttCtx->qos > 0) {
-            PRINTF("\tResponse Reason Code %d", mqttCtx->publish.resp.reason_code);
-        }
-    #endif
-        if (rc != MQTT_CODE_SUCCESS) {
-            goto disconn;
-        }
-    #ifdef WOLFMQTT_V5
-        if (mqttCtx->publish.props != NULL) {
-            /* Release the allocated properties */
-            MqttClient_PropsFree(mqttCtx->publish.props);
-        }
-    #endif
-    }
-
     /* Read Loop */
-    PRINTF("MQTT Waiting for message...");
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Waiting for message...");
+    }
 
     do {
-        /* check for test mode */
-        if (mqttCtx->test_mode) {
-            PRINTF("MQTT Test mode, exit now");
-            break;
-        }
-
         /* Try and read packet */
         rc = MqttClient_WaitMessage(&mqttCtx->client,
                                             mqttCtx->cmd_timeout_ms);
@@ -548,7 +471,9 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
         if (mStopRead) {
             rc = MQTT_CODE_SUCCESS;
-            PRINTF("MQTT Exiting...");
+            if (mqttCtx->debug_on) {
+                PRINTF("MQTT Exiting...");
+            }
             break;
         }
 
@@ -557,32 +482,15 @@ int mqttclient_test(MQTTCtx *mqttCtx)
         else if (rc == MQTT_CODE_STDIN_WAKE) {
             XMEMSET(mqttCtx->rx_buf, 0, MAX_BUFFER_SIZE);
             if (XFGETS((char*)mqttCtx->rx_buf, MAX_BUFFER_SIZE - 1,
-                    stdin) != NULL)
-            {
-                rc = (int)XSTRLEN((char*)mqttCtx->rx_buf);
-
-                /* Publish Topic */
-                mqttCtx->stat = WMQ_PUB;
-                XMEMSET(&mqttCtx->publish, 0, sizeof(MqttPublish));
-                mqttCtx->publish.retain = 0;
-                mqttCtx->publish.qos = mqttCtx->qos;
-                mqttCtx->publish.duplicate = 0;
-                mqttCtx->publish.topic_name = mqttCtx->topic_name;
-                mqttCtx->publish.packet_id = mqtt_get_packetid();
-                mqttCtx->publish.buffer = mqttCtx->rx_buf;
-                mqttCtx->publish.total_len = (word16)rc;
-                rc = MqttClient_Publish(&mqttCtx->client,
-                       &mqttCtx->publish);
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
-                    MqttClient_ReturnCodeToString(rc), rc);
+                    stdin) != NULL) {
             }
         }
     #endif
         else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
             /* Keep Alive */
-            PRINTF("Keep-alive timeout, sending ping");
-
+            if (mqttCtx->debug_on) {
+                PRINTF("Keep-alive timeout, sending ping");
+            }
             rc = MqttClient_Ping_ex(&mqttCtx->client, &mqttCtx->ping);
             if (rc != MQTT_CODE_SUCCESS) {
                 PRINTF("MQTT Ping Keep Alive Error: %s (%d)",
@@ -614,8 +522,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     rc = MqttClient_Unsubscribe(&mqttCtx->client,
            &mqttCtx->unsubscribe);
 
-    PRINTF("MQTT Unsubscribe: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Unsubscribe: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
     if (rc != MQTT_CODE_SUCCESS) {
         goto disconn;
     }
@@ -646,14 +556,16 @@ disconn:
     }
 #endif
 
-    PRINTF("MQTT Disconnect: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
-
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Disconnect: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
     rc = MqttClient_NetDisconnect(&mqttCtx->client);
 
-    PRINTF("MQTT Socket Disconnect: %s (%d)",
-        MqttClient_ReturnCodeToString(rc), rc);
-
+    if (mqttCtx->debug_on) {
+        PRINTF("MQTT Socket Disconnect: %s (%d)",
+            MqttClient_ReturnCodeToString(rc), rc);
+    }
 exit:
 
     /* Free resources */
@@ -677,7 +589,6 @@ exit:
         {
             if (fdwCtrlType == CTRL_C_EVENT) {
                 mStopRead = 1;
-                PRINTF("Received Ctrl+c");
                 return TRUE;
             }
             return FALSE;
@@ -688,13 +599,12 @@ exit:
         {
             if (signo == SIGINT) {
                 mStopRead = 1;
-                PRINTF("Received SIGINT");
             }
         }
     #endif
 
 #if defined(NO_MAIN_DRIVER)
-int mqttclient_main(int argc, char** argv)
+int mqttSub_main(int argc, char** argv)
 #else
 int main(int argc, char** argv)
 #endif
@@ -704,6 +614,15 @@ int main(int argc, char** argv)
 
     /* init defaults */
     mqtt_init_ctx(&mqttCtx);
+
+    /* Set default client ID */
+    mqttCtx.client_id = "wolfMQTT_sub";
+
+    /* Set default host to localhost */
+    mqttCtx.host = "localhost";
+
+    /* Set example debug messages off (turn on with '-d') */
+    mqttCtx.debug_on = 0;
 
     /* parse arguments */
     rc = mqtt_parse_args(&mqttCtx, argc, argv);
@@ -727,7 +646,7 @@ int main(int argc, char** argv)
     }
 #endif
 
-    rc = mqttclient_test(&mqttCtx);
+    rc = sub_client(&mqttCtx);
 
     mqtt_free_ctx(&mqttCtx);
 


### PR DESCRIPTION
New examples in `examples/pub-sub`

These can be used for quickly testing MQTT application or scripting.

By default, they connect to localhost. Specify a topic with `-n`
`./examples/pub-sub/mqtt-sub -n '#'`

`./examples/pub-sub/mqtt-pub -n test -m "Hello world!"`

Enable verbose example debug with `-d`

