### PR TITLE
Exclude CI tests with external brokers

### DIFF
--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -11,6 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -11,6 +11,8 @@ jobs:
 
     runs-on: macos-latest
     timeout-minutes: 10
+    env:
+      WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
     steps:
     - uses: actions/checkout@master
       with:

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -18,10 +18,10 @@ jobs:
         repository: wolfssl/wolfssl
         path: wolfssl
     - name: wolfssl autogen
-      working-directory: ./wolfssl        
+      working-directory: ./wolfssl
       run: ./autogen.sh
     - name: wolfssl configure
-      working-directory: ./wolfssl 
+      working-directory: ./wolfssl
       run: ./configure --enable-enckeys
     - name: wolfssl make
       working-directory: ./wolfssl
@@ -43,6 +43,8 @@ jobs:
       if: ${{ failure() && steps.make-check.outcome == 'failure' }}
       run: |
         more test-suite.log
+      env: 
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
     - name: configure with SN Enabled
       run: ./configure --enable-sn
     - name: make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ if (WOLFMQTT_EXAMPLES)
     add_mqtt_example(fwpush firmware/fwpush.c)
     add_mqtt_example(fwclient firmware/fwclient.c)
     add_mqtt_example(mqtt-pub pub-sub/mqtt-pub.c)
-    add_mqtt_example(mqtt-pub pub-sub/mqtt-sub.c)
+    add_mqtt_example(mqtt-sub pub-sub/mqtt-sub.c)
 endif()
 
 ####################################################

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -5,18 +5,22 @@
 # Check for application
 [ ! -x ./examples/aws/awsiot ] && echo -e "\n\nAWS IoT MQTT Client doesn't exist" && exit 1
 
-def_args="-T -C 2000"
+if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS"; then
+    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set, won't run"
+else
+    def_args="-T -C 2000"
 
-# Run with TLS and QoS 0-1
+    # Run with TLS and QoS 0-1
 
-./examples/aws/awsiot $def_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
+    ./examples/aws/awsiot $def_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
 
-./examples/aws/awsiot $def_args -t -q 1 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=1" && exit 1
+    ./examples/aws/awsiot $def_args -t -q 1 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=1" && exit 1
 
-echo -e "\n\nAWS IoT MQTT Client Tests Passed"
+    echo -e "\n\nAWS IoT MQTT Client Tests Passed"
+fi
 
 exit 0

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -5,18 +5,22 @@
 # Check for application
 [ ! -x ./examples/azure/azureiothub ] && echo -e "\n\nAzureIotHub MQTT Client doesn't exist" && exit 1
 
-def_args="-T -C 2000"
+if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS"; then
+    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set, won't run"
+else
+    def_args="-T -C 2000"
 
-# Run with TLS and QoS 0-1
+    # Run with TLS and QoS 0-1
 
-./examples/azure/azureiothub $def_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=0" && exit 1
+    ./examples/azure/azureiothub $def_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=0" && exit 1
 
-./examples/azure/azureiothub $def_args -t -q 1 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=1" && exit 1
+    ./examples/azure/azureiothub $def_args -t -q 1 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=1" && exit 1
 
-echo -e "\n\nAzureIotHub MQTT Client Tests Passed"
+    echo -e "\n\nAzureIotHub MQTT Client Tests Passed"
+fi
 
 exit 0


### PR DESCRIPTION
Script tests will now check if the environment variable `WOLFMQTT_NO_EXTERNAL_BROKER_TESTS` is enabled.

This was necessary because the CI tests were failing when the scripts attempted connections to the test brokers too frequently.

The Ubuntu test does run the AWS and Azure tests on the first config / make check, but not subsequent tests.