### PR TITLE
Add DTLS support to MQTT-SN client

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,26 +189,7 @@ This example enables the wolfMQTT client to connect to the IBM Watson Internet o
 ### MQTT-SN Example
 The Sensor Network client implements the MQTT-SN protocol for low-bandwidth networks. There are several differences from MQTT, including the ability to use a two byte Topic ID instead the full topic during subscribe and publish. The SN client requires an MQTT-SN gateway. The gateway acts as an intermediary between the SN clients and the broker. This client was tested with the Eclipse Paho MQTT-SN Gateway, which connects by default to the public Eclipse broker, much like our wolfMQTT Client example. The address of the gateway must be configured as the host. The example is located in `/examples/sn-client/`.
 
-A special feature of MQTT-SN is the ability to use QoS level -1 (negative one) to publish to a predefined topic without first connecting to the gateway. There is no feedback in the application if there was an error, so confirmation of the test would involve running the `sn-client` first and watching for the publish from the `sn-client_qos-1`. There is an example provided in `/examples/sn-client/sn-client_qos-1`. It requires some configuration changes of the gateway.
-
-* Enable the the QoS-1 feature, predefined topics, and change the gateway name in `gateway.conf`:
-
-```
-QoS-1=YES
-PredefinedTopic=YES
-PredefinedTopicList=./predefinedTopic.conf
-.
-.
-.
-#GatewayName=PahoGateway-01
-GatewayName=WolfGateway
-```
-
-* Comment out all entries and add a new topic in `predefinedTopic.conf`:
-
-```
-WolfGatewayQoS-1,wolfMQTT/example/testTopic, 1
-```
+More about MQTT-SN examples in [examples/sn-client/README.md](examples/sn-client/README.md)
 
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.

--- a/examples/include.am
+++ b/examples/include.am
@@ -168,4 +168,5 @@ EXTRA_DIST+=       examples/mqttuart.c \
                    examples/aws/awsiot.vcxproj \
                    examples/wiot/wiot.vcxproj \
                    examples/sn-client/sn-client.vcxproj \
+                   examples/sn-client/README.md \
                    examples/multithread/multithread.vcxproj

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -188,6 +188,11 @@ int mqtt_parse_args(MQTTCtx* mqttCtx, int argc, char** argv);
 int err_sys(const char* msg);
 
 int mqtt_tls_cb(MqttClient* client);
+
+#ifdef WOLFMQTT_SN
+int mqtt_dtls_cb(MqttClient* client);
+#endif
+
 word16 mqtt_get_packetid(void);
 
 #ifdef WOLFMQTT_NONBLOCK

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -24,37 +24,13 @@
     #include <config.h>
 #endif
 
-#include "wolfmqtt/mqtt_client.h"
 #include "examples/mqttnet.h"
-#include "examples/mqttexample.h"
-#include "examples/mqttport.h"
-
-/* Local context for Net callbacks */
-typedef enum {
-    SOCK_BEGIN = 0,
-    SOCK_CONN
-} NB_Stat;
 
 #if 0 /* TODO: add multicast support */
 typedef struct MulticastCtx {
 
 } MulticastCtx;
 #endif
-
-
-typedef struct _SocketContext {
-    SOCKET_T fd;
-    NB_Stat stat;
-    SOCK_ADDR_IN addr;
-#ifdef MICROCHIP_MPLAB_HARMONY
-    word32 bytes;
-#endif
-#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
-    /* "self pipe" -> signal wake sleep() */
-    SOCKET_T pfd[2];
-#endif
-    MQTTCtx* mqttCtx;
-} SocketContext;
 
 /* Private functions */
 
@@ -578,7 +554,7 @@ static int SN_NetConnect(void *context, const char* host, word16 port,
     struct addrinfo hints;
     MQTTCtx* mqttCtx = sock->mqttCtx;
 
-    PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use TLS %d",
+    PRINTF("NetConnect: Host %s, Port %u, Timeout %d ms, Use DTLS %d",
         host, port, timeout_ms, mqttCtx->use_tls);
 
     /* Get address information for host and locate IPv4 */
@@ -830,6 +806,12 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
             }
             else {
                 bytes += rc; /* Data */
+    #ifdef ENABLE_MQTT_TLS
+                if (MqttClient_Flags(&mqttCtx->client, 0, 0)
+                    & MQTT_CLIENT_FLAG_IS_TLS) {
+                    break;
+                }
+    #endif
             }
         }
 

--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -27,6 +27,27 @@
 #endif
 
 #include "examples/mqttexample.h"
