### PR TITLE
Add MQTT v3.1.1 spec compliance checks

### DIFF
--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -255,6 +255,11 @@ int MqttEncode_Vbi(byte *buf, word32 x)
     int rc = 0;
     byte encodedByte;
 
+    /* [MQTT-2.2.3]: Max value is 268,435,455 (0x0FFFFFFF) */
+    if (x > MQTT_PACKET_MAX_REMAIN_LEN) {
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+    }
+
     do {
         encodedByte = (x & ~MQTT_PACKET_LEN_ENCODE_MASK) & 0xFF;
         x >>= 7;
@@ -709,6 +714,12 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
 
     /* Validate required arguments */
     if (tx_buf == NULL || mc_connect == NULL || mc_connect->client_id == NULL) {
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
+    }
+
+    /* [MQTT-3.1.2-22]: If the User Name Flag is set to 0, the Password Flag
+     * MUST be set to 0 */
+    if (mc_connect->password != NULL && mc_connect->username == NULL) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -260,6 +260,8 @@ enum MqttPacketFlags {
 /* Packet Header: Size is variable 2 - 5 bytes */
 #define MQTT_PACKET_MAX_LEN_BYTES   4
 #define MQTT_PACKET_LEN_ENCODE_MASK 0x80UL
+/* [MQTT-2.2.3] Maximum value encodable by the Variable Byte Integer scheme */
+#define MQTT_PACKET_MAX_REMAIN_LEN  0x0FFFFFFFUL /* 268,435,455 */
 typedef struct _MqttPacket {
     /* Type = bits 4-7, Flags = 0-3 are flags */
     byte        type_flags; /* MqttPacketType and MqttPacketFlags */


### PR DESCRIPTION
* Enforce [MQTT-3.1.2-22]: reject CONNECT when password is set without username. 
* Add [MQTT-2.2.3]: validate Variable Byte Integer max value (268,435,455) in MqttEncode_Vbi.