### PR TITLE
Tiny readme cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ More about MQTT-SN examples in [examples/sn-client/README.md](examples/sn-client
 ### Multithread Example
 This example exercises the multithreading capabilities of the client library. The client implements two tasks: one that publishes to the broker; and another that waits for messages from the broker. The publish thread is created `NUM_PUB_TASKS` times (10 by default) and sends unique messages to the broker. This feature is enabled using the `--enable-mt` configuration option. The example is located in `/examples/multithread/`.
 
-The multi-threading feature can also be used with the non-blocking socket (--enable-nb).
+The multi-threading feature can also be used with the non-blocking socket (--enable-nonblock).
 
 If you are having issues with thread synchronization on Linux consider using not the conditional signal (`WOLFMQTT_NO_COND_SIGNAL`).
 

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -51,7 +51,7 @@ CMakeFiles.txt in the build system.
 
 ## Build and Run Samples
 
-Follow the [instructions](https://docs.zephyrproject.org/latest/connectivity/networking/qemu_setup.html) to setup the infratructure to enable networking in QEMU. Run the following commands in parallel in this order in the `net-tools` directory to allow comunication between the QEMU instance and the host. Make sure to disable any software that modifies the local network like VPN's.
+Follow the [instructions](https://docs.zephyrproject.org/latest/connectivity/networking/qemu_setup.html) to setup the infratructure to enable networking in QEMU. Run the following commands in parallel in this order in the `net-tools` directory to allow communication between the QEMU instance and the host. Make sure to disable any software that modifies the local network like VPN's.
 
 ```bash
 ./loop-socat.sh


### PR DESCRIPTION
Small cleanup to Zephyr and main readme:

- README.md: `enable-nb` should be `enable-nonblock`. There is no `enable-nb` configure option.
```
./configure --enable-nb 
configure: WARNING: unrecognized options: --enable-nb
...
```
- zephyr/README.md:  `comunication` -> `communication`.