+#include "examples/mqttport.h"
+
+/* Local context for Net callbacks */
+typedef enum {
+    SOCK_BEGIN = 0,
+    SOCK_CONN
+} NB_Stat;
+
+typedef struct _SocketContext {
+    SOCKET_T fd;
+    NB_Stat stat;
+    SOCK_ADDR_IN addr;
+#ifdef MICROCHIP_MPLAB_HARMONY
+    word32 bytes;
+#endif
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_ENABLE_STDIN_CAP)
+    /* "self pipe" -> signal wake sleep() */
+    SOCKET_T pfd[2];
+#endif
+    MQTTCtx* mqttCtx;
+} SocketContext;
 
 /* Functions used to handle the MqttNet structure creation / destruction */
 int MqttClientNet_Init(MqttNet* net, MQTTCtx* mqttCtx);

--- a/examples/sn-client/README.md
+++ b/examples/sn-client/README.md
@@ -1,0 +1,82 @@
+# MQTT-SN Example
+The Sensor Network client implements the MQTT-SN protocol for low-bandwidth networks. There are several differences from MQTT, including the ability to use a two byte Topic ID instead the full topic during subscribe and publish. The SN client requires an MQTT-SN gateway. The gateway acts as an intermediary between the SN clients and the broker. This client was tested with the Eclipse Paho MQTT-SN Gateway, which connects by default to the public Eclipse broker, much like our wolfMQTT Client example. The address of the gateway must be configured as the host. The example is located in `/examples/sn-client/`.
+
+To enable Sensor Network protocol support, configure wolfMQTT using:
+`./configure --enable-sn`
+
+## QoS-1
+A special feature of MQTT-SN is the ability to use QoS level -1 (negative one) to publish to a predefined topic without first connecting to the gateway. There is no feedback in the application if there was an error, so confirmation of the test would involve running the `sn-client` first and watching for the publish from the `sn-client_qos-1`. There is an example provided in `/examples/sn-client/sn-client_qos-1`. It requires some configuration changes of the gateway.
+
+* Enable the the QoS-1 feature, predefined topics, and change the gateway name in `gateway.conf`:
+
+```
+QoS-1=YES
+PredefinedTopic=YES
+PredefinedTopicList=./predefinedTopic.conf
+.
+.
+.
+#GatewayName=PahoGateway-01
+GatewayName=WolfGateway
+```
+
+* Comment out all entries and add a new topic in `predefinedTopic.conf`:
+
+```
+WolfGatewayQoS-1,wolfMQTT/example/testTopic, 1
+```
+
+## MQTT-SN with DTLS
+MQTT-SN can be secured using DTLS. This enables encryption of sensor data to the gateway. The Eclipse Paho MQTT-SN Gateway supports DTLS clients.
+
+To build the Eclipse Paho MQTT-SN Gateway with DTLS:
+`<gateway-folder>/MQTTSNGateway$ ./build.sh dtls`
+
+To build wolfSSL with DTLS support:
+`./configure --enable-dtls && make && sudo make install`
+
+To run the wolfMQTT sn-client example with DTLS:
+`./examples/sn-client/sn-client -t`
+
+### Notes for Gateway configuration
+* To use with local mosquitto broker, edit MQTTSNGateway/gateway.conf. Also set paths to DTLS cert / key.
+
+```
+-BrokerName=mqtt.eclipseprojects.io
++BrokerName=localhost
+
+...
+
+-DtlsCertsKey=/etc/ssl/certs/gateway.pem
+-DtlsPrivKey=/etc/ssl/private/privkey.pem
++#DtlsCertsKey=/etc/ssl/certs/gateway.pem
++DtlsCertsKey=/<path_to_repo>/wolfssl/certs/server-cert.pem
++#DtlsPrivKey=/etc/ssl/private/privkey.pem
++DtlsPrivKey=/<path_to_repo>/wolfssl/certs/server-key.pem
+```
+* I had to fix a bug in the gateway (could be related to the openssl or compiler version):
+
+```
+diff --git a/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp b/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
+index 3f2dcf3..363d0ba 100644
+--- a/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
++++ b/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
+@@ -308,7 +308,7 @@ Connections::~Connections()
+     {
+         for (int i = 0; i < _numfds; i++)
+         {
+-            if (_ssls[i] > 0)
++            if (_ssls[i] > (SSL *)0)
+             {
+                 SSL_shutdown(_ssls[i]);
+                 SSL_free(_ssls[i]);
+@@ -416,7 +416,7 @@ void Connections::close(int index)
+         }
+     }
+ 
+-    if (ssl > 0)
++    if (ssl > (SSL *)0)
+     {
+         _numfds--;
+         SSL_shutdown(ssl);
+```

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2780,6 +2780,24 @@ const char* MqttClient_ReturnCodeToString(int return_code)
 }
 #endif /* !WOLFMQTT_NO_ERROR_STRINGS */
 
