### PR TITLE
Fixes for non-blocking edge cases

### DIFF
--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -2,7 +2,7 @@ name: fsanitize check Test
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
@@ -88,4 +88,4 @@ jobs:
     - name: Show logs on failure
       if: failure() || cancelled()
       run: |
-        more test-suite.log
+        cat test-suite.log

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -2,7 +2,7 @@ name: macOS Build Test
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -2,7 +2,7 @@ name: Ubuntu Build Test
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
@@ -59,13 +59,13 @@ jobs:
       run: ./configure
     - name: wolfmqtt make
       run: make
+    # Note: this will run the external tests for this CI only
     - name: wolfmqtt make check
       run: make check
 
-      env: 
-        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
-
     - name: wolfmqtt configure with SN Enabled
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-sn
     - name: wolfmqtt make
       run: make
@@ -73,6 +73,8 @@ jobs:
       run: make check
 
     - name: wolfmqtt configure with Non-Block
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: wolfmqtt make
       run: make
@@ -80,6 +82,8 @@ jobs:
       run: make check
 
     - name: wolfmqtt configure with Non-Block and Multi-threading
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: wolfmqtt make
       run: make
@@ -87,6 +91,8 @@ jobs:
       run: make check
 
     - name: configure with Multi-threading and WOLFMQTT_DYN_PROP
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-mt CFLAGS="-DWOLFMQTT_DYN_PROP"
     - name: make
       run: make
@@ -97,4 +103,4 @@ jobs:
     - name: Show logs on failure
       if: failure() || cancelled()
       run: |
-        more test-suite.log
+        cat test-suite.log

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -2,7 +2,7 @@ name: Windows Build Test
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 

--- a/examples/firmware/fwpush.h
+++ b/examples/firmware/fwpush.h
@@ -33,7 +33,7 @@ typedef struct FwpushCBdata_s {
     const char *filename;
     byte *data;
     FILE *fp;
-}FwpushCBdata;
+} FwpushCBdata;
 
 /* Exposed functions */
 int fwpush_test(MQTTCtx *mqttCtx);

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -497,11 +497,10 @@ int mqttclient_test(MQTTCtx *mqttCtx)
     #endif
 
         /* This loop allows payloads larger than the buffer to be sent by
-           repeatedly calling publish.
-        */
+         * repeatedly calling publish. */
         do {
             rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-        } while(rc == MQTT_CODE_PUB_CONTINUE);
+        } while (rc == MQTT_CODE_PUB_CONTINUE || rc == MQTT_CODE_CONTINUE);
 
         if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
             WOLFMQTT_FREE(mqttCtx->publish.buffer);

--- a/examples/mqttexample.h
+++ b/examples/mqttexample.h
@@ -200,6 +200,9 @@ word16 mqtt_get_packetid(void);
 int mqtt_check_timeout(int rc, word32* start_sec, word32 timeout_sec);
 #endif
 
+int mqtt_fill_random_hexstr(char* buf, word32 bufLen);
+char* mqtt_append_random(const char* inStr, word32 inLen);
+
 int mqtt_file_load(const char* filePath, byte** fileBuf, int *fileLen);
 
 #ifdef WOLFSSL_ENCRYPTED_KEYS

--- a/examples/pub-sub/mqtt-pub.c
+++ b/examples/pub-sub/mqtt-pub.c
@@ -374,11 +374,10 @@ int pub_client(MQTTCtx *mqttCtx)
     #endif
 
         /* This loop allows payloads larger than the buffer to be sent by
-           repeatedly calling publish.
-        */
+         * repeatedly calling publish. */
         do {
             rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-        } while(rc == MQTT_CODE_PUB_CONTINUE);
+        } while (rc == MQTT_CODE_PUB_CONTINUE);
 
         if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
             WOLFMQTT_FREE(mqttCtx->publish.buffer);

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -11,7 +11,6 @@ else
     def_args="-T -C 2000"
 
     # Run with TLS and QoS 0-1
