### PR TITLE
Add lastError to preserve TLS error code

### DIFF
--- a/wolfmqtt/mqtt_socket.h
+++ b/wolfmqtt/mqtt_socket.h
@@ -73,6 +73,7 @@ typedef struct _MqttTls {
     int                 sockRcWrite;
     int                 timeout_ms_read;
     int                 timeout_ms_write;
+    int                 lastError;
 } MqttTls;
 #endif
 


### PR DESCRIPTION
Customer requested a way to get the TLS error in the net disconnect callback. This adds a `lastError` field to the `client->tls` structure and copies any error found during connect, read, or write.

Fixes ZD211143