### PR TITLE
Improvements for client property stack

### DIFF
--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -78,3 +78,14 @@ jobs:
       if: ${{ failure() && steps.make-check-nonblock-mt.outcome == 'failure' }}
       run: |
         more test-suite.log
+    - name: configure with Multi-threading and WOLFMQTT_DYN_PROP
+      run: ./configure --enable-mt CFLAGS="-DWOLFMQTT_DYN_PROP"
+    - name: make
+      run: make
+    - name: make check
+      id: make-check-mt-dynprop
+      run: make check
+    - name: Show logs on failure
+      if: ${{ failure() && steps.make-check-mt-dynprop.outcome == 'failure' }}
+      run: |
+        more test-suite.log


### PR DESCRIPTION
Improvements for client property stack. Don't use lock for `WOLFMQTT_DYN_PROP`. If using multi-threading make sure `clientPropStack_lock` is not de-initialized, since it could be shared by multiple client instances. Add CI test. 

ZD 16814