### PR TITLE
Allow disabling the posix conditional signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ More about MQTT-SN examples in [examples/sn-client/README.md](examples/sn-client
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 
+The multi-threading feature can also be used with the non-blocking socket (--enable-nb).
+
+If you are having issues with thread synchronization on Linux consider using not the conditional signal (`WOLFMQTT_NO_COND_SIGNAL`).
+
 ### Atomic publish and subscribe examples
 In the `examples/pub-sub` folder, there are two simple client examples:
 * mqtt-pub - publishes to a topic

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -106,9 +106,11 @@
         #define WOLFMQTT_POSIX_SEMAPHORES
         #include <pthread.h>
         typedef struct {
+        #ifndef WOLFMQTT_NO_COND_SIGNAL
             volatile int lockCount;
-            pthread_mutex_t mutex;
             pthread_cond_t cond;
+        #endif
+            pthread_mutex_t mutex;
         } wm_Sem;
 
     #elif defined(FREERTOS)


### PR DESCRIPTION
Add support for using a simple posix mutex by disabling the conditional signal using `WOLFMQTT_NO_COND_SIGNAL`.
ZD 16769