### PR TITLE
Fix Doxygen issues

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@master
+    - uses: actions/checkout@master
       with:
         repository: wolfssl/wolfssl
         path: wolfssl
@@ -30,7 +31,7 @@ jobs:
       run: ./autogen.sh
     - name: wolfssl configure
       working-directory: ./wolfssl
-      run: ./configure --enable-enckeys
+      run: ./configure --enable-enckeys --prefix=$GITHUB_WORKSPACE/build-dir
     - name: wolfssl make
       working-directory: ./wolfssl
       run: make
@@ -38,12 +39,14 @@ jobs:
       working-directory: ./wolfssl
       run: make install
 
-    - uses: actions/checkout@master
+    - name: Check wolfSSL install dir
+      run: ls $GITHUB_WORKSPACE/build-dir
+
     - name: autogen
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure
+      run: ./configure --with-libwolfssl-prefix=$GITHUB_WORKSPACE/build-dir
     - name: make
       run: make
     - name: make check
@@ -57,21 +60,21 @@ jobs:
       run: make check
 
     - name: configure with SN Enabled
-      run: ./configure --enable-sn
+      run: ./configure --enable-sn --with-libwolfssl-prefix=$GITHUB_WORKSPACE/build-dir
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with Non-Block
-      run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+      run: ./configure --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK" --with-libwolfssl-prefix=$GITHUB_WORKSPACE/build-dir
     - name: make
       run: make
     - name: make check
       run: make check
 
     - name: configure with Non-Block and Multi-threading
-      run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK"
+      run: ./configure --enable-mt --enable-nonblock CFLAGS="-DWOLFMQTT_TEST_NONBLOCK" --with-libwolfssl-prefix=$GITHUB_WORKSPACE/build-dir
     - name: make
       run: make
     - name: make check

--- a/examples/mqttport.h
+++ b/examples/mqttport.h
@@ -141,10 +141,27 @@ extern "C" {
 
     #define SOCKET_INVALID (-1)
 
+    typedef zsock_fd_set fd_set;
+    #define FD_ZERO ZSOCK_FD_ZERO
+    #define FD_SET  ZSOCK_FD_SET
+    #define FD_ISSET  ZSOCK_FD_ISSET
+    #define select zsock_select
+
     #ifdef WOLFSSL_ZEPHYR
         /* wolfSSL takes care of most defines */
         #include <wolfssl/wolfcrypt/wc_port.h>
     #else
+        #define addrinfo   zsock_addrinfo
+        #define getaddrinfo   zsock_getaddrinfo
+        #define freeaddrinfo   zsock_freeaddrinfo
+        #define socket zsock_socket
+        #define close zsock_close
+        #define SOCK_CONNECT zsock_connect
+        #define getsockopt zsock_getsockopt
+        #define setsockopt zsock_setsockopt
+        #define send zsock_send
+        #define recv zsock_recv
+        #define MSG_PEEK ZSOCK_MSG_PEEK
         #ifndef NO_FILESYSTEM
             #define XFOPEN              z_fs_open
             #define XFCLOSE             z_fs_close

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -251,7 +251,6 @@ WOLFMQTT_API int MqttClient_Init(
 
 /*! \brief      Cleans up resources allocated to the MqttClient structure
  *  \param      client      Pointer to MqttClient structure
- *  \return     none
  */
 WOLFMQTT_API void MqttClient_DeInit(MqttClient *client);
 
@@ -360,6 +359,7 @@ WOLFMQTT_API int MqttClient_Publish_ex(
                             with message data
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
+ *  \param      pubCb       Function pointer to callback routine
  *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or
                 MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -58,11 +58,11 @@ Follow the [instructions](https://docs.zephyrproject.org/latest/connectivity/net
 sudo ./loop-slip-tap.sh
 ```
 
-Run the following commands in parallel in this order in the `zephyrproject` directory to setup a MQTT broker and subscriber.
+Run the following commands in parallel in this order in the `zephyrproject` directory to setup a MQTT broker and subscriber (on port 11883 as defined in the mosquitto config).
 
 ```bash
 cd modules/lib/wolfmqtt && mosquitto -c scripts/broker_test/mosquitto.conf
-mosquitto_sub -t sensors
+mosquitto_sub -p 11883 -t sensors
 ```
 
 ### Build and Run client Test Application
@@ -76,6 +76,8 @@ west build -t run
 ```
 
 ### Build and Run client TLS Test Application
+Prerequisite:
+Add wolfSSL Zephyr module: https://github.com/wolfSSL/wolfssl/blob/master/zephyr/README.md
 
 build and execute `client TLS`
 

--- a/zephyr/samples/client/user_settings.h
+++ b/zephyr/samples/client/user_settings.h
@@ -5,6 +5,13 @@
 extern "C" {
 #endif
 
+#include <zephyr/net/socket_select.h>
+
+/* If a custom user_settings file is provided use it instead */
+#ifdef WOLFMQTT_SETTINGS_FILE
+#include WOLFMQTT_SETTINGS_FILE
+#endif
+
 #undef NO_FILESYSTEM
 #define NO_FILESYSTEM
 

--- a/zephyr/samples/client_tls/user_settings.h
+++ b/zephyr/samples/client_tls/user_settings.h
@@ -5,8 +5,11 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_WOLFSSL_SETTINGS_FILE
-#include CONFIG_WOLFSSL_SETTINGS_FILE
+#include <zephyr/net/socket_select.h>
+
+/* If a custom user_settings file is provided use it instead */
+#ifdef WOLFMQTT_SETTINGS_FILE
+#include WOLFMQTT_SETTINGS_FILE
 #endif
 
 #undef NO_FILESYSTEM


### PR DESCRIPTION
* Fix issues in documentation generation:
```
Generating docs for compoun/var/lib/jenkins/workspace/wolfSSL/nightly-docs-job-v2/wolfMQTT/wolfmqtt/wolfmqtt/mqtt_client.h:256: warning: documented empty return type of MqttClient_DeInit

/var/lib/jenkins/workspace/wolfSSL/nightly-docs-job-v2/wolfMQTT/wolfmqtt/wolfmqtt/mqtt_client.h:369: warning: The following parameter of MqttClient_Publish_WriteOnly(MqttClient *client, MqttPublish *publish, MqttPublishCb pubCb) is not documented:
  parameter 'pubCb'
```

* Fix MacOS workflow
* Fix Zephyr workflow build errors