+word32 MqttClient_Flags(MqttClient *client,  word32 mask, word32 flags)
+{
+    word32 ret = 0;
+    if (client != NULL) {
+#ifdef WOLFMQTT_MULTITHREAD
+        /* Get client lock on to ensure no other threads are active */
+        wm_SemLock(&client->lockClient);
+#endif
+        client->flags &= ~mask;
+        client->flags |= flags;
+        ret = client->flags;
+#ifdef WOLFMQTT_MULTITHREAD
+        wm_SemUnlock(&client->lockClient);
+#endif
+    }
+    return ret;
+}
+
 #ifdef WOLFMQTT_SN
 
 /* Private functions */

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -96,9 +96,18 @@ typedef int (*MqttPublishCb)(MqttPublish* publish);
 
 /* Client flags */
 enum MqttClientFlags {
-    MQTT_CLIENT_FLAG_IS_CONNECTED = 0x01,
-    MQTT_CLIENT_FLAG_IS_TLS = 0x02
+    MQTT_CLIENT_FLAG_IS_CONNECTED = 0x01 << 0,
+    MQTT_CLIENT_FLAG_IS_TLS       = 0x01 << 1,
+    MQTT_CLIENT_FLAG_IS_DTLS      = 0x01 << 2
 };
+/*! \brief      Sets flags in the MqttClient structure. To be used from
+                the application before calling MqttClient_NetConnect.
+ *  \param      client      Pointer to MqttClient structure
+ *  \param      mask        Flags to clear
+ *  \param      flags       Flags to set
+ *  \return     Value of flags in the MqttClient structure
+ */
+WOLFMQTT_API word32 MqttClient_Flags(struct _MqttClient *client,  word32 mask, word32 flags);
 
 typedef enum _MqttPkStat {
     MQTT_PK_BEGIN,
@@ -510,11 +519,11 @@ WOLFMQTT_API int MqttClient_IsMessageActive(
  *  \param      client      Pointer to MqttClient structure
  *  \param      host        Address of the broker server
  *  \param      port        Optional custom port. If zero will use defaults
+ *  \param      timeout_ms  Milliseconds until read timeout
  *  \param      use_tls     If non-zero value will connect with and use TLS for
                             encryption of data
  *  \param      cb          A function callback for configuration of the SSL
                             context certificate checking
- *  \param      timeout_ms  Milliseconds until read timeout
  *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
                 (see enum MqttPacketResponseCodes)
  */

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -98,7 +98,7 @@ WOLFMQTT_LOCAL int MqttSocket_Read(struct _MqttClient *client, byte* buf,
 #ifdef WOLFMQTT_SN
 WOLFMQTT_LOCAL int MqttSocket_Peek(struct _MqttClient *client, byte* buf,
         int buf_len, int timeout_ms);
-#endif
+#endif /* WOLFMQTT_SN */
 WOLFMQTT_LOCAL int MqttSocket_Connect(struct _MqttClient *client,
         const char* host, word16 port, int timeout_ms, int use_tls,
         MqttTlsCb cb);


### PR DESCRIPTION
Tested with mosquitto as broker, https://github.com/eclipse/paho.mqtt-sn.embedded-c as gateway.

1. To use with local mosquitto broker, edit `MQTTSNGateway/gateway.conf`. Also set paths to DTLS cert / key.
```
-BrokerName=mqtt.eclipseprojects.io
+BrokerName=localhost

...

-DtlsCertsKey=/etc/ssl/certs/gateway.pem
-DtlsPrivKey=/etc/ssl/private/privkey.pem
+#DtlsCertsKey=/etc/ssl/certs/gateway.pem
+DtlsCertsKey=/<path_to_repo>/wolfssl/certs/server-cert.pem
+#DtlsPrivKey=/etc/ssl/private/privkey.pem
+DtlsPrivKey=/<path_to_repo>/wolfssl/certs/server-key.pem
```
* I had to fix a bug in the gateway (could be related to the openssl or compiler version):
```
diff --git a/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp b/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
index 3f2dcf3..363d0ba 100644
--- a/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/dtls/SensorNetwork.cpp
@@ -308,7 +308,7 @@ Connections::~Connections()
     {
         for (int i = 0; i < _numfds; i++)
         {
-            if (_ssls[i] > 0)
+            if (_ssls[i] > (SSL *)0)
             {
                 SSL_shutdown(_ssls[i]);
                 SSL_free(_ssls[i]);
@@ -416,7 +416,7 @@ void Connections::close(int index)
         }
     }
 
-    if (ssl > 0)
+    if (ssl > (SSL *)0)
     {
         _numfds--;
         SSL_shutdown(ssl);
```

* Build gateway with DTLS:
`<gateway-folder>/MQTTSNGateway$ ./build.sh dtls`

2. Build wolfSSL with DTLS:  `./configure --enable-dtls && make && sudo make install`
3. Build wolfMQTT with SN support:  `./configure --enable-sn && make`
4. Run the broker: `mosquitto`
5. Run the gateway: `<gateway-folder>/MQTTSNGateway$ ./bin/MQTT-SNGateway`
6. To run the wolfMQTT sn-client example with DTLS:
`./examples/sn-client/sn-client -t`
