### PR TITLE
Improvements to multithread locking and tests.

### DIFF
--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -64,7 +64,7 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      run: ./configure --disable-tls
+      run: ./configure --enable-all --disable-tls
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -63,6 +63,13 @@ jobs:
     - name: make check
       run: make check
 
+    - name: configure without TLS
+      run: ./configure --disable-tls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+
     - name: configure with SN Enabled
       run: ./configure --enable-sn CC="gcc -fsanitize=address"
     - name: make

--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -64,7 +64,7 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      run: ./configure CC="gcc -fsanitize=address" --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+      run: ./configure CC="gcc -fsanitize=address" --enable-all --disable-tls
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -96,3 +96,4 @@ jobs:
       if: failure() || cancelled()
       run: |
         cat test-suite.log
+        cat scripts/*.log

--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -64,28 +64,28 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      run: ./configure --enable-all --disable-tls
+      run: ./configure CC="gcc -fsanitize=address" --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with SN Enabled
-      run: ./configure --enable-sn CC="gcc -fsanitize=address"
+      run: ./configure CC="gcc -fsanitize=address" --enable-sn
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with Non-Block
-      run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK" CC="gcc -fsanitize=address"
+      run: ./configure CC="gcc -fsanitize=address" --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with Non-Block and Multi-threading
-      run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK" CC="gcc -fsanitize=address"
+      run: ./configure CC="gcc -fsanitize=address" --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -82,3 +82,4 @@ jobs:
       if: failure() || cancelled()
       run: |
         cat test-suite.log
+        cat scripts/*.log

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -45,6 +45,13 @@ jobs:
     - name: make check
       run: make check
 
+    - name: configure without TLS
+      run: ./configure --disable-tls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+
     - name: configure with SN Enabled
       run: ./configure --enable-sn
     - name: make

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+env:
+  WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
+
 jobs:
   build:
 
@@ -17,7 +20,10 @@ jobs:
         repository: wolfssl/wolfssl
         path: wolfssl
     - name: brew
-      run: brew install automake libtool md5sha1sum
+      run: |
+        brew install automake libtool md5sha1sum mosquitto
+        echo "/usr/local/sbin/" >> $GITHUB_PATH
+        echo "/usr/local/opt/mosquitto/sbin/" >> $GITHUB_PATH
 
     - name: wolfssl autogen
       working-directory: ./wolfssl
@@ -44,17 +50,13 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      env:
-        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
-      run: ./configure --enable-all --disable-tls
+      run: ./configure --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with SN Enabled
-      env:
-        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-sn
     - name: make
       run: make
@@ -62,8 +64,6 @@ jobs:
       run: make check
 
     - name: configure with Non-Block
-      env:
-        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
@@ -71,8 +71,6 @@ jobs:
       run: make check
 
     - name: configure with Non-Block and Multi-threading
-      env:
-        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -50,7 +50,7 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      run: ./configure --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+      run: ./configure --enable-all --disable-tls
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -11,8 +11,6 @@ jobs:
 
     runs-on: macos-latest
     timeout-minutes: 10
-    env:
-      WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
     steps:
     - uses: actions/checkout@master
       with:
@@ -46,13 +44,17 @@ jobs:
       run: make check
 
     - name: configure without TLS
-      run: ./configure --disable-tls
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
+      run: ./configure --enable-all --disable-tls
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with SN Enabled
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-sn
     - name: make
       run: make
@@ -60,6 +62,8 @@ jobs:
       run: make check
 
     - name: configure with Non-Block
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make
@@ -67,6 +71,8 @@ jobs:
       run: make check
 
     - name: configure with Non-Block and Multi-threading
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
       run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: make
       run: make

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -66,7 +66,7 @@ jobs:
     - name: wolfmqtt configure without TLS
       env:
         WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
-      run: ./configure --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+      run: ./configure --enable-all --disable-tls
     - name: wolfmqtt make
       run: make
     - name: wolfmqtt make check

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -66,7 +66,7 @@ jobs:
     - name: wolfmqtt configure without TLS
       env:
         WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
-      run: ./configure --enable-all --disable-tls
+      run: ./configure --enable-all --disable-tls CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
     - name: wolfmqtt make
       run: make
     - name: wolfmqtt make check

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -63,6 +63,15 @@ jobs:
     - name: wolfmqtt make check
       run: make check
 
+    - name: wolfmqtt configure without TLS
+      env:
+        WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
+      run: ./configure --disable-tls
+    - name: wolfmqtt make
+      run: make
+    - name: wolfmqtt make check
+      run: make check
+
     - name: wolfmqtt configure with SN Enabled
       env:
         WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -113,3 +113,4 @@ jobs:
       if: failure() || cancelled()
       run: |
         cat test-suite.log
+        cat scripts/*.log

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -66,7 +66,7 @@ jobs:
     - name: wolfmqtt configure without TLS
       env:
         WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1
-      run: ./configure --disable-tls
+      run: ./configure --enable-all --disable-tls
     - name: wolfmqtt make
       run: make
     - name: wolfmqtt make check

--- a/examples/firmware/fwpush.h
+++ b/examples/firmware/fwpush.h
@@ -38,4 +38,8 @@ typedef struct FwpushCBdata_s {
 /* Exposed functions */
 int fwpush_test(MQTTCtx *mqttCtx);
 
+#if defined(NO_MAIN_DRIVER)
+int fwpush_main(int argc, char** argv);
+#endif
+
 #endif /* WOLFMQTT_FWPUSH_H */

--- a/examples/mqttexample.c
+++ b/examples/mqttexample.c
@@ -150,6 +150,7 @@ static int mqtt_get_rand(byte* data, word32 len)
     for (i = 0; i<len; i++) {
         data[i] = (byte)rand();
     }
