### PR TITLE
Fix: Correct state transition check in MqttClient_Auth

### DIFF
--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2692,7 +2692,7 @@ int MqttClient_Auth(MqttClient *client, MqttAuth* auth)
 
         auth->stat.write = MQTT_MSG_HEADER;
     }
-    if (auth->stat.write == MQTT_MSG_BEGIN) {
+    if (auth->stat.write == MQTT_MSG_HEADER) {
         int xfer = client->write.len;
 
         /* Send authentication packet */


### PR DESCRIPTION
Fixes <https://github.com/wolfSSL/wolfMQTT/issues/442>

Corrects a critical logic error in `MqttClient_Auth` where the function failed to check for the correct internal message state before attempting to send the AUTH packet payload over the network.

### Problem

In `MqttClient_Auth`, the function transitions the write state from `MQTT_MSG_BEGIN` to **`MQTT_MSG_HEADER`** after encoding the fixed and
variable headers.

The subsequent block responsible for transmitting the packet incorrectly checked
if the state was still **`MQTT_MSG_BEGIN`**.

If the function was called again after the initial encoding, this logic error
would cause the AUTH packet to **stall indefinitely** because the state check
failed, preventing the `wolfMqtt_Write` call.

### ✅ Solution

The conditional check has been updated to look for the correct state, **`MQTT_MSG_HEADER`**, which is the state required to start the network
transmission phase.

**Code Change Detail:**

```C
// Before:
if (auth->stat.write == MQTT_MSG_BEGIN) {
// After:
if (auth->stat.write == MQTT_MSG_HEADER) {
```

This ensures the AUTH packet is correctly picked up and sent upon subsequent
calls, resolving the potential stall in the authentication flow.