### PR TITLE
Improve cmake duplicate component check

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/CMakeLists.txt
@@ -68,6 +68,7 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
         "${CMAKE_CURRENT_LIST_DIR}/components/my${KEYWORD}"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/wolfssl__${KEYWORD}"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/gojimmypi__my${KEYWORD}"
+        # Add any other known user "my[component] here"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/${THIS_USER}__my${KEYWORD}"
         "$ENV{IDF_PATH}/components/${KEYWORD}/"
         "$ENV{IDF_PATH}/components/esp-${KEYWORD}/"
@@ -75,16 +76,30 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
 
     set(EXISTING_COUNT 0)
     set(MATCHING_DIRS "")  # List to store found directories
+    set(SEEN_DIRS "")  # To store unique normalized existing paths
 
     foreach(DIR ${DIR_LIST})
         file(TO_CMAKE_PATH "${DIR}" DIR)  # Normalize paths
         message(STATUS "Checking for ${KEYWORD} in ${DIR}")
+
         if(EXISTS "${DIR}")
-            math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+            # Check if DIR already seen
+            list(FIND SEEN_DIRS "${DIR}" IDX)
+
+            if(IDX EQUAL -1)
+                # Not seen before
+                list(APPEND SEEN_DIRS "${DIR}")
+                list(APPEND MATCHING_DIRS "${DIR}")
+                math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+                message(STATUS "Found: ${DIR}")
+            else()
+                message(STATUS "Already counted: ${DIR}")
+            endif()
+
             list(APPEND MATCHING_DIRS "${DIR}")
             message(STATUS "Found: ${DIR}")
-        endif()
-    endforeach()
+        endif() # EXISTS "${DIR}"
+    endforeach() # DIR ${DIR_LIST}
 
     if(EXISTING_COUNT GREATER_EQUAL 2)
         set(${RESULT_VAR} TRUE PARENT_SCOPE)

--- a/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/components/wolfmqtt/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/components/wolfmqtt/README.md
@@ -1,21 +1,21 @@
 # wolfMQTT for Espressif ESP-IDF
 
