### PR TITLE
Fix stat reset for ping response

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,7 @@ name: CIFuzz
 on: [pull_request]
 jobs:
   Fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
     - name: Build Fuzzers

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 # Install cmake

--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   espressif_latest:
     name: latest Docker container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # This should be a safe limit for the tests to run.
     timeout-minutes: 12
     container:

--- a/.github/workflows/fsanitize-check.yml
+++ b/.github/workflows/fsanitize-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     env:
       WOLFMQTT_NO_EXTERNAL_BROKER_TESTS: 1

--- a/.github/workflows/mqtt-sn-check.yml
+++ b/.github/workflows/mqtt-sn-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/ubuntu-check-curl.yml
+++ b/.github/workflows/ubuntu-check-curl.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -37,7 +37,7 @@ jobs:
             libglib2.0-dev libgtk2.0-0 liblocale-gettext-perl libncurses5-dev libpcap-dev \
             libpopt0 libsdl1.2-dev libsdl2-dev libssl-dev libtool libtool-bin locales make \
             net-tools ninja-build openssh-client parallel pkg-config python3-dev python3-pip \
-            python3-ply python3-setuptools python-is-python3 qemu rsync socat srecord sudo \
+            python3-ply python3-setuptools python-is-python3 qemu-kvm rsync socat srecord sudo \
             texinfo unzip wget ovmf xz-utils
 
       - name: Install west

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,7 +17,7 @@ jobs:
         config:
           - zephyr-ref: v3.4.0
             zephyr-sdk: 0.16.1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1209,7 +1209,9 @@ wait_again:
                 client->packet.buf_len, packet_type, packet_id);
         #endif
 
-            mms_stat->read = MQTT_MSG_PAYLOAD;
+            if (packet_type != MQTT_PACKET_TYPE_PING_RESP) {
+                mms_stat->read = MQTT_MSG_PAYLOAD;
+            }
         }
         FALL_THROUGH;
 
@@ -1446,15 +1448,9 @@ wait_again:
             break;
     } /* switch (mms_stat->ack) */
 
-#ifdef WOLFMQTT_DEBUG_CLIENT
-    if (rc != MQTT_CODE_CONTINUE) {
-        PRINTF("MqttClient_WaitType: rc %d, state %d-%d-%d",
-            rc, mms_stat->read, mms_stat->write, mms_stat->ack);
-    }
-#endif
-
     /* no data read or ack done, then reset state */
-    if (mms_stat->read == MQTT_MSG_WAIT) {
+    if (mms_stat->read == MQTT_MSG_WAIT ||
+        mms_stat->read == MQTT_MSG_HEADER) {
         mms_stat->read = MQTT_MSG_BEGIN;
     }
 
@@ -1507,6 +1503,13 @@ wait_again:
         MQTT_TRACE_MSG("Wait Again");
         goto wait_again;
     }
+#ifdef WOLFMQTT_DEBUG_CLIENT
+    if (rc != MQTT_CODE_CONTINUE) {
+        PRINTF("MqttClient_WaitType: rc %d, state %d-%d-%d",
+            rc, mms_stat->read, mms_stat->write, mms_stat->ack);
+    }
+#endif
+
 
     return rc;
 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1209,8 +1209,12 @@ wait_again:
                 client->packet.buf_len, packet_type, packet_id);
         #endif
 
+            /* Ping response is special case, no payload */
             if (packet_type != MQTT_PACKET_TYPE_PING_RESP) {
                 mms_stat->read = MQTT_MSG_PAYLOAD;
+            }
+            else {
+                mms_stat->read = MQTT_MSG_WAIT;
             }
         }
         FALL_THROUGH;
@@ -1449,8 +1453,7 @@ wait_again:
     } /* switch (mms_stat->ack) */
 
     /* no data read or ack done, then reset state */
-    if (mms_stat->read == MQTT_MSG_WAIT ||
-        mms_stat->read == MQTT_MSG_HEADER) {
+    if (mms_stat->read == MQTT_MSG_WAIT) {
         mms_stat->read = MQTT_MSG_BEGIN;
     }
 


### PR DESCRIPTION
Resolves an issue with ping responses not resetting the `stat.read` value after completing. This only affected ping responses since they are used multiple times and do not have a payload to handle.

Fixes an issue reported in ZD19107