### PR TITLE
Fix Zephyr example

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -5,4 +5,10 @@ if(CONFIG_WOLFMQTT)
   FILE(GLOB wolfmqtt_sources ${ZEPHYR_CURRENT_MODULE_DIR}/src/*.c)
   target_sources(app PRIVATE ${wolfmqtt_sources})
   add_definitions(-DWOLFMQTT_ZEPHYR)
+
+  if(CONFIG_WOLFMQTT_SETTINGS_FILE)
+      target_compile_definitions(wolfmqtt INTERFACE
+        WOLFMQTT_SETTINGS_FILE="${CONFIG_WOLFMQTT_SETTINGS_FILE}"
+      )
+    endif()
 endif()

--- a/zephyr/samples/client/user_settings.h
+++ b/zephyr/samples/client/user_settings.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+/* If a custom user_settings file is provided use it instead */
+#ifdef WOLFMQTT_SETTINGS_FILE
+#include WOLFMQTT_SETTINGS_FILE
+#endif
+
 #undef NO_FILESYSTEM
 #define NO_FILESYSTEM
 

--- a/zephyr/samples/client_tls/user_settings.h
+++ b/zephyr/samples/client_tls/user_settings.h
@@ -5,8 +5,9 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_WOLFSSL_SETTINGS_FILE
-#include CONFIG_WOLFSSL_SETTINGS_FILE
+/* If a custom user_settings file is provided use it instead */
+#ifdef WOLFMQTT_SETTINGS_FILE
+#include WOLFMQTT_SETTINGS_FILE
 #endif
 
 #undef NO_FILESYSTEM


### PR DESCRIPTION
Fix Zephyr custom user_settings.h. Changed in: https://github.com/wolfSSL/wolfssl/pull/7325

```
/home/runner/work/wolfMQTT/wolfMQTT/zephyr/twister-out/qemu_x86/zephyr/samples/client_tls/sample.lib.wolfmqtt_client_tls/zephyr/include/generated/autoconf.h:34:38: error: empty filename in #include
   34 | #define CONFIG_WOLFSSL_SETTINGS_FILE ""
      |                                      ^~
```