+    ret = 0; /* success */
 #endif
     return ret;
 }
@@ -177,6 +178,9 @@ int mqtt_fill_random_hexstr(char* buf, word32 bufLen)
                 buf[pos + (i*2)+1] = kHexChar[in & 0xf];
             }
             pos += sz*2;
+        }
+        else {
+            PRINTF("MQTT Fill Random Failed! %d", rc);
         }
     }
     return rc;
@@ -217,7 +221,8 @@ void mqtt_show_usage(MQTTCtx* mqttCtx)
 #ifdef ENABLE_MQTT_TLS
         PRINTF("-p <num>    Port to connect on, default: Normal %d, TLS %d",
                 MQTT_DEFAULT_PORT, MQTT_SECURE_PORT);
-        PRINTF("-t          Enable TLS");
+        PRINTF("-t          Enable TLS"); /* Note: this string is used in test
+                                           * scripts to detect TLS feature */
         PRINTF("-A <file>   Load CA (validate peer)");
         PRINTF("-K <key>    Use private key (for TLS mutual auth)");
         PRINTF("-c <cert>   Use certificate (for TLS mutual auth)");

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -800,7 +800,7 @@ static int NetRead_ex(void *context, byte* buf, int buf_len,
 
         if (do_read) {
             /* Try and read number of buf_len provided,
-                minus what's already been read */
+             * minus what's already been read */
             rc = (int)SOCK_RECV(sock->fd,
                            &buf[bytes],
                            buf_len - bytes,

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -562,8 +562,8 @@ static void *waitMessage_task(void *param)
     #endif
         else if (rc == MQTT_CODE_ERROR_TIMEOUT) {
             if (mqttCtx->test_mode) {
-                mqtt_stop_set();
                 /* timeout in test mode should exit */
+                mqtt_stop_set();
                 PRINTF("MQTT Exiting timeout...");
                 break;
             }
@@ -748,11 +748,11 @@ int multithread_test(MQTTCtx *mqttCtx)
         /* Join threads - wait for completion */
         if (THREAD_JOIN(threadList, threadCount)) {
 #ifdef __GLIBC__
-            /* %m is specific to glibc/uclibc/musl, and recently (2018)
-             * added to FreeBSD */
+            /* "%m" is specific to glibc/uclibc/musl, and FreeBSD (as of 2018).
+             * Uses errno and not argument required */
             PRINTF("THREAD_JOIN failed: %m");
 #else
-            PRINTF("THREAD_JOIN failed: %d",errno);
+            PRINTF("THREAD_JOIN failed: %d", errno);
 #endif
         }
 

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -619,11 +619,11 @@ static void *publish_task(void *param)
         MqttClient_CancelMessage(&mqttCtx->client, (MqttObject*)&publish);
     }
 
-    wm_SemLock(&mtLock);
     PRINTF("MQTT Publish: Topic %s, %s (%d)",
         publish.topic_name,
         MqttClient_ReturnCodeToString(rc), rc);
 
+    wm_SemLock(&mtLock);
     mNumMsgsDone++;
     wm_SemUnlock(&mtLock);
 

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -103,13 +103,14 @@ static int mqtt_stop_get(void)
     return rc;
 }
 
+#define MQTT_CODE_TEST_EXIT -200
 static int check_response(MQTTCtx* mqttCtx, int rc, word32* startSec,
     int packet_type, word32 timeoutMs)
 {
     /* check for test mode */
-    if (mqtt_stop_get()) {
+    if (mqtt_stop_get() && packet_type != MQTT_PACKET_TYPE_UNSUBSCRIBE) {
         PRINTF("MQTT Exiting Thread...");
-        return MQTT_CODE_ERROR_SYSTEM;
+        return MQTT_CODE_TEST_EXIT;
     }
 
 #ifdef WOLFMQTT_NONBLOCK
@@ -387,7 +388,7 @@ static int multithread_test_finish(MQTTCtx *mqttCtx)
 
     PRINTF("MQTT Client Done: %d", mqttCtx->return_code);
 
-    if (mStopRead && mqttCtx->return_code == MQTT_CODE_ERROR_SYSTEM) {
+    if (mStopRead && mqttCtx->return_code == MQTT_CODE_TEST_EXIT) {
         /* this is okay, we requested termination */
         mqttCtx->return_code = MQTT_CODE_SUCCESS;
     }

--- a/scripts/awsiot.test
+++ b/scripts/awsiot.test
@@ -5,8 +5,15 @@
 # Check for application
 [ ! -x ./examples/aws/awsiot ] && echo -e "\n\nAWS IoT MQTT Client doesn't exist" && exit 1
 
-if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS"; then
-    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set, won't run"
+# Check for TLS support
+has_tls=no
+./examples/aws/awsiot -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
+if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS" && test $has_tls == yes; then
+    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set or no TLS, won't run"
 else
     def_args="-T -C 2000"
 

--- a/scripts/azureiothub.test
+++ b/scripts/azureiothub.test
@@ -5,8 +5,15 @@
 # Check for application
 [ ! -x ./examples/azure/azureiothub ] && echo -e "\n\nAzureIotHub MQTT Client doesn't exist" && exit 1
 
-if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS"; then
-    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set, won't run"
+# Check for TLS support
+has_tls=no
+./examples/azure/azureiothub -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
+if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS" && test $has_tls == yes; then
+    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set or no TLS, won't run"
 else
     # Use short timeout here, since we can't get a publish response to complete test
     # So use the timeout and ping response to complete test

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -22,6 +22,13 @@ do_cleanup() {
 # Check for application
 [ ! -x ./examples/mqttclient/mqttclient ] && echo -e "\n\nMQTT Client doesn't exist" && exit 1
 
+# Check for TLS support
+has_tls=no
+./examples/mqttclient/mqttclient -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
 def_args="-T -C 2000"
 
 # Check for mosquitto
@@ -47,8 +54,7 @@ then
     ecc_mutual_auth_args="-c certs/client-ecc-cert.pem -K certs/ecc-client-key.pem"
 fi
 
-# Run with and without TLS and QoS 0-2
-
+# Run without TLS and QoS 0-2
 ./examples/mqttclient/mqttclient $def_args $port_args -q 0 $1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
@@ -61,29 +67,33 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
-./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && do_cleanup "-1"
+if test $has_tls == yes
+then
+    # Run with TLS and QoS 0-2
+    ./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
-./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 1 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && do_cleanup "-1" 
+    ./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 1 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=1" && do_cleanup "-1"
 
-./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 2 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && do_cleanup "-1"
+    ./examples/mqttclient/mqttclient $def_args $tls_port_args -t -q 2 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=2" && do_cleanup "-1"
 
-./examples/mqttclient/mqttclient $def_args $mutual_auth_args $tls_port_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0, RSA mutual auth" && do_cleanup "-1"
+    ./examples/mqttclient/mqttclient $def_args $mutual_auth_args $tls_port_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0, RSA mutual auth" && do_cleanup "-1"
 
-./examples/mqttclient/mqttclient $def_args $ecc_mutual_auth_args $tls_port_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0, ECC mutual auth" && do_cleanup "-1"
+    ./examples/mqttclient/mqttclient $def_args $ecc_mutual_auth_args $tls_port_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMQTT Client failed! TLS=On, QoS=0, ECC mutual auth" && do_cleanup "-1"
+fi
 
 # End broker
 do_cleanup "0"
- 
+
 echo -e "\n\nMQTT Client Tests Passed"
 
 exit 0

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -19,6 +19,19 @@ do_cleanup() {
     fi
 }
 
+generate_port() { # function to produce a random port number
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
+    echo -e "Using port $port"
+}
+
+
 # Check for application
 [ ! -x ./examples/mqttclient/mqttclient ] && echo -e "\n\nMQTT Client doesn't exist" && exit 1
 
@@ -34,22 +47,31 @@ def_args="-T -C 2000"
 # Check for mosquitto
 if command -v mosquitto
 then
-    # bwrap only if using a local mosquitto instance
-    if [ "${AM_BWRAPPED-}" != "yes" ]; then
-        bwrap_path="$(command -v bwrap)"
-        if [ -n "$bwrap_path" ]; then
-            echo "Client test using bwrap"
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        # bwrap only if using a local mosquitto instance
+        if [ "${AM_BWRAPPED-}" != "yes" ]; then
+            echo "Using bwrap"
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+
+        broker_args="-c scripts/broker_test/mosquitto.conf"
+        port=11883
+    else
+        # mosquitto broker custom port non-TLS only
+        has_tls=no
+        generate_port
+        broker_args="-p $port"
     fi
-    # Run mosquitto broker
-    mosquitto -c scripts/broker_test/mosquitto.conf &
+    mosquitto $broker_args &
     broker_pid=$!
     echo "Broker PID is $broker_pid"
+    sleep 0.1
+
     def_args="${def_args} -h localhost"
     tls_port_args="-p 18883"
-    port_args="-p 11883"
+    port_args="-p ${port}"
     mutual_auth_args="-c certs/client-cert.pem -K certs/client-key.pem"
     ecc_mutual_auth_args="-c certs/client-ecc-cert.pem -K certs/ecc-client-key.pem"
 fi

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -54,6 +54,8 @@ then
     ecc_mutual_auth_args="-c certs/client-ecc-cert.pem -K certs/ecc-client-key.pem"
 fi
 
+echo -e "Base args: $def_args $port_args"
+
 # Run without TLS and QoS 0-2
 ./examples/mqttclient/mqttclient $def_args $port_args -q 0 $1
 RESULT=$?

--- a/scripts/client.test
+++ b/scripts/client.test
@@ -55,6 +55,7 @@ then
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+        unset AM_BWRAPPED
 
         broker_args="-c scripts/broker_test/mosquitto.conf"
         port=11883

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -64,7 +64,12 @@ then
         fi
 
         broker_args="-c scripts/broker_test/mosquitto.conf"
-        port=11883
+        if test $has_tls == yes
+        then
+            port=18883
+        else
+            port=11883
+        fi
     else
         # mosquitto broker custom port non-TLS only
         has_tls=no

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -6,10 +6,8 @@ no_pid=-1
 broker_pid=$no_pid
 
 do_cleanup() {
-    if [ $ENABLE_MQTT_TLS -ne 1 ]; then
-        # Delete file
-        rm $fileout
-    fi
+    # Delete file
+    rm $fileout
 
     if  [ $broker_pid != $no_pid ]
     then
@@ -24,6 +22,19 @@ do_cleanup() {
     fi
 }
 
+generate_port() { # function to produce a random port number
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
+    echo -e "Using port $port"
+}
+
+
 # Check for application
 [ ! -x ./examples/firmware/fwpush ] && echo -e "\n\nMQTT Example fwpush doesn't exist" && exit 1
 [ ! -x ./examples/firmware/fwclient ] && echo -e "\n\nMQTT Example fwclient doesn't exist" && exit 1
@@ -36,10 +47,6 @@ if [ $? -eq 0 ]; then
 fi
 
 def_args="-T -C 5000 -n wolfMQTT/example/firmware_$((RANDOM))"
-if test $has_tls == yes
-then
-    def_args="${def_args} -t"
-fi
 filein=./examples/publish.dat
 fileout=./examples/publish.dat.trs
 
@@ -47,24 +54,35 @@ fileout=./examples/publish.dat.trs
 # Check for mosquitto
 if command -v mosquitto
 then
-    # bwrap only if using a local mosquitto instance
-    if [ "${AM_BWRAPPED-}" != "yes" ]; then
-        bwrap_path="$(command -v bwrap)"
-        if [ -n "$bwrap_path" ]; then
-            echo "Firmware test using bwrap"
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        # bwrap only if using a local mosquitto instance
+        if [ "${AM_BWRAPPED-}" != "yes" ]; then
+            echo "Using bwrap"
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+
+        broker_args="-c scripts/broker_test/mosquitto.conf"
+        port=11883
+    else
+        # mosquitto broker custom port non-TLS only
+        has_tls=no
+        generate_port
+        broker_args="-p $port"
     fi
-    # Run mosquitto broker
-    mosquitto -c scripts/broker_test/mosquitto.conf &
+    mosquitto $broker_args &
     broker_pid=$!
     echo "Broker PID is $broker_pid"
-    def_args="${def_args} -h localhost -p 18883"
+    sleep 0.1
+
+    def_args="${def_args} -h localhost -p ${port}"
 fi
 
-grep -F -e 'ENABLE_MQTT_TLS' ./wolfmqtt/options.h
-ENABLE_MQTT_TLS=$?
+if test $has_tls == yes
+then
+    def_args="${def_args} -t"
+fi
 
 echo -e "Base args: $def_args"
 
@@ -84,13 +102,11 @@ server_result=$?
 # give some time for the client complete
 sleep 0.5
 
-if [ $ENABLE_MQTT_TLS -ne 1 ]; then
-    # Compare files
-    echo "Comparing files"
-    md5sum -b $filein $fileout
-    compare_result=$?
-    [ $compare_result -ne 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && do_cleanup "-1"
-fi
+# Compare files
+echo "Comparing files"
+md5sum -b $filein $fileout
+compare_result=$?
+[ $compare_result -ne 0 ] && echo -e "\n\nMQTT Example firmware compare failed!" && do_cleanup "-1"
 
 # End broker
 do_cleanup "0"

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -66,6 +66,8 @@ fi
 grep -F -e 'ENABLE_MQTT_TLS' ./wolfmqtt/options.h
 ENABLE_MQTT_TLS=$?
 
+echo -e "Base args: $def_args"
+
 # Start firmware client
 ./examples/firmware/fwclient $def_args -f $fileout $1 &
 client_result=$?

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -28,9 +28,21 @@ do_cleanup() {
 [ ! -x ./examples/firmware/fwpush ] && echo -e "\n\nMQTT Example fwpush doesn't exist" && exit 1
 [ ! -x ./examples/firmware/fwclient ] && echo -e "\n\nMQTT Example fwclient doesn't exist" && exit 1
 
-def_args="-t -T -C 5000 -n wolfMQTT/example/firmware_$((RANDOM))"
+# Check for TLS support
+has_tls=no
+./examples/mqttclient/mqttclient -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
+def_args="-T -C 5000 -n wolfMQTT/example/firmware_$((RANDOM))"
+if test $has_tls == yes
+then
+    def_args="${def_args} -t"
+fi
 filein=./examples/publish.dat
 fileout=./examples/publish.dat.trs
+
 
 # Check for mosquitto
 if command -v mosquitto

--- a/scripts/firmware.test
+++ b/scripts/firmware.test
@@ -62,6 +62,7 @@ then
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+        unset AM_BWRAPPED
 
         broker_args="-c scripts/broker_test/mosquitto.conf"
         if test $has_tls == yes

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -19,6 +19,18 @@ do_cleanup() {
     fi
 }
 
+generate_port() { # function to produce a random port number
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
+    echo -e "Using port $port"
+}
+
 # Check for application
 [ ! -x ./examples/multithread/multithread ] && echo -e "\n\nMultithread Client doesn't exist" && exit 1
 
@@ -34,22 +46,31 @@ def_args="-T -C 2000"
 # Check for mosquitto
 if command -v mosquitto
 then
-    # bwrap only if using a local mosquitto instance
-    if [ "${AM_BWRAPPED-}" != "yes" ]; then
-        bwrap_path="$(command -v bwrap)"
-        if [ -n "$bwrap_path" ]; then
-            echo "multithread test using bwrap"
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        # bwrap only if using a local mosquitto instance
+        if [ "${AM_BWRAPPED-}" != "yes" ]; then
+            echo "Using bwrap"
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+
+        broker_args="-c scripts/broker_test/mosquitto.conf"
+        port=11883
+    else
+        # mosquitto broker custom port non-TLS only
+        has_tls=no
+        generate_port
+        broker_args="-p $port"
     fi
-    # Run mosquitto broker
-    mosquitto -c scripts/broker_test/mosquitto.conf &
+    mosquitto $broker_args &
     broker_pid=$!
     echo "Broker PID is $broker_pid"
+    sleep 0.1
+
     def_args="${def_args} -h localhost"
     tls_port_args="-p 18883"
-    port_args="-p 11883"
+    port_args="-p ${port}"
 fi
 
 echo -e "Base args: $def_args $port_args"

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -54,6 +54,7 @@ then
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+        unset AM_BWRAPPED
 
         broker_args="-c scripts/broker_test/mosquitto.conf"
         port=11883

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -22,6 +22,13 @@ do_cleanup() {
 # Check for application
 [ ! -x ./examples/multithread/multithread ] && echo -e "\n\nMultithread Client doesn't exist" && exit 1
 
+# Check for TLS support
+has_tls=no
+./examples/multithread/multithread -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
 def_args="-T -C 2000"
 
 # Check for mosquitto
@@ -45,8 +52,8 @@ then
     port_args="-p 11883"
 fi
 
-# Run with and without TLS and QoS 0-2
 
+# Run without TLS and QoS 0-2
 ./examples/multithread/multithread $def_args $port_args -q 0 $1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
@@ -59,21 +66,25 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
-./examples/multithread/multithread $def_args $tls_port_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && do_cleanup "-1"
+if test $has_tls == yes
+then
+    # Run with TLS and QoS 0-2
+    ./examples/multithread/multithread $def_args $tls_port_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
-./examples/multithread/multithread $def_args $tls_port_args -t -q 1 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && do_cleanup "-1"
+    ./examples/multithread/multithread $def_args $tls_port_args -t -q 1 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=1" && do_cleanup "-1"
 
-./examples/multithread/multithread $def_args $tls_port_args -t -q 2 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && do_cleanup "-1"
+    ./examples/multithread/multithread $def_args $tls_port_args -t -q 2 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nMultithread Client failed! TLS=On, QoS=2" && do_cleanup "-1"
+fi
 
 # End broker
 do_cleanup "0"
- 
+
 echo -e "\n\nMultithread MQTT Client Tests Passed"
 
 exit 0

--- a/scripts/multithread.test
+++ b/scripts/multithread.test
@@ -52,6 +52,7 @@ then
     port_args="-p 11883"
 fi
 
+echo -e "Base args: $def_args $port_args"
 
 # Run without TLS and QoS 0-2
 ./examples/multithread/multithread $def_args $port_args -q 0 $1

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -56,6 +56,7 @@ then
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+        unset AM_BWRAPPED
 
         broker_args="-c scripts/broker_test/mosquitto.conf"
         port=11883

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -54,6 +54,8 @@ then
     port_args="-p 11883"
 fi
 
+echo -e "Base args: $def_args $port_args"
+
 # Run without TLS and QoS 0-2
 ./examples/nbclient/nbclient $def_args $port_args -q 0 $1
 RESULT=$?

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -19,6 +19,18 @@ do_cleanup() {
     fi
 }
 
+generate_port() { # function to produce a random port number
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
+    echo -e "Using port $port"
+}
+
 # Check for application
 [ ! -x ./examples/nbclient/nbclient ] && echo -e "\n\nNon-blocking Client doesn't exist" && exit 1
 
@@ -36,22 +48,31 @@ def_args="-T -C 2000"
 # Check for mosquitto
 if command -v mosquitto
 then
-    # bwrap only if using a local mosquitto instance
-    if [ "${AM_BWRAPPED-}" != "yes" ]; then
-        bwrap_path="$(command -v bwrap)"
-        if [ -n "$bwrap_path" ]; then
-            echo "nbclient test using bwrap"
+    bwrap_path="$(command -v bwrap)"
+    if [ -n "$bwrap_path" ]; then
+        # bwrap only if using a local mosquitto instance
+        if [ "${AM_BWRAPPED-}" != "yes" ]; then
+            echo "Using bwrap"
             export AM_BWRAPPED=yes
             exec "$bwrap_path" --unshare-net --dev-bind / / "$0" "$@"
         fi
+
+        broker_args="-c scripts/broker_test/mosquitto.conf"
+        port=11883
+    else
+        # mosquitto broker custom port non-TLS only
+        has_tls=no
+        generate_port
+        broker_args="-p $port"
     fi
-    # Run mosquitto broker
-    mosquitto -c scripts/broker_test/mosquitto.conf &
+    mosquitto $broker_args &
     broker_pid=$!
     echo "Broker PID is $broker_pid"
+    sleep 0.1
+
     def_args="${def_args} -h localhost"
     tls_port_args="-p 18883"
-    port_args="-p 11883"
+    port_args="-p ${port}"
 fi
 
 echo -e "Base args: $def_args $port_args"

--- a/scripts/nbclient.test
+++ b/scripts/nbclient.test
@@ -22,6 +22,13 @@ do_cleanup() {
 # Check for application
 [ ! -x ./examples/nbclient/nbclient ] && echo -e "\n\nNon-blocking Client doesn't exist" && exit 1
 
+# Check for TLS support
+has_tls=no
+./examples/multithread/multithread -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
 # Use minimum of 2 seconds
 # The check timout will sometimes incorrectly trigger if 1 second is used
 def_args="-T -C 2000"
@@ -47,8 +54,7 @@ then
     port_args="-p 11883"
 fi
 
-# Run with and without TLS and QoS 0-2
-
+# Run without TLS and QoS 0-2
 ./examples/nbclient/nbclient $def_args $port_args -q 0 $1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=0" && do_cleanup "-1"
@@ -61,21 +67,25 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=Off, QoS=2" && do_cleanup "-1"
 
-./examples/nbclient/nbclient $def_args $tls_port_args -t -q 0 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && do_cleanup "-1"
+if test $has_tls == yes
+then
+    # Run with TLS and QoS 0-2
+    ./examples/nbclient/nbclient $def_args $tls_port_args -t -q 0 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=0" && do_cleanup "-1"
 
-./examples/nbclient/nbclient $def_args $tls_port_args -t -q 1 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && do_cleanup "-1"
+    ./examples/nbclient/nbclient $def_args $tls_port_args -t -q 1 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=1" && do_cleanup "-1"
 
-./examples/nbclient/nbclient $def_args $tls_port_args -t -q 2 $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && do_cleanup "-1"
+    ./examples/nbclient/nbclient $def_args $tls_port_args -t -q 2 $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nNon-blocking Client failed! TLS=On, QoS=2" && do_cleanup "-1"
+fi
 
 # End broker
 do_cleanup "0"
- 
+
 echo -e "\n\nNon-blocking MQTT Client Tests Passed"
 
 exit 0

--- a/scripts/wiot.test
+++ b/scripts/wiot.test
@@ -7,14 +7,25 @@
 # Check for application
 [ ! -x ./examples/wiot/wiot ] && echo -e "\n\nWatson IoT MQTT Client doesn't exist" && exit 1
 
+# Check for TLS support
+has_tls=no
+./examples/azure/azureiothub -? 2>&1 | grep -- 'Enable TLS'
+if [ $? -eq 0 ]; then
+    has_tls=yes
+fi
+
 def_args="-T -C 2000"
 
-# Run
+if test -n "$WOLFMQTT_NO_EXTERNAL_BROKER_TESTS" && test $has_tls == yes; then
+    echo "WOLFMQTT_NO_EXTERNAL_BROKER_TESTS set or no TLS, won't run"
+else
+    # Run
 
-./examples/wiot/wiot $def_args $1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nWatson IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
+    ./examples/wiot/wiot $def_args $1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nWatson IoT MQTT Client failed! TLS=On, QoS=0" && exit 1
 
-echo -e "\n\nWatson IoT MQTT Client Tests Passed"
+    echo -e "\n\nWatson IoT MQTT Client Tests Passed"
+fi
 
 exit 0

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2649,13 +2649,6 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
         #endif
-            if (tmpResp->packet_type == MQTT_PACKET_TYPE_PUBLISH) {
-                /* Also cancel any publish responses */
-                MqttPublish* publish = (MqttPublish*)msg;
-                if (publish) {
-                    MqttClient_RespList_Remove(client, &publish->resp.pendResp);
-                }
-            }
             MqttClient_RespList_Remove(client, tmpResp);
             break;
         }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -31,6 +31,10 @@
 /* forward declarations */
 static int MqttClient_Publish_ReadPayload(MqttClient* client,
     MqttPublish* publish, int timeout_ms);
+#if !defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+static int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg);
+#endif
+
 
 #ifdef WOLFMQTT_MULTITHREAD
 
@@ -2588,6 +2592,9 @@ int MqttClient_WaitMessage(MqttClient *client, int timeout_ms)
     return MqttClient_WaitMessage_ex(client, &client->msg, timeout_ms);
 }
 
+#if !defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+static
+#endif
 int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
 {
     int rc = MQTT_CODE_SUCCESS;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2465,7 +2465,9 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *p_disconnect)
     }
 
 #if defined(WOLFMQTT_DISCONNECT_CB) && defined(WOLFMQTT_USE_CB_ON_DISCONNECT)
-    /* Trigger disconnect callback */
+    /* Trigger disconnect callback - for intentional disconnect
+     * This callback may occur on a network failure during an intentional
+     * disconnect if the transport/socket is not setup yet. */
     if (client->disconnect_cb
     #ifdef WOLFMQTT_NONBLOCK
         && rc != MQTT_CODE_CONTINUE

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1087,7 +1087,8 @@ wait_again:
             if (rc <= 0) {
             #ifdef WOLFMQTT_NONBLOCK
                 if (rc == MQTT_CODE_CONTINUE &&
-                                          client->packet.stat > MQTT_PK_BEGIN) {
+                        (client->packet.stat > MQTT_PK_BEGIN ||
+                         client->read.total > 0)) {
                     /* advance state, since we received some data */
                     mms_stat->read = MQTT_MSG_HEADER;
                 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2733,9 +2733,19 @@ int MqttClient_NetDisconnect(MqttClient *client)
     /* Get client lock on to ensure no other threads are active */
     wm_SemLock(&client->lockClient);
 
+#ifdef WOLFMQTT_DEBUG_CLIENT
+    PRINTF("Net Disconnect: Removing pending responses");
+#endif
     for (tmpResp = client->firstPendResp;
          tmpResp != NULL;
          tmpResp = tmpResp->next) {
+    #ifdef WOLFMQTT_DEBUG_CLIENT
+        PRINTF("\tPendResp: %p (obj %p), Type %s (%d), ID %d, InProc %d, Done %d",
+            tmpResp, tmpResp->packet_obj,
+            MqttPacket_TypeDesc(tmpResp->packet_type),
+            tmpResp->packet_type, tmpResp->packet_id,
+            tmpResp->packetProcessing, tmpResp->packetDone);
+    #endif
         MqttClient_RespList_Remove(client, tmpResp);
     }
     wm_SemUnlock(&client->lockClient);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2649,6 +2649,13 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
         #endif
+            if (tmpResp->packet_type == MQTT_PACKET_TYPE_PUBLISH) {
+                /* Also cancel any publish responses */
+                MqttPublish* publish = (MqttPublish*)msg;
+                if (publish) {
+                    MqttClient_RespList_Remove(client, &publish->resp.pendResp);
+                }
+            }
             MqttClient_RespList_Remove(client, tmpResp);
             break;
         }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1276,7 +1276,7 @@ wait_again:
             client->packetAck.protocol_level = client->protocol_level;
         #endif
 
-            mms_stat->write = MQTT_MSG_ACK;
+            mms_stat->ack = MQTT_MSG_ACK;
             break;
         }
 
@@ -1296,7 +1296,7 @@ wait_again:
         }
     } /* switch (mms_stat->read) */
 
-    switch (mms_stat->write)
+    switch (mms_stat->ack)
     {
         case MQTT_MSG_BEGIN:
         case MQTT_MSG_WAIT:
@@ -1321,7 +1321,7 @@ wait_again:
             client->write.len = rc;
             rc = MQTT_CODE_SUCCESS;
 
-            mms_stat->write = MQTT_MSG_HEADER;
+            mms_stat->ack = MQTT_MSG_HEADER;
         }
         FALL_THROUGH;
 
@@ -1343,7 +1343,7 @@ wait_again:
                 rc = MQTT_CODE_SUCCESS; /* success */
             }
 
-            mms_stat->write = MQTT_MSG_BEGIN; /* reset write state */
+            mms_stat->ack = MQTT_MSG_BEGIN; /* reset write state */
             break;
         }
 
@@ -1352,17 +1352,17 @@ wait_again:
         case MQTT_MSG_PAYLOAD2:
         default:
         #ifdef WOLFMQTT_DEBUG_CLIENT
-            PRINTF("MqttClient_WaitType: Invalid write state %d!",
-                mms_stat->write);
+            PRINTF("MqttClient_WaitType: Invalid ack state %d!",
+                mms_stat->ack);
         #endif
             rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
             break;
-    } /* switch (mms_stat->write) */
+    } /* switch (mms_stat->ack) */
 
 #ifdef WOLFMQTT_DEBUG_CLIENT
     if (rc != MQTT_CODE_CONTINUE) {
-        PRINTF("MqttClient_WaitType: rc %d, state %d-%d",
-            rc, mms_stat->read, mms_stat->write);
+        PRINTF("MqttClient_WaitType: rc %d, state %d-%d-%d",
+            rc, mms_stat->read, mms_stat->write, mms_stat->ack);
     }
 #endif
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2466,8 +2466,13 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *p_disconnect)
 
 #if defined(WOLFMQTT_DISCONNECT_CB) && defined(WOLFMQTT_USE_CB_ON_DISCONNECT)
     /* Trigger disconnect callback */
-    if (client->disconnect_cb)
+    if (client->disconnect_cb
+    #ifdef WOLFMQTT_NONBLOCK
+        && rc != MQTT_CODE_CONTINUE
+    #endif
+        ) {
         client->disconnect_cb(client, rc, client->disconnect_ctx);
+    }
 #endif
 
     /* No response for MQTT disconnect packet */

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1315,7 +1315,10 @@ wait_again:
             }
 
             client->write.len = rc;
+            /* Note: static analyzer complains about set, but not used here.
+             * Keeping it to ensure no future issues with rc > 0 */
             rc = MQTT_CODE_SUCCESS;
+            (void)rc; /* inhibit clang-analyzer-deadcode.DeadStores */
 
             mms_stat->ack = MQTT_MSG_HEADER;
         }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -170,14 +170,6 @@ static int MqttWriteStart(MqttClient* client, MqttMsgStat* stat)
         MQTT_TRACE_MSG("Warning, send already locked!");
         rc = MQTT_CODE_ERROR_SYSTEM;
     }
