### PR TITLE
Fix Helgrind thread errors with enable-tls, and enable-curl.

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1551,6 +1551,16 @@ int MqttClient_Init(MqttClient *client, MqttNet* net,
     if (rc == 0) {
         rc = wm_SemInit(&client->lockClient);
     }
+    #ifdef ENABLE_MQTT_TLS
+    if (rc == 0) {
+        rc = wm_SemInit(&client->lockSSL);
+    }
+    #endif
+    #ifdef ENABLE_MQTT_CURL
+    if (rc == 0) {
+        rc = wm_SemInit(&client->lockCURL);
+    }
+    #endif
 #endif
 
     if (rc == 0) {
@@ -1573,6 +1583,12 @@ void MqttClient_DeInit(MqttClient *client)
         (void)wm_SemFree(&client->lockSend);
         (void)wm_SemFree(&client->lockRecv);
         (void)wm_SemFree(&client->lockClient);
+    #ifdef ENABLE_MQTT_TLS
+        (void)wm_SemFree(&client->lockSSL);
+    #endif
+    #ifdef ENABLE_MQTT_CURL
+        (void)wm_SemFree(&client->lockCURL);
+    #endif
 #endif
     }
 #ifdef WOLFMQTT_V5

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -209,6 +209,12 @@ typedef struct _MqttClient {
     wm_Sem lockSend;
     wm_Sem lockRecv;
     wm_Sem lockClient;
+    #ifdef ENABLE_MQTT_TLS
+    wm_Sem lockSSL;
+    #endif
+    #ifdef ENABLE_MQTT_CURL
+    wm_Sem lockCURL;
+    #endif
     struct _MqttPendResp* firstPendResp; /* protected with client lock */
     struct _MqttPendResp* lastPendResp;  /* protected with client lock */
 #endif

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -71,7 +71,8 @@ typedef struct _MqttTls {
     WOLFSSL             *ssl;
     int                 sockRcRead;
     int                 sockRcWrite;
-    int                 timeout_ms;
+    int                 timeout_ms_read;
+    int                 timeout_ms_write;
 } MqttTls;
 #endif
 


### PR DESCRIPTION
Fix Helgrind thread errors around simultaneous reads and writes from different threads:
- Simultaneous read and write with WOLFSSL struct.
- Simultaneous read and write with CURL handle.
- Separate `tls.timeout_ms` member into separate `tls.timeout_ms_read` and `tls.timeout_ms_write` members to prevent simultaneous assignment or overwriting.
- Separate `mqttcurl_test_nonblock()` into separate read and write functions to fix simultaneous updates from different read/write threads.