### PR TITLE
Curl gh fix

### DIFF
--- a/examples/mqttnet.h
+++ b/examples/mqttnet.h
@@ -58,6 +58,7 @@ typedef struct _SocketContext {
 #endif
 #ifdef ENABLE_MQTT_CURL
     CURL  *  curl;
+    int      bytes; /* track partial read/write */
 #endif
 #ifdef ENABLE_MQTT_WEBSOCKET
     void* websocket_ctx;


### PR DESCRIPTION
  1. Handles partial transfers correctly - accumulates bytes in sock->bytes     
  2. Reduces round-trips - loops internally until complete instead of returning 
  MQTT_CODE_CONTINUE for each partial transfer                                  
  3. Properly waits - uses mqttcurl_wait when CURLE_AGAIN is returned           
  4. Handles connection closed - returns MQTT_CODE_ERROR_NETWORK when recvd == 0