-
     ./examples/aws/awsiot $def_args -t -q 0 $1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nAWS IoT MQTT Client failed! TLS=On, QoS=0" && exit 1

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -8,10 +8,11 @@
 if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS"; then
     echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set, won't run"
 else
+    # Use short timeout here, since we can't get a publish response to complete test
+    # So use the timeout and ping response to complete test
     def_args="-T -C 2000"
 
     # Run with TLS and QoS 0-1
-
     ./examples/azure/azureiothub $def_args -t -q 0 $1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "\n\nAzureIotHub MQTT Client failed! TLS=On, QoS=0" && exit 1

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -28,7 +28,7 @@ do_cleanup() {
 [ ! -x ./examples/firmware/fwpush ] && echo -e "\n\nMQTT Example fwpush doesn't exist" && exit 1
 [ ! -x ./examples/firmware/fwclient ] && echo -e "\n\nMQTT Example fwclient doesn't exist" && exit 1
 
-def_args="-t -T -C 2000"
+def_args="-t -T -C 5000 -n wolfMQTT/example/firmware_$((RANDOM))"
 filein=./examples/publish.dat
 fileout=./examples/publish.dat.trs
 
@@ -54,15 +54,18 @@ fi
 grep -F -e 'ENABLE_MQTT_TLS' ./wolfmqtt/options.h
 ENABLE_MQTT_TLS=$?
 
+# Start firmware client
+./examples/firmware/fwclient $def_args -f $fileout $1 &
+client_result=$?
+[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && do_cleanup "-1"
+
+# give some time for the client to connect and wait (it starts a new session)
+sleep 0.5
+
 # Start firmware push
 ./examples/firmware/fwpush $def_args -r -f $filein $1
 server_result=$?
 [ $server_result -ne 0 ] && echo -e "\n\nMQTT Example fwpush failed!" && do_cleanup "-1"
-
-# Start firmware client
-./examples/firmware/fwclient $def_args -f $fileout $1
-client_result=$?
-[ $client_result -ne 0 ] && echo -e "\n\nMQTT Example fwclient failed!" && do_cleanup "-1"
 
 if [ $ENABLE_MQTT_TLS -ne 1 ]; then
     # Compare files
@@ -74,7 +77,7 @@ fi
 
 # End broker
 do_cleanup "0"
- 
+
 echo -e "\n\nFirmware Example MQTT Client Tests Passed"
 
 exit 0

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -123,6 +123,15 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
 {
     int rc;
 
+#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+    static int testNbWriteAlt = 0;
+    if (!testNbWriteAlt) {
+        testNbWriteAlt = 1;
+        return MQTT_CODE_CONTINUE;
+    }
+    testNbWriteAlt = 0;
+#endif
+
 #ifdef ENABLE_MQTT_TLS
     if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_TLS) {
         client->tls.timeout_ms = timeout_ms;
@@ -133,8 +142,11 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
             int error = wolfSSL_get_error(client->tls.ssl, 0);
         #endif
         #ifdef WOLFMQTT_DEBUG_SOCKET
-            if (error != WOLFSSL_ERROR_WANT_WRITE &&
-                error != WC_PENDING_E) {
+            if (error != WOLFSSL_ERROR_WANT_WRITE
+            #ifdef WOLFSSL_ASYNC_CRYPT
+                && error != WC_PENDING_E
+            #endif
+            ) {
                 PRINTF("MqttSocket_WriteDo: SSL Error=%d (rc %d, sockrc %d)",
                     error, rc, client->tls.sockRcWrite);
             }
@@ -152,6 +164,19 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
     else
 #endif /* ENABLE_MQTT_TLS */
     {
+    #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+        static int testSmallerWrite = 0;
+        if (!testSmallerWrite) {
+            if (buf_len > 100) {
+                buf_len /= 2;
+            }
+            testSmallerWrite = 1;
+        }
+        else {
+            testSmallerWrite = 0;
+        }
+    #endif
+
         rc = client->net->write(client->net->context, buf, buf_len,
             timeout_ms);
     }
@@ -221,12 +246,12 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
     int rc;
 
 #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-    static int testNbAlt = 0;
-    if (!testNbAlt) {
-        testNbAlt = 1;
+    static int testNbReadAlt = 0;
+    if (!testNbReadAlt) {
+        testNbReadAlt = 1;
         return MQTT_CODE_CONTINUE;
     }
-    testNbAlt = 0;
+    testNbReadAlt = 0;
 #endif
 
 #ifdef ENABLE_MQTT_TLS
@@ -237,8 +262,11 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
         if (rc < 0) {
             int error = wolfSSL_get_error(client->tls.ssl, 0);
         #ifdef WOLFMQTT_DEBUG_SOCKET
-            if (error != WOLFSSL_ERROR_WANT_READ &&
-                error != WC_PENDING_E) {
+            if (error != WOLFSSL_ERROR_WANT_READ
+            #ifdef WOLFSSL_ASYNC_CRYPT
+                && error != WC_PENDING_E
+            #endif
+            ) {
                 PRINTF("MqttSocket_ReadDo: SSL Error=%d (rc %d, sockrc %d)",
                     error, rc, client->tls.sockRcRead);
             }
@@ -488,9 +516,12 @@ exit:
         int errnum = 0;
         if (client->tls.ssl) {
             errnum = wolfSSL_get_error(client->tls.ssl, 0);
-            if (errnum == WOLFSSL_ERROR_WANT_READ ||
-                errnum == WOLFSSL_ERROR_WANT_WRITE ||
-                errnum == WC_PENDING_E) {
+            if (   errnum == WOLFSSL_ERROR_WANT_READ
+                || errnum == WOLFSSL_ERROR_WANT_WRITE
+            #ifdef WOLFSSL_ASYNC_CRYPT
+                || errnum == WC_PENDING_E
+            #endif
+            ) {
                 return MQTT_CODE_CONTINUE;
             }
         #ifdef WOLFMQTT_DEBUG_SOCKET

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -235,9 +235,7 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
         client->tls.sockRcRead = 0; /* init value */
         rc = wolfSSL_read(client->tls.ssl, (char*)buf, buf_len);
         if (rc < 0) {
-        #if defined(WOLFMQTT_DEBUG_SOCKET) || defined(WOLFSSL_ASYNC_CRYPT)
             int error = wolfSSL_get_error(client->tls.ssl, 0);
-        #endif
         #ifdef WOLFMQTT_DEBUG_SOCKET
             if (error != WOLFSSL_ERROR_WANT_READ &&
                 error != WC_PENDING_E) {
@@ -252,7 +250,12 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
             if (error == WC_PENDING_E) {
                 rc = MQTT_CODE_CONTINUE;
             }
+            else
         #endif
+            /* used with compatibility layer to communicate peer close */
+            if (error == WOLFSSL_ERROR_ZERO_RETURN) {
+                rc = MQTT_CODE_ERROR_NETWORK;
+            }
         }
     }
     else


### PR DESCRIPTION
* Fixes for non-blocking publish with payload larger than maximum TX buffer. ZD 16769
* Fixes for write non-blocking (would block) edge cases.
* Fix for write position on cancel of message in progress.
* Added check for zero return on read, which is a compatibility layer indicator for disconnect.
* Added write WOLFMQTT_TEST_NONBLOCK support.
* Fix to make sure ctrl+c is honored during a want read/write case.
* Fix the firmware update example to properly synchronize publish and use a unique topic name.
* Improve multi-thread test message to use larger size (> tx but) and in test mode check for actual message.
* Improve remote test done logic.
* Only run GitHub CI for PR's, not local push.
* Properly set `WOLFMQTT_NO_EXTERNAL_BROKER_TESTS` for each test.
* Use cat for logs, not more.