-    /* detect if a write is already in progress */
-    if (wm_SemLock(&client->lockClient) == 0) {
-        if (client->write.total > 0) {
-            MQTT_TRACE_MSG("Partial write in progress!");
-            rc = MQTT_CODE_CONTINUE; /* can't write yet */
-        }
-        wm_SemUnlock(&client->lockClient);
-    }
     if (rc != 0) {
         return rc;
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2032,10 +2032,12 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     /* check if response already received from other thread */
                     rc = MqttClient_CheckPendResp(client, resp_type,
                         publish->packet_id);
+                #ifndef WOLFMQTT_NONBLOCK
                     if (rc == MQTT_CODE_CONTINUE) {
                         /* mark success, let other thread handle response */
                         rc = MQTT_CODE_SUCCESS;
                     }
+                #endif
                 }
                 else
             #endif

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1381,8 +1381,16 @@ wait_again:
 
 #ifdef WOLFMQTT_NONBLOCK
     #ifdef WOLFMQTT_DEBUG_CLIENT
-    client->lastRc = rc;
+    #ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) == 0)
     #endif
+    {
+        client->lastRc = rc;
+    #ifdef WOLFMQTT_MULTITHREAD
+        wm_SemUnlock(&client->lockClient);
+    #endif
+    }
+    #endif /* WOLFMQTT_DEBUG_CLIENT */
     if (rc == MQTT_CODE_CONTINUE) {
         return rc;
     }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1963,7 +1963,6 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
     {
         case MQTT_PK_BEGIN:
         {
-            client->read.pos = 0;
             client->packet.header_len = MQTT_PACKET_HEADER_MIN_SIZE;
             client->packet.remain_len = 0;
 

--- a/src/mqtt_sn_client.c
+++ b/src/mqtt_sn_client.c
@@ -506,7 +506,7 @@ wait_again:
                 PRINTF("SN_Client_WaitType recv lock error");
                 return rc;
             }
-            mms_stat->isReadLocked = 1;
+            mms_stat->isReadActive = 1;
             MQTT_TRACE_MSG("SN lockRecv");
         #endif
 
@@ -667,8 +667,8 @@ wait_again:
         mms_stat->read = MQTT_MSG_BEGIN;
 
     #ifdef WOLFMQTT_MULTITHREAD
-        if (mms_stat->isReadLocked) {
-            mms_stat->isReadLocked = 0;
+        if (mms_stat->isReadActive) {
+            mms_stat->isReadActive = 0;
             wm_SemUnlock(&client->lockRecv);
         }
     #endif

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -173,9 +173,8 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
     #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
         static int testSmallerWrite = 0;
         if (!testSmallerWrite) {
-            if (buf_len > 100) {
+            if (buf_len > 1)
                 buf_len /= 2;
-            }
             testSmallerWrite = 1;
         }
         else {
@@ -300,9 +299,8 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
     #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
         static int testSmallerRead = 0;
         if (!testSmallerRead) {
-            if (buf_len > 100) {
+            if (buf_len > 1)
                 buf_len /= 2;
-            }
             testSmallerRead = 1;
         }
         else {

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -217,6 +217,7 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
         buf_len - client->write.pos, timeout_ms);
     if (rc >= 0) {
         client->write.pos += rc;
+        client->write.total += rc;
         if (client->write.pos < buf_len) {
             rc = MQTT_CODE_CONTINUE;
         }
@@ -233,6 +234,7 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
             break;
         }
         client->write.pos += rc;
+        client->write.total += rc;
     } while (client->write.pos < buf_len);
 #endif /* WOLFMQTT_NONBLOCK */
 
@@ -339,6 +341,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
         buf_len - client->read.pos, timeout_ms);
     if (rc >= 0) {
         client->read.pos += rc;
+        client->read.total += rc;
         if (client->read.pos < buf_len) {
             rc = MQTT_CODE_CONTINUE;
         }
@@ -355,6 +358,7 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
             break;
         }
         client->read.pos += rc;
+        client->read.total += rc;
     } while (client->read.pos < buf_len);
 #endif /* WOLFMQTT_NONBLOCK */
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -41,6 +41,12 @@
 #ifdef WOLFMQTT_NO_STDIO
     #undef WOLFMQTT_DEBUG_SOCKET
 #endif
