### PR TITLE
Add fflush to mqtt-sub example

### DIFF
--- a/examples/pub-sub/mqtt-sub.c
+++ b/examples/pub-sub/mqtt-sub.c
@@ -98,6 +98,8 @@ static int mqtt_message_cb(MqttClient *client, MqttMessage *msg,
         PRINTF("%s", buf);
     }
 
+    fflush(stdout);
+
     #ifdef WOLFMQTT_V5
     {
         /* Properties can be checked in the message callback */


### PR DESCRIPTION
Add an fflush after the message has been been printed

Fixes #446 

