### PR TITLE
wolfssl 5.7.2 time_helper type adjustments for Espressif example

### DIFF
--- a/IDE/Espressif/ESP-IDF/compileAllExamples.sh
+++ b/IDE/Espressif/ESP-IDF/compileAllExamples.sh
@@ -15,7 +15,7 @@ if  [[ "$IDF_PATH" == "" ]]; then
 fi
 
 # See https://components.espressif.com/components/wolfssl/wolfssl
-WOLFSSL_COMPONENT=wolfssl/wolfssl^5.6.6-stable-update2-esp32
+WOLFSSL_COMPONENT=wolfssl/wolfssl^5.7.2
 
 SCRIPT_DIR=$(builtin cd "${BASH_SOURCE%/*}" || exit 1; pwd)
 RUN_SETUP=$1
@@ -38,7 +38,7 @@ if [ $BUILD_PUBLISHED_EXAMPLES -ne 0 ]; then
     echo "************************************************************************"
 
     # See https://components.espressif.com/components/wolfssl/wolfmqtt
-    idf.py create-project-from-example "wolfssl/wolfssl^5.6.6-stable-update2-esp32:template"
+    idf.py create-project-from-example "wolfssl/wolfssl^5.7.2:template"
 
     THIS_ERROR_CODE=$?
     if [ $THIS_ERROR_CODE -ne 0 ]; then

--- a/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/include/time_helper.h
+++ b/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/include/time_helper.h
@@ -31,21 +31,23 @@
 extern "C" {
 #endif
 
+#include <esp_err.h>
+
 /* a function to show the current data and time */
-int esp_show_current_datetime();
+esp_err_t esp_show_current_datetime();
 
 /* worst case, if GitHub time not available, used fixed time */
-int set_fixed_default_time(void);
+esp_err_t set_fixed_default_time(void);
 
 /* set time from string (e.g. GitHub commit time) */
-int set_time_from_string(char* time_buffer);
+esp_err_t set_time_from_string(const char* time_buffer);
 
 /* set time from NTP servers,
  * also initially calls set_fixed_default_time or set_time_from_string */
-int set_time(void);
+esp_err_t set_time(void);
 
 /* wait NTP_RETRY_COUNT seconds before giving up on NTP time */
-int set_time_wait_for_ntp(void);
+esp_err_t set_time_wait_for_ntp(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/time_helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/time_helper.c
@@ -92,7 +92,7 @@ char* ntpServerList[NTP_SERVER_COUNT] = NTP_SERVER_LIST;
 extern char* ntpServerList[NTP_SERVER_COUNT];
 
 /* Show the current date and time */
-int esp_show_current_datetime()
+esp_err_t esp_show_current_datetime()
 {
     time_t now;
     char strftime_buf[64];
@@ -109,7 +109,7 @@ int esp_show_current_datetime()
 }
 
 /* the worst-case scenario is a hard-coded date/time */
-int set_fixed_default_time(void)
+esp_err_t set_fixed_default_time(void)
 {
     /* ideally, we'd like to set time from network,
      * but let's set a default time, just in case */
@@ -139,7 +139,7 @@ int set_fixed_default_time(void)
  *
  * returns 0 = success if able to set the time from the provided string
  * error for any other value, typically -1 */
-int set_time_from_string(char* time_buffer)
+esp_err_t set_time_from_string(const char* time_buffer)
 {
     /* expecting github default formatting: 'Thu Aug 31 12:41:45 2023 -0700' */
     const char *format = "%3s %3s %d %d:%d:%d %d %s";
@@ -223,7 +223,7 @@ int set_time_from_string(char* time_buffer)
 }
 
 /* set time; returns 0 if succecssfully configured with NTP */
-int set_time(void)
+esp_err_t set_time(void)
 {
 #ifndef NTP_SERVER_COUNT
     ESP_LOGW(TAG, "Warning: no sntp server names defined. "
@@ -320,7 +320,7 @@ int set_time(void)
 }
 
 /* wait for NTP to actually set the time */
-int set_time_wait_for_ntp(void)
+esp_err_t set_time_wait_for_ntp(void)
 {
     int ret = 0;
 #ifdef HAS_ESP_NETIF_SNTP

--- a/IDE/Espressif/ESP-IDF/examples/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/README.md
@@ -7,3 +7,30 @@ These are the core [examples](./README.md) for wolMQTT:
 - [AWS IoT MQTT](./AWS_IoT_MQTT/README.md)
 
 For details on wolfMQTT [see the wolfMQTT Manual](https://www.wolfssl.com/documentation/manuals/wolfmqtt/wolfMQTT-Manual.pdf).
+
+## Getting Started:
+
+Here's an example using the command-line [idf.py](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-py.html).
+
+Edit your `WRK_IDF_PATH`to point to your ESP-IDF install directory.
+
+```
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.2
+
+echo "Run export.sh from ${WRK_IDF_PATH}"
+. ${WRK_IDF_PATH}/export.sh
+
+# build the example:
+idf.py build
+
+# optionally erase the flash
+idf.py erase-flash -p /dev/ttyS19 -b 115200
+
+# flash the code onto the serial device at /dev/ttyS19
+idf.py flash -p /dev/ttyS19 -b 115200
+
+# build, flash, and view UART output with one command:
+idf.py flash -p /dev/ttyS19 -b 115200 monitor
+```
+
+Press `Ctrl+]` to exit `idf.py monitor`. See [additional monitor keyboard commands](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-monitor.html).


### PR DESCRIPTION
Similar to https://github.com/wolfSSL/wolfssh/pull/730 this PR fixes some return types  in the AWS MQTT example for time-related functions that are now found in [esp-sdk-lib.h](https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h) in the latest published [wolfSSL Managed Component](https://components.espressif.com/components/wolfssl/wolfssl) (version `5.7.2`).