### PR TITLE
Fix publish with topic ID >=127

### DIFF
--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -49,13 +49,22 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
     MQTTCtx* mqttCtx = (MQTTCtx*)client->ctx;
 
     if (msg_new) {
-        /* Topic ID or short topic name */
-        topicId = (word16)(msg->topic_name[0] << 8 | msg->topic_name[1]);
+        if (!(msg->topic_type & SN_TOPIC_ID_TYPE_SHORT)) {
+            /* Topic ID name */
+            topicId = (word16)((byte)msg->topic_name[0] << 8 |
+                               (byte)msg->topic_name[1]);
 
-        /* Print incoming message */
-        PRINTF("MQTT-SN Message: Topic ID %d, Qos %d, Id %d, Len %u",
-                topicId, msg->qos, msg->packet_id, msg->total_len);
-
+            /* Print incoming message */
+            PRINTF("MQTT-SN Message: Topic ID %hu, Qos %d, Id %d, Len %u",
+                    topicId, msg->qos, msg->packet_id, msg->total_len);
+        }
+        else {
+            /* Topic short name */
+            /* Print incoming message */
+            PRINTF("MQTT-SN Message: Topic ID %c%c, Qos %d, Id %d, Len %u",
+                    msg->topic_name[0], msg->topic_name[1],
+                    msg->qos, msg->packet_id, msg->total_len);
+        }
         /* for test mode: check if TEST_MESSAGE was received */
         if (mqttCtx != NULL && mqttCtx->test_mode) {
             if (XSTRLEN(TEST_MESSAGE) == msg->buffer_len &&
@@ -89,7 +98,7 @@ static int sn_message_cb(MqttClient *client, MqttMessage *msg,
    assigns a new topic ID to a topic name. */
 static int sn_reg_callback(word16 topicId, const char* topicName, void *ctx)
 {
-    PRINTF("MQTT-SN Register CB: New topic ID: %d : \"%s\"", topicId, topicName);
+    PRINTF("MQTT-SN Register CB: New topic ID: %hu : \"%s\"", topicId, topicName);
     (void)ctx;
 
     return(MQTT_CODE_SUCCESS);
@@ -112,7 +121,9 @@ int sn_test(MQTTCtx *mqttCtx)
     int rc = MQTT_CODE_SUCCESS;
     word16 topicID;
 
-    PRINTF("MQTT-SN Client: QoS %d", mqttCtx->qos);
+    PRINTF("MQTT-SN Client: Client ID %s, QoS %d",
+            mqttCtx->client_id,
+            mqttCtx->qos);
 
     /* Initialize Network */
     rc = SN_ClientNet_Init(&mqttCtx->net, mqttCtx);
@@ -232,7 +243,7 @@ int sn_test(MQTTCtx *mqttCtx)
             /* Topic ID is returned in RegAck */
             topicID = regist->regack.topicId;
         }
-        PRINTF("....MQTT-SN Register Ack: rc = %d, topic id = %d",
+        PRINTF("....MQTT-SN Register Ack: rc = %d, topic id = %hu",
                 regist->regack.return_code, regist->regack.topicId);
     }
 
@@ -251,7 +262,7 @@ int sn_test(MQTTCtx *mqttCtx)
         PRINTF("MQTT-SN Subscribe: topic name = %s", subscribe.topicNameId);
         rc = SN_Client_Subscribe(&mqttCtx->client, &subscribe);
 
-        PRINTF("....MQTT-SN Subscribe Ack: topic id = %d, rc = %d",
+        PRINTF("....MQTT-SN Subscribe Ack: topic id = %hu, rc = %d",
                 subscribe.subAck.topicId, subscribe.subAck.return_code);
 
         if ((rc == 0) && (subscribe.subAck.return_code == SN_RC_ACCEPTED)) {
@@ -278,7 +289,7 @@ int sn_test(MQTTCtx *mqttCtx)
         PRINTF("MQTT-SN Subscribe: topic name = %s", subscribe.topicNameId);
         rc = SN_Client_Subscribe(&mqttCtx->client, &subscribe);
 
-        PRINTF("....MQTT-SN Subscribe Ack: topic id = %d, rc = %d",
+        PRINTF("....MQTT-SN Subscribe Ack: topic id = %hu, rc = %d",
                 subscribe.subAck.topicId,
                 (rc == 0) ? subscribe.subAck.return_code : rc);
     }
@@ -305,8 +316,8 @@ int sn_test(MQTTCtx *mqttCtx)
 
         rc = SN_Client_Publish(&mqttCtx->client, &mqttCtx->publishSN);
 
-        PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
-            (word16)*mqttCtx->publishSN.topic_name,
+        PRINTF("MQTT-SN Publish: topic id = %hu, rc = %d\r\nPayload = %s",
+                *(word16*)mqttCtx->publishSN.topic_name,
                 mqttCtx->publishSN.return_code,
                 mqttCtx->publishSN.buffer);
         if (rc != MQTT_CODE_SUCCESS) {
@@ -343,12 +354,12 @@ int sn_test(MQTTCtx *mqttCtx)
         subscribe.topicNameId = pd_topic_id;
         subscribe.packet_id = mqtt_get_packetid();
 
-        PRINTF("MQTT-SN Predefined Subscribe: topic id = %d",
+        PRINTF("MQTT-SN Predefined Subscribe: topic id = %hu",
                 subscribe.topicNameId[1]);
         rc = SN_Client_Subscribe(&mqttCtx->client, &subscribe);
 
         if (rc == MQTT_CODE_SUCCESS) {
-            PRINTF("....MQTT-SN Predefined Subscribe Ack: topic id = %d, rc = %d",
+            PRINTF("....MQTT-SN Predefined Subscribe Ack: topic id = %hu, rc = %d",
                     subscribe.subAck.topicId, subscribe.subAck.return_code);
         }
         if ((rc == MQTT_CODE_SUCCESS) && (subscribe.subAck.return_code != 0)) {
@@ -376,7 +387,7 @@ int sn_test(MQTTCtx *mqttCtx)
 
         rc = SN_Client_Publish(&mqttCtx->client, &publish);
 
-        PRINTF("MQTT-SN Predefined Publish: topic id = %d, rc = %d\r\nPayload = %s",
+        PRINTF("MQTT-SN Predefined Publish: topic id = %hu, rc = %d\r\nPayload = %s",
                 publish.topic_name[1],
                 publish.return_code,
                 publish.buffer);
@@ -392,7 +403,7 @@ int sn_test(MQTTCtx *mqttCtx)
         unsub.topicNameId = pd_topic_id;
         unsub.packet_id = mqtt_get_packetid();
 
-        PRINTF("MQTT-SN Unsubscribe Predefined Topic: topic ID = %d",
+        PRINTF("MQTT-SN Unsubscribe Predefined Topic: topic id = %hu",
                 unsub.topicNameId[1]);
         rc = SN_Client_Unsubscribe(&mqttCtx->client, &unsub);
         PRINTF("....MQTT-SN Unsubscribe Predefined Topic Ack: rc = %d", rc);
@@ -534,7 +545,7 @@ int sn_test(MQTTCtx *mqttCtx)
                 mqttCtx->publishSN.total_len = (word16)rc;
                 rc = SN_Client_Publish(&mqttCtx->client,
                        &mqttCtx->publishSN);
-                PRINTF("MQTT-SN Publish: topic id = %d, rc = %d\r\nPayload = %s",
+                PRINTF("MQTT-SN Publish: topic id = %hu, rc = %d\r\nPayload = %s",
                     (word16)*mqttCtx->publishSN.topic_name,
                         mqttCtx->publishSN.return_code,
                         mqttCtx->publishSN.buffer);

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -3138,7 +3138,7 @@ int SN_Encode_Publish(byte *tx_buf, int tx_buf_len, SN_Publish *publish)
     }
     else {
         /* Topic ID */
-        tx_payload += MqttEncode_Num(tx_payload, (word16)*publish->topic_name);
+        tx_payload += MqttEncode_Num(tx_payload, *(word16*)publish->topic_name);
     }
 
     tx_payload += MqttEncode_Num(tx_payload, publish->packet_id);
@@ -3201,7 +3201,7 @@ int SN_Decode_Publish(byte *rx_buf, int rx_buf_len, SN_Publish *publish)
 
     publish->retain = flags & SN_PACKET_FLAG_RETAIN;
 
-    publish->type = flags & SN_PACKET_FLAG_TOPICIDTYPE_MASK;
+    publish->topic_type = flags & SN_PACKET_FLAG_TOPICIDTYPE_MASK;
 
     /* Decode payload */
 


### PR DESCRIPTION
Fixes zd16708

* While sending MQTT-SN Publish, if normal topic id is less than or equal to 127, publish is done correctly on the expected topic id.
* If topic id is equal to or greater than 128, some garbage value is sent in topic ID in publish packet instead of the given topic id. Example, when we try to publish on Normal topic ID 128, Publish is sent on topic ID 65408 instead.

Fixed by proper cast of word16 in `SN_Encode_Publish`

Also fixes topic_type set in `SN_Decode_Publish`