-[wolfMQTT](https://www.wolfMQTT.com) provides commercial-grade, world-class encryption libraries to secure connections 
-from tiny embedded devices to the largest cloud and super computing platforms. 
+[wolfMQTT](https://www.wolfMQTT.com) provides commercial-grade, world-class encryption libraries to secure connections
+from tiny embedded devices to the largest cloud and super computing platforms.
 
-Makers and students can use these libraries free of charge, as long as they abide by abide by the terms of GPLV2 licensing. 
+Makers and students can use these libraries free of charge, as long as they abide by abide by the terms of GPLV2 licensing.
 
-Commercial customers are invited to contact wolfSSL for licensing options. 
-Visit [wolfSSL.com/Espressif/](https://www.wolfSSL.com/Espressif/) to learn 
+Commercial customers are invited to contact wolfSSL for licensing options.
+Visit [wolfSSL.com/Espressif/](https://www.wolfSSL.com/Espressif/) to learn
 more about Espressif-specific development efforts for wolfSSL, wolfMQTT, wolfSSH, and more.
 
 ## Getting Started
 
 The easiest way to get started is by using the Espressif Managed Component Registry
-at 
+at [wolfssl/wolfmqtt](https://components.espressif.com/components/wolfssl/wolfmqtt)
 
-The latest experimental development version can be found at the staging site: 
-[gojimmypi/mywolfmqtt](https://components-staging.espressif.com/components/gojimmypi/mywolfmqtt/versions/1.0.14-test?language=en).
+The latest experimental development version can be found at the staging site:
+[gojimmypi/mywolfmqtt](https://components-staging.espressif.com/components/gojimmypi/mywolfmqtt/versions/1.18.0).
 
 ```
 #!/bin/bash
@@ -25,7 +25,7 @@ The latest experimental development version can be found at the staging site:
 # Needed for Staging site:
 export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
 
-idf.py create-project-from-example "gojimmypi/mywolfmqtt^1.0.14-test:AWS_IoT_MQTT"
+idf.py create-project-from-example "gojimmypi/mywolfmqtt^1.18.0:AWS_IoT_MQTT"
 
 cd AWS_IoT_MQTT
 

--- a/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT/main/CMakeLists.txt
@@ -64,26 +64,50 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
         "${CMAKE_HOME_DIRECTORY}/components/my${KEYWORD}"
         "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__${KEYWORD}"
         "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__my${KEYWORD}"
+        # Add any other known user "my[component] here"
         "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__my${KEYWORD}"
         "$ENV{IDF_PATH}/components/${KEYWORD}/"
         "$ENV{IDF_PATH}/components/esp-${KEYWORD}/"
     )
 
     set(EXISTING_COUNT 0)
+    set(MATCHING_DIRS "")  # List to store found directories
+    set(SEEN_DIRS "")  # To store unique normalized existing paths
 
     foreach(DIR ${DIR_LIST})
-        message(STATUS "Checking ${DIR}")
         file(TO_CMAKE_PATH "${DIR}" DIR)  # Normalize paths
-        message(STATUS "Checking ${DIR}")
+        message(STATUS "Checking for ${KEYWORD} in ${DIR}")
+
         if(EXISTS "${DIR}")
-            math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+            # Check if DIR already seen
+            list(FIND SEEN_DIRS "${DIR}" IDX)
+
+            if(IDX EQUAL -1)
+                # Not seen before
+                list(APPEND SEEN_DIRS "${DIR}")
+                list(APPEND MATCHING_DIRS "${DIR}")
+                math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+                message(STATUS "Found: ${DIR}")
+            else()
+                message(STATUS "Already counted: ${DIR}")
+            endif()
+
+            list(APPEND MATCHING_DIRS "${DIR}")
             message(STATUS "Found: ${DIR}")
-        endif()
-    endforeach()
+        endif() # EXISTS "${DIR}"
+    endforeach() # DIR ${DIR_LIST}
 
     if(EXISTING_COUNT GREATER_EQUAL 2)
         set(${RESULT_VAR} TRUE PARENT_SCOPE)
-        message(STATUS "WARNING: At least two '${KEYWORD}' component directories exist.")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "WARNING: Found duplicate '${KEYWORD}' in")
+        foreach(DUP_DIR ${MATCHING_DIRS})
+            message(STATUS "  - ${DUP_DIR}")
+        endforeach()
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(WARNING "WARNING: More than 1 '${KEYWORD}' component directories exist.")
 
         # Append the warning flag to CMAKE_C_FLAGS and propagate it to the parent scope
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${KEYWORD}_MULTI_INSTALL_WARNING")

--- a/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/CMakeLists.txt
@@ -68,6 +68,7 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
         "${CMAKE_CURRENT_LIST_DIR}/components/my${KEYWORD}"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/wolfssl__${KEYWORD}"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/gojimmypi__my${KEYWORD}"
+        # Add any other known user "my[component] here"
         "${CMAKE_CURRENT_LIST_DIR}/managed_components/${THIS_USER}__my${KEYWORD}"
         "$ENV{IDF_PATH}/components/${KEYWORD}/"
         "$ENV{IDF_PATH}/components/esp-${KEYWORD}/"
@@ -75,16 +76,30 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
 
     set(EXISTING_COUNT 0)
     set(MATCHING_DIRS "")  # List to store found directories
+    set(SEEN_DIRS "")  # To store unique normalized existing paths
 
     foreach(DIR ${DIR_LIST})
         file(TO_CMAKE_PATH "${DIR}" DIR)  # Normalize paths
         message(STATUS "Checking for ${KEYWORD} in ${DIR}")
+
         if(EXISTS "${DIR}")
-            math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+            # Check if DIR already seen
+            list(FIND SEEN_DIRS "${DIR}" IDX)
+
+            if(IDX EQUAL -1)
+                # Not seen before
+                list(APPEND SEEN_DIRS "${DIR}")
+                list(APPEND MATCHING_DIRS "${DIR}")
+                math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+                message(STATUS "Found: ${DIR}")
+            else()
+                message(STATUS "Already counted: ${DIR}")
+            endif()
+
             list(APPEND MATCHING_DIRS "${DIR}")
             message(STATUS "Found: ${DIR}")
-        endif()
-    endforeach()
+        endif() # EXISTS "${DIR}"
+    endforeach() # DIR ${DIR_LIST}
 
     if(EXISTING_COUNT GREATER_EQUAL 2)
         set(${RESULT_VAR} TRUE PARENT_SCOPE)

--- a/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/components/wolfmqtt/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/components/wolfmqtt/README.md
@@ -1,21 +1,20 @@
 # wolfMQTT for Espressif ESP-IDF
 
-[wolfMQTT](https://www.wolfMQTT.com) provides commercial-grade, world-class encryption libraries to secure connections 
-from tiny embedded devices to the largest cloud and super computing platforms. 
+[wolfMQTT](https://www.wolfMQTT.com) provides commercial-grade, world-class encryption libraries to secure connections
+from tiny embedded devices to the largest cloud and super computing platforms.
 
-Makers and students can use these libraries free of charge, as long as they abide by abide by the terms of GPLV2 licensing. 
+Makers and students can use these libraries free of charge, as long as they abide by abide by the terms of GPLV2 licensing.
 
-Commercial customers are invited to contact wolfSSL for licensing options. 
-Visit [wolfSSL.com/Espressif/](https://www.wolfSSL.com/Espressif/) to learn 
+Commercial customers are invited to contact wolfSSL for licensing options.
+Visit [wolfSSL.com/Espressif/](https://www.wolfSSL.com/Espressif/) to learn
 more about Espressif-specific development efforts for wolfSSL, wolfMQTT, wolfSSH, and more.
 
 ## Getting Started
 
 The easiest way to get started is by using the Espressif Managed Component Registry
-at 
+at: [wolfssl/wolfmqtt](https://components.espressif.com/components/wolfssl/wolfmqtt)
 
-The latest experimental development version can be found at the staging site: 
-[gojimmypi/mywolfmqtt](https://components-staging.espressif.com/components/gojimmypi/mywolfmqtt/versions/1.0.14-test?language=en).
+The latest experimental development version can be found at the staging site: [gojimmypi/mywolfmqtt](https://components-staging.espressif.com/components/gojimmypi/mywolfmqtt/versions/1.18.0-preview8a?language=en).
 
 ```
 #!/bin/bash
@@ -25,7 +24,7 @@ The latest experimental development version can be found at the staging site:
 # Needed for Staging site:
 export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
 
-idf.py create-project-from-example "gojimmypi/mywolfmqtt^1.0.14-test:AWS_IoT_MQTT"
+idf.py create-project-from-example "gojimmypi/mywolfmqtt^1.18.0-preview8a::AWS_IoT_MQTT"
 
 cd AWS_IoT_MQTT
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template/main/CMakeLists.txt
@@ -64,26 +64,50 @@ function(CHECK_DUPLICATE_LIBRARIES RESULT_VAR KEYWORD)
         "${CMAKE_HOME_DIRECTORY}/components/my${KEYWORD}"
         "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__${KEYWORD}"
         "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__my${KEYWORD}"
+        # Add any other known user "my[component] here"
         "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__my${KEYWORD}"
         "$ENV{IDF_PATH}/components/${KEYWORD}/"
         "$ENV{IDF_PATH}/components/esp-${KEYWORD}/"
     )
 
     set(EXISTING_COUNT 0)
+    set(MATCHING_DIRS "")  # List to store found directories
+    set(SEEN_DIRS "")  # To store unique normalized existing paths
 
     foreach(DIR ${DIR_LIST})
-        message(STATUS "Checking ${DIR}")
         file(TO_CMAKE_PATH "${DIR}" DIR)  # Normalize paths
-        message(STATUS "Checking ${DIR}")
+        message(STATUS "Checking for ${KEYWORD} in ${DIR}")
+
         if(EXISTS "${DIR}")
-            math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+            # Check if DIR already seen
+            list(FIND SEEN_DIRS "${DIR}" IDX)
+
+            if(IDX EQUAL -1)
+                # Not seen before
+                list(APPEND SEEN_DIRS "${DIR}")
+                list(APPEND MATCHING_DIRS "${DIR}")
+                math(EXPR EXISTING_COUNT "${EXISTING_COUNT} + 1")
+                message(STATUS "Found: ${DIR}")
+            else()
+                message(STATUS "Already counted: ${DIR}")
+            endif()
+
+            list(APPEND MATCHING_DIRS "${DIR}")
             message(STATUS "Found: ${DIR}")
-        endif()
-    endforeach()
+        endif() # EXISTS "${DIR}"
+    endforeach() # DIR ${DIR_LIST}
 
     if(EXISTING_COUNT GREATER_EQUAL 2)
         set(${RESULT_VAR} TRUE PARENT_SCOPE)
-        message(STATUS "WARNING: At least two '${KEYWORD}' component directories exist.")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "WARNING: Found duplicate '${KEYWORD}' in")
+        foreach(DUP_DIR ${MATCHING_DIRS})
+            message(STATUS "  - ${DUP_DIR}")
+        endforeach()
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(STATUS  "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        message(WARNING "WARNING: More than 1 '${KEYWORD}' component directories exist.")
 
         # Append the warning flag to CMAKE_C_FLAGS and propagate it to the parent scope
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${KEYWORD}_MULTI_INSTALL_WARNING")


### PR DESCRIPTION
A slight polish to the updates in https://github.com/wolfSSL/wolfMQTT/pull/420

The PR modifies the `CHECK_DUPLICATE_LIBRARIES` CMake function to ensure false-positive duplicate library messages will not occur.

This is likely only a problem for me at this moment, due to these two lines.

```
        "${CMAKE_CURRENT_LIST_DIR}/managed_components/gojimmypi__my${KEYWORD}"
        "${CMAKE_CURRENT_LIST_DIR}/managed_components/${THIS_USER}__my${KEYWORD}"
```

Some other user may use the `mywolfmqtt` library and/or create their own `mywolfmqtt` component.

There's also an update in output message format to make it much more obvious when duplicate component directories are found.

This is as-published code in staging [gojimmypi/mywolfmqtt 1.18.0-preview8b](https://components-staging.espressif.com/components/gojimmypi/mywolfmqtt/versions/1.18.0-preview8b) and [wolfssl/wolfmqtt 1.18.0-preview8d](https://components.espressif.com/components/wolfssl/wolfmqtt/versions/1.18.0-preview8d)