+
+/* #define WOLFMQTT_TEST_NONBLOCK */
+#ifdef WOLFMQTT_TEST_NONBLOCK
+    #define WOLFMQTT_TEST_NONBLOCK_TIMES 1
+#endif
+
 /* lwip */
 #ifdef WOLFSSL_LWIP
     #undef read
@@ -125,8 +131,8 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
 
 #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
     static int testNbWriteAlt = 0;
-    if (!testNbWriteAlt) {
-        testNbWriteAlt = 1;
+    if (testNbWriteAlt < WOLFMQTT_TEST_NONBLOCK_TIMES) {
+        testNbWriteAlt++;
         return MQTT_CODE_CONTINUE;
     }
     testNbWriteAlt = 0;
@@ -247,8 +253,8 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
 
 #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
     static int testNbReadAlt = 0;
-    if (!testNbReadAlt) {
-        testNbReadAlt = 1;
+    if (testNbReadAlt < WOLFMQTT_TEST_NONBLOCK_TIMES) {
+        testNbReadAlt++;
         return MQTT_CODE_CONTINUE;
     }
     testNbReadAlt = 0;

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -128,8 +128,9 @@ typedef struct _MqttPkRead {
 } MqttPkRead;
 
 typedef struct _MqttSk {
-    int pos;
-    int len;
+    int pos;   /* position inside current buffer */
+    int len;   /* length of current segment being sent */
+    int total; /* number bytes sent or received */
 } MqttSk;
 
 #ifdef WOLFMQTT_DISCONNECT_CB
@@ -496,9 +497,8 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
     MqttObject *msg,
     int timeout_ms);
 
-#if defined(WOLFMQTT_MULTITHREAD) || defined(WOLFMQTT_NONBLOCK)
-/*! \brief      In a multi-threaded and non-blocking mode this allows you to
-                cancel an MQTT object that was previously submitted.
+/*! \brief      Cancel a partially sent message. Applies to multi-threaded or
+                non-blocking mode
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
  *  \param      msg         Pointer to MqttObject structure
@@ -508,7 +508,6 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
 WOLFMQTT_API int MqttClient_CancelMessage(
     MqttClient *client,
     MqttObject *msg);
-#endif
 
 #ifdef WOLFMQTT_NONBLOCK
 /*! \brief      In a non-blocking mode this checks if the message has a read

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -497,8 +497,9 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
     MqttObject *msg,
     int timeout_ms);
 
-/*! \brief      Cancel a partially sent message. Applies to multi-threaded or
-                non-blocking mode
+#if defined(WOLFMQTT_MULTITHREAD) || defined(WOLFMQTT_NONBLOCK)
+/*! \brief      In a multi-threaded and non-blocking mode this allows you to
+                cancel an MQTT object that was previously submitted.
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
  *  \param      msg         Pointer to MqttObject structure
@@ -508,6 +509,7 @@ WOLFMQTT_API int MqttClient_WaitMessage_ex(
 WOLFMQTT_API int MqttClient_CancelMessage(
     MqttClient *client,
     MqttObject *msg);
+#endif
 
 #ifdef WOLFMQTT_NONBLOCK
 /*! \brief      In a non-blocking mode this checks if the message has a read

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -292,10 +292,8 @@ typedef struct _MqttMsgStat {
     MqttMsgState read;
     MqttMsgState write;
 
-#ifdef WOLFMQTT_MULTITHREAD
-    byte isReadLocked:1;
-    byte isWriteLocked:1;
-#endif
+    byte isReadActive:1;
+    byte isWriteActive:1;
 } MqttMsgStat;
 
 #ifdef WOLFMQTT_MULTITHREAD

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -291,6 +291,7 @@ typedef enum _MqttMsgState {
 typedef struct _MqttMsgStat {
     MqttMsgState read;
     MqttMsgState write;
+    MqttMsgState ack;
 
     byte isReadActive:1;
     byte isWriteActive:1;


### PR DESCRIPTION
* Refactor of locking to better detect and handle edge cases. Allow partial writes on all packet types.
* Fix for issue processing wait for a publish with ack on a different packet type causing the write state to get reset.
* Fix issue with publish write only incorrectly removing pending response. ZD 16769. 
* Fix for cancelling publish to also attempt to cancel any publish responses expected (Qos 1 and 2).
* Fix for read of fixed portion (2 bytes) of header when only 1 is returned.
* Remove extra test non-block in `MqttClient_Publish_ReadPayload` (already handled in `MqttSocket_Read`).
* Improvements to the testing
* Cleanup return code 0=success (use MQTT_CODE_SUCCESS)