### PR TITLE
Fix some Helgrind thread errors with enable-tls, and enable-curl.

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1551,6 +1551,11 @@ int MqttClient_Init(MqttClient *client, MqttNet* net,
     if (rc == 0) {
         rc = wm_SemInit(&client->lockClient);
     }
+    #ifdef ENABLE_MQTT_CURL
+    if (rc == 0) {
+        rc = wm_SemInit(&client->lockCURL);
+    }
+    #endif
 #endif
 
     if (rc == 0) {
@@ -1573,6 +1578,9 @@ void MqttClient_DeInit(MqttClient *client)
         (void)wm_SemFree(&client->lockSend);
         (void)wm_SemFree(&client->lockRecv);
         (void)wm_SemFree(&client->lockClient);
+    #ifdef ENABLE_MQTT_CURL
+        (void)wm_SemFree(&client->lockCURL);
+    #endif
 #endif
     }
 #ifdef WOLFMQTT_V5

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -64,7 +64,7 @@ int MqttSocket_TlsSocketReceive(WOLFSSL* ssl, char *buf, int sz,
     (void)ssl; /* Not used */
 
     rc = client->net->read(client->net->context, (byte*)buf, sz,
-        client->tls.timeout_ms);
+        client->tls.timeout_ms_read);
 
     /* save network read response */
     client->tls.sockRcRead = rc;
@@ -87,7 +87,7 @@ int MqttSocket_TlsSocketSend(WOLFSSL* ssl, char *buf, int sz,
     (void)ssl; /* Not used */
 
     rc = client->net->write(client->net->context, (byte*)buf, sz,
-        client->tls.timeout_ms);
+        client->tls.timeout_ms_write);
 
     /* save network write response */
     client->tls.sockRcWrite = rc;
@@ -116,7 +116,8 @@ int MqttSocket_Init(MqttClient *client, MqttNet *net)
     #if defined(ENABLE_MQTT_TLS) && !defined(ENABLE_MQTT_CURL)
         client->tls.ctx = NULL;
         client->tls.ssl = NULL;
-        client->tls.timeout_ms = client->cmd_timeout_ms;
+        client->tls.timeout_ms_read = client->cmd_timeout_ms;
+        client->tls.timeout_ms_write = client->cmd_timeout_ms;
     #endif
 
         /* Validate callbacks are not null! */
@@ -134,8 +135,9 @@ static int MqttSocket_WriteDo(MqttClient *client, const byte* buf, int buf_len,
 
 #if defined(ENABLE_MQTT_TLS) && !defined(ENABLE_MQTT_CURL)
     if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_TLS) {
-        client->tls.timeout_ms = timeout_ms;
+        client->tls.timeout_ms_write = timeout_ms;
         client->tls.sockRcWrite = 0; /* init value */
+
         rc = wolfSSL_write(client->tls.ssl, (char*)buf, buf_len);
         if (rc < 0) {
         #if defined(WOLFMQTT_DEBUG_SOCKET) || defined(WOLFSSL_ASYNC_CRYPT)
@@ -236,8 +238,9 @@ static int MqttSocket_ReadDo(MqttClient *client, byte* buf, int buf_len,
 
 #if defined(ENABLE_MQTT_TLS) && !defined(ENABLE_MQTT_CURL)
     if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_TLS) {
-        client->tls.timeout_ms = timeout_ms;
+        client->tls.timeout_ms_read = timeout_ms;
         client->tls.sockRcRead = 0; /* init value */
+
         rc = wolfSSL_read(client->tls.ssl, (char*)buf, buf_len);
         if (rc < 0) {
             int error = wolfSSL_get_error(client->tls.ssl, 0);

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -209,6 +209,9 @@ typedef struct _MqttClient {
     wm_Sem lockSend;
     wm_Sem lockRecv;
     wm_Sem lockClient;
+    #ifdef ENABLE_MQTT_CURL
+    wm_Sem lockCURL;
+    #endif
     struct _MqttPendResp* firstPendResp; /* protected with client lock */
     struct _MqttPendResp* lastPendResp;  /* protected with client lock */
 #endif

--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -71,7 +71,8 @@ typedef struct _MqttTls {
     WOLFSSL             *ssl;
     int                 sockRcRead;
     int                 sockRcWrite;
-    int                 timeout_ms;
+    int                 timeout_ms_read;
+    int                 timeout_ms_write;
 } MqttTls;
 #endif
 


### PR DESCRIPTION
Fixes a subset of thread errors from PR https://github.com/wolfSSL/wolfMQTT/pull/395.

Fix some Helgrind thread errors around simultaneous reads and writes from different threads:

- Simultaneous read and write with CURL handle.
- Separate tls.timeout_ms member into separate tls.timeout_ms_read and tls.timeout_ms_write members to prevent simultaneous assignment or overwriting.
- Separate `mqttcurl_test_nonblock()` into separate read and write functions to fix simultaneous updates from different read/write threads.

This passes whereas PR https://github.com/wolfSSL/wolfMQTT/pull/395 fails. Apparently the extra locking around SSL struct makes the multithreading CI tests unstable, though it fixes threading errors.

Note: ultimately tested with helgrind and drd:
- `valgrind --tool=helgrind --track-lockorders=yes --free-is-write=yes --fair-sched=yes -s`
- `valgrind --tool=drd --trace-mutex=yes --fair-sched=yes -s`