### PR TITLE
Fixes for non-blocking with larger payload and improvements to the test and examples

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -617,8 +617,9 @@ int awsiot_test(MQTTCtx *mqttCtx)
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }
-            PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                mqttCtx->publish.topic_name, MqttClient_ReturnCodeToString(rc), rc);
+            PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
+                MqttClient_ReturnCodeToString(rc), rc);
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
@@ -676,8 +677,8 @@ int awsiot_test(MQTTCtx *mqttCtx)
                         mqttCtx->publish.buffer = (byte*)mqttCtx->app_ctx;
                         mqttCtx->publish.total_len = (word32)XSTRLEN((char*)mqttCtx->app_ctx);
                         rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-                        PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                            mqttCtx->publish.topic_name,
+                        PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                            mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
                 }

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -60,7 +60,9 @@ static int mTestDone = 0;
 #define APP_HARDWARE         "wolf_aws_iot_demo"
 #define APP_FIRMWARE_VERSION LIBWOLFMQTT_VERSION_STRING
 
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE         512    /* Maximum size for network read/write callbacks */
+#endif
 #define AWSIOT_HOST             "a2dujmi05ideo2-ats.iot.us-west-2.amazonaws.com"
 #define AWSIOT_DEVICE_ID        "demoDevice"
 #define AWSIOT_QOS              MQTT_QOS_1

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -439,8 +439,9 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             if (rc == MQTT_CODE_CONTINUE) {
                 return rc;
             }
-            PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                mqttCtx->publish.topic_name, MqttClient_ReturnCodeToString(rc), rc);
+            PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
+                MqttClient_ReturnCodeToString(rc), rc);
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;
             }
@@ -496,8 +497,8 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                         mqttCtx->publish.total_len = (word16)rc;
 
                         rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-                        PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                            mqttCtx->publish.topic_name,
+                        PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                            mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                             MqttClient_ReturnCodeToString(rc), rc);
                     }
                 }

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -76,7 +76,9 @@ static int mTestDone = 0;
  * https://azure.microsoft.com/en-us/documentation/articles/iot-hub-sas-tokens/#using-sas-tokens-as-a-device
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support
  */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE         1024    /* Maximum size for network read/write callbacks */
+#endif
 #define AZURE_API_VERSION       "?api-version=2018-06-30"
 #define AZURE_HOST              "wolfMQTT.azure-devices.net"
 #define AZURE_DEVICE_ID         "demoDevice"

--- a/examples/firmware/fwclient.c
+++ b/examples/firmware/fwclient.c
@@ -55,7 +55,9 @@
 #include "examples/mqttnet.h"
 
 /* Configuration */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE         FIRMWARE_MAX_PACKET
+#endif
 
 /* Locals */
 static int mStopRead = 0;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -455,8 +455,8 @@ int fwpush_test(MQTTCtx *mqttCtx)
                 return rc;
             }
 
-            PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                mqttCtx->publish.topic_name,
+            PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                 MqttClient_ReturnCodeToString(rc), rc);
             if (rc != MQTT_CODE_SUCCESS) {
                 goto disconn;

--- a/examples/firmware/fwpush.c
+++ b/examples/firmware/fwpush.c
@@ -56,7 +56,9 @@
 #include "examples/mqttnet.h"
 
 /* Configuration */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE         FIRMWARE_MAX_PACKET
+#endif
 
 /* Locals */
 static int mStopRead = 0;

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -510,8 +510,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
             mqttCtx->pub_file = NULL; /* don't try and send file again */
         }
 
-        PRINTF("MQTT Publish: Topic %s, %s (%d)",
-            mqttCtx->publish.topic_name,
+        PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+            mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
             MqttClient_ReturnCodeToString(rc), rc);
     #ifdef WOLFMQTT_V5
         if (mqttCtx->qos > 0) {
@@ -576,8 +576,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                 mqttCtx->publish.total_len = (word16)rc;
                 rc = MqttClient_Publish(&mqttCtx->client,
                        &mqttCtx->publish);
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
+                PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                    mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                     MqttClient_ReturnCodeToString(rc), rc);
             }
         }

--- a/examples/mqttclient/mqttclient.c
+++ b/examples/mqttclient/mqttclient.c
@@ -34,7 +34,9 @@ static int mStopRead = 0;
 
 /* Maximum size for network read/write callbacks. There is also a v5 define that
    describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 
 #ifdef WOLFMQTT_PROPERTY_CB
 #define MAX_CLIENT_ID_LEN 64
@@ -504,6 +506,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
         if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
             WOLFMQTT_FREE(mqttCtx->publish.buffer);
+            mqttCtx->publish.buffer = NULL;
+            mqttCtx->pub_file = NULL; /* don't try and send file again */
         }
 
         PRINTF("MQTT Publish: Topic %s, %s (%d)",

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -424,8 +424,9 @@ int mqttsimple_test(void)
     if (rc != MQTT_CODE_SUCCESS) {
         goto exit;
     }
-    PRINTF("MQTT Publish: Topic %s, Qos %d, Message %s",
-        mqttObj.publish.topic_name, mqttObj.publish.qos, mqttObj.publish.buffer);
+    PRINTF("MQTT Publish: Topic %s, ID %d, Qos %d, Message %s",
+        mqttObj.publish.topic_name, mqttObj.publish.packet_id,
+        mqttObj.publish.qos, mqttObj.publish.buffer);
 
     /* Wait for messages */
     while (1) {

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -42,7 +42,9 @@
 
 /* Maximum size for network read/write callbacks. There is also a v5 define that
    describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 
 /* Total size of test message to build */
 #define TEST_MESSAGE_SIZE 1048 /* span more than one max packet */

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -559,8 +559,8 @@ static void *waitMessage_task(void *param)
                     MqttClient_CancelMessage(&mqttCtx->client,
                         (MqttObject*)&mqttCtx->publish);
                 }
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
+                PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                    mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                     MqttClient_ReturnCodeToString(rc), rc);
             }
         }
@@ -637,8 +637,8 @@ static void *publish_task(void *param)
             MqttClient_CancelMessage(&mqttCtx->client, (MqttObject*)&publish[i]);
         }
 
-        PRINTF("MQTT Publish: Topic %s, %s (%d)",
-            publish[i].topic_name,
+        PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+            publish[i].topic_name, publish[i].packet_id,
             MqttClient_ReturnCodeToString(rc[i]), rc[i]);
 
         wm_SemLock(&mtLock);

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -38,7 +38,9 @@ static int mTestDone = 0;
 /* Configuration */
 
 /* Maximum size for network read/write callbacks. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 
 #ifdef WOLFMQTT_PROPERTY_CB
 #define MAX_CLIENT_ID_LEN 64
@@ -444,6 +446,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
 
                 if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
                     WOLFMQTT_FREE(mqttCtx->publish.buffer);
+                    mqttCtx->publish.buffer = NULL;
+                    mqttCtx->pub_file = NULL; /* don't try and send file again */
                 }
 
                 PRINTF("MQTT Publish: Topic %s, %s (%d)",

--- a/examples/nbclient/nbclient.c
+++ b/examples/nbclient/nbclient.c
@@ -450,8 +450,8 @@ int mqttclient_test(MQTTCtx *mqttCtx)
                     mqttCtx->pub_file = NULL; /* don't try and send file again */
                 }
 
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
+                PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                    mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                     MqttClient_ReturnCodeToString(rc), rc);
                 if (rc != MQTT_CODE_SUCCESS) {
                     goto disconn;

--- a/examples/pub-sub/mqtt-pub.c
+++ b/examples/pub-sub/mqtt-pub.c
@@ -30,8 +30,10 @@
 /* Configuration */
 
 /* Maximum size for network read/write callbacks. There is also a v5 define that
-   describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+ * describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 
 #ifdef WOLFMQTT_PROPERTY_CB
 #define MAX_CLIENT_ID_LEN 64
@@ -381,6 +383,8 @@ int pub_client(MQTTCtx *mqttCtx)
 
         if ((mqttCtx->pub_file) && (mqttCtx->publish.buffer)) {
             WOLFMQTT_FREE(mqttCtx->publish.buffer);
+            mqttCtx->publish.buffer = NULL;
+            mqttCtx->pub_file = NULL; /* don't try and send file again */
         }
         if (mqttCtx->debug_on) {
             PRINTF("MQTT Publish: Topic %s, %s (%d)",

--- a/examples/pub-sub/mqtt-pub.c
+++ b/examples/pub-sub/mqtt-pub.c
@@ -387,8 +387,8 @@ int pub_client(MQTTCtx *mqttCtx)
             mqttCtx->pub_file = NULL; /* don't try and send file again */
         }
         if (mqttCtx->debug_on) {
-            PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                mqttCtx->publish.topic_name,
+            PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                 MqttClient_ReturnCodeToString(rc), rc);
         }
         if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/pub-sub/mqtt-sub.c
+++ b/examples/pub-sub/mqtt-sub.c
@@ -33,8 +33,10 @@ static int mStopRead = 0;
 /* Configuration */
 
 /* Maximum size for network read/write callbacks. There is also a v5 define that
-   describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+ * describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 
 #ifdef WOLFMQTT_PROPERTY_CB
 #define MAX_CLIENT_ID_LEN 64

--- a/examples/sn-client/sn-client.c
+++ b/examples/sn-client/sn-client.c
@@ -36,7 +36,9 @@ static int mStopRead = 0;
 
 /* Configuration */
 /* Maximum size for network read/write callbacks. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 #define TEST_MESSAGE    "test"
 #define SHORT_TOPIC_NAME "s1"
 
@@ -215,11 +217,11 @@ int sn_test(MQTTCtx *mqttCtx)
         /* Send Connect and wait for Connect Ack */
         rc = SN_Client_Connect(&mqttCtx->client, connect);
 
-        if (rc != MQTT_CODE_SUCCESS) {                                          
-            PRINTF("MQTT-SN Connect: %s (%d)",                                  
-                MqttClient_ReturnCodeToString(rc), rc);                         
-            goto disconn;                                                       
-        }    
+        if (rc != MQTT_CODE_SUCCESS) {
+            PRINTF("MQTT-SN Connect: %s (%d)",
+                MqttClient_ReturnCodeToString(rc), rc);
+            goto disconn;
+        }
 
         /* Validate Connect Ack info */
         PRINTF("....MQTT-SN Connect Ack: Return Code %u",

--- a/examples/sn-client/sn-client_qos-1.c
+++ b/examples/sn-client/sn-client_qos-1.c
@@ -40,7 +40,9 @@ static int mStopRead = 0;
 
 /* Configuration */
 /* Maximum size for network read/write callbacks. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 #define TEST_MESSAGE    "QoS-1 test message"
 char    SHORT_TOPIC_NAME[] = {1};
 

--- a/examples/sn-client/sn-multithread.c
+++ b/examples/sn-client/sn-multithread.c
@@ -36,7 +36,9 @@
 /* Configuration */
 
 /* Maximum size for network read/write callbacks. */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024
+#endif
 #define TEST_MESSAGE    "test00"
 /* Number of publish tasks. Each will send a unique message to the broker. */
 #define NUM_PUB_TASKS   10

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -41,7 +41,9 @@ static int mStopRead = 0;
 static int mTestDone = 0;
 
 /* Configuration */
+#ifndef MAX_BUFFER_SIZE
 #define MAX_BUFFER_SIZE 1024 /* Maximum size for network read/write callbacks */
+#endif
 
 /* Undefine if using an IBM WIOT Platform account that you created. */
 #define WIOT_USE_QUICKSTART

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -265,8 +265,9 @@ int wiot_test(MQTTCtx *mqttCtx)
 
     rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
 
-    PRINTF("MQTT Publish: Topic %s, %s (%d)",
-        mqttCtx->publish.topic_name, MqttClient_ReturnCodeToString(rc), rc);
+    PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+        mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
+        MqttClient_ReturnCodeToString(rc), rc);
     if (rc != MQTT_CODE_SUCCESS) {
         goto disconn;
     }
@@ -316,8 +317,8 @@ int wiot_test(MQTTCtx *mqttCtx)
                 mqttCtx->publish.buffer = mqttCtx->rx_buf;
                 mqttCtx->publish.total_len = (word16)rc;
                 rc = MqttClient_Publish(&mqttCtx->client, &mqttCtx->publish);
-                PRINTF("MQTT Publish: Topic %s, %s (%d)",
-                    mqttCtx->publish.topic_name,
+                PRINTF("MQTT Publish: Topic %s, ID %d, %s (%d)",
+                    mqttCtx->publish.topic_name, mqttCtx->publish.packet_id,
                     MqttClient_ReturnCodeToString(rc), rc);
             }
         }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1984,7 +1984,9 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
             int i;
             client->packet.stat = MQTT_PK_READ_HEAD;
 
-            for (i = 0; i < MQTT_PACKET_MAX_LEN_BYTES; i++) {
+            for (i = (client->packet.header_len - MQTT_PACKET_HEADER_MIN_SIZE);
+                 i < MQTT_PACKET_MAX_LEN_BYTES;
+                 i++) {
                 /* Check if another byte is needed */
                 if ((header->len[i] & MQTT_PACKET_LEN_ENCODE_MASK) == 0) {
                     /* Variable byte length can be determined */

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -42,11 +42,6 @@
     #undef WOLFMQTT_DEBUG_SOCKET
 #endif
 
-/* #define WOLFMQTT_TEST_NONBLOCK */
-#ifdef WOLFMQTT_TEST_NONBLOCK
-    #define WOLFMQTT_TEST_NONBLOCK_TIMES 1
-#endif
-
 /* lwip */
 #ifdef WOLFSSL_LWIP
     #undef read
@@ -63,18 +58,6 @@ int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
     int rc;
     MqttClient *client = (MqttClient*)ptr;
     (void)ssl; /* Not used */
-
-#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-    static int testSmallerTlsRead = 0;
-    if (!testSmallerTlsRead) {
-        if (sz > 2)
-            sz /= 2;
-        testSmallerTlsRead = 1;
-    }
-    else {
-        testSmallerTlsRead = 0;
-    }
-#endif
 
     rc = client->net->read(client->net->context, (byte*)buf, sz,
         client->tls.timeout_ms);
@@ -98,18 +81,6 @@ int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
     int rc;
     MqttClient *client = (MqttClient*)ptr;
     (void)ssl; /* Not used */
-
-#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-    static int testSmallerTlsWrite = 0;
-    if (!testSmallerTlsWrite) {
-        if (sz > 2)
-            sz /= 2;
-        testSmallerTlsWrite = 1;
-    }
-    else {
-        testSmallerTlsWrite = 0;
-    }
-#endif
 
     rc = client->net->write(client->net->context, (byte*)buf, sz,
         client->tls.timeout_ms);
@@ -153,15 +124,6 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
 {
     int rc;
 
-#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-    static int testNbWriteAlt = 0;
-    if (testNbWriteAlt < WOLFMQTT_TEST_NONBLOCK_TIMES) {
-        testNbWriteAlt++;
-        return MQTT_CODE_CONTINUE;
-    }
-    testNbWriteAlt = 0;
-#endif
-
 #ifdef ENABLE_MQTT_TLS
     if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_TLS) {
         client->tls.timeout_ms = timeout_ms;
@@ -194,18 +156,6 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
     else
 #endif /* ENABLE_MQTT_TLS */
     {
-    #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-        static int testSmallerWrite = 0;
-        if (!testSmallerWrite) {
-            if (buf_len > 2)
-                buf_len /= 2;
-            testSmallerWrite = 1;
-        }
-        else {
-            testSmallerWrite = 0;
-        }
-    #endif
-
         rc = client->net->write(client->net->context, buf, buf_len,
             timeout_ms);
     }
@@ -276,15 +226,6 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
 {
     int rc;
 
-#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-    static int testNbReadAlt = 0;
-    if (testNbReadAlt < WOLFMQTT_TEST_NONBLOCK_TIMES) {
-        testNbReadAlt++;
-        return MQTT_CODE_CONTINUE;
-    }
-    testNbReadAlt = 0;
-#endif
-
 #ifdef ENABLE_MQTT_TLS
     if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_TLS) {
         client->tls.timeout_ms = timeout_ms;
@@ -320,17 +261,6 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
     else
 #endif /* ENABLE_MQTT_TLS */
     {
-    #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
-        static int testSmallerRead = 0;
-        if (!testSmallerRead) {
-            if (buf_len > 2)
-                buf_len /= 2;
-            testSmallerRead = 1;
-        }
-        else {
-            testSmallerRead = 0;
-        }
-    #endif
         rc = client->net->read(client->net->context, buf, buf_len, timeout_ms);
     }
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -64,6 +64,18 @@ int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
     MqttClient *client = (MqttClient*)ptr;
     (void)ssl; /* Not used */
 
+#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+    static int testSmallerTlsRead = 0;
+    if (!testSmallerTlsRead) {
+        if (sz > 2)
+            sz /= 2;
+        testSmallerTlsRead = 1;
+    }
+    else {
+        testSmallerTlsRead = 0;
+    }
+#endif
+
     rc = client->net->read(client->net->context, (byte*)buf, sz,
         client->tls.timeout_ms);
 
@@ -86,6 +98,18 @@ int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
     int rc;
     MqttClient *client = (MqttClient*)ptr;
     (void)ssl; /* Not used */
+
+#if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
+    static int testSmallerTlsWrite = 0;
+    if (!testSmallerTlsWrite) {
+        if (sz > 2)
+            sz /= 2;
+        testSmallerTlsWrite = 1;
+    }
+    else {
+        testSmallerTlsWrite = 0;
+    }
+#endif
 
     rc = client->net->write(client->net->context, (byte*)buf, sz,
         client->tls.timeout_ms);
@@ -173,7 +197,7 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
     #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
         static int testSmallerWrite = 0;
         if (!testSmallerWrite) {
-            if (buf_len > 1)
+            if (buf_len > 2)
                 buf_len /= 2;
             testSmallerWrite = 1;
         }
@@ -299,7 +323,7 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
     #if defined(WOLFMQTT_NONBLOCK) && defined(WOLFMQTT_TEST_NONBLOCK)
         static int testSmallerRead = 0;
         if (!testSmallerRead) {
-            if (buf_len > 1)
+            if (buf_len > 2)
                 buf_len /= 2;
             testSmallerRead = 1;
         }

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -131,6 +131,9 @@ typedef struct _MqttSk {
     int pos;   /* position inside current buffer */
     int len;   /* length of current segment being sent */
     int total; /* number bytes sent or received */
+
+    /* status bit for if client read or write is active */
+    byte isActive:1;
 } MqttSk;
 
 #ifdef WOLFMQTT_DISCONNECT_CB

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -115,7 +115,7 @@ enum MqttClientFlags {
 WOLFMQTT_API word32 MqttClient_Flags(struct _MqttClient *client,  word32 mask, word32 flags);
 
 typedef enum _MqttPkStat {
-    MQTT_PK_BEGIN,
+    MQTT_PK_BEGIN = 0,
     MQTT_PK_READ_HEAD,
     MQTT_PK_READ
 } MqttPkStat;


### PR DESCRIPTION
* Fix for continue during variable part of the header. A continue in the middle of variable would not correctly process for large messages.
* Fixed issue with QoS2 on received publish ACK getting skipped if write is already locked.
* Further improve WOLFMQTT_TEST_NONBLOCK.
* Added logic for detection of active read or write to return MQTT_CODE_CONTINUE.
* By default keep mutex locked if we tried to write. The wolfSSL TLS engine requires an SSL_Write that returns WANT_WRITE to be called with the same buffer/sz, not a different one, even if no data was sent. If user wants to enable the feature anyways they can use WOLFMQTT_ALLOW_NODATA_UNLOCK. Only the write has this logic as the issue doesn't exist for an SSL_Read.
* Fixes for using the `-f [file]` option with examples. 
* Allow build-time override of `MAX_BUFFER_SIZE` in examples.
* Add packet_id to the publish log message in examples.
* Add test case for trying to send multiple publishes in the same thread.
ZD 16769