### PR TITLE
Replace deprecated VeriSign CA with Amazon Root CA 1 + Starfield G2

### DIFF
--- a/.github/workflows/ubuntu-check-curl.yml
+++ b/.github/workflows/ubuntu-check-curl.yml
@@ -11,6 +11,13 @@ jobs:
 
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    # Serialize with every other workflow that runs awsiot.test against
+    # AWS IoT under the hard-coded "demoDevice" client ID. Without this,
+    # parallel runs from sibling workflows clobber each other's MQTT
+    # connections.
+    concurrency:
+      group: wolfmqtt-awsiot-external
+      cancel-in-progress: false
 
     steps:
     - name: Install dependencies

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -11,6 +11,14 @@ jobs:
 
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    # Serialize across all workflows that exercise the hard-coded
+    # "demoDevice" MQTT client ID against AWS IoT. Parallel runs from
+    # different workflows (ubuntu-check, ubuntu-check-curl, this file's
+    # aws-ca-regression) otherwise collide on the AWS side and produce
+    # spurious "MQTT Connect/Subscribe: Error (Network) (-8)" failures.
+    concurrency:
+      group: wolfmqtt-awsiot-external
+      cancel-in-progress: false
 
     steps:
     - name: Install dependencies
@@ -130,13 +138,16 @@ jobs:
     # the demo, so this job needs external network access (same as the
     # `build` job's `make check`).
     #
-    # `needs: build` serializes AWS IoT access: the `build` job already
-    # invokes scripts/awsiot.test via `make check`, and both jobs share
-    # the same hard-coded MQTT client ID "demoDevice". Running them in
-    # parallel causes AWS IoT to drop connections ("MQTT Connect: Error
-    # (Network) (-8)") from client-id collisions, which looks like a
-    # test failure but is unrelated to the CA changes this job checks.
+    # `needs: build` serializes AWS IoT access within this workflow.
+    # The repo-wide `concurrency:` group below serializes against other
+    # workflows (e.g. ubuntu-check-curl) that also run awsiot.test
+    # against the same hard-coded "demoDevice" client ID. Without both,
+    # parallel jobs cause AWS IoT to drop connections with "MQTT
+    # Connect/Subscribe: Error (Network) (-8)".
     needs: build
+    concurrency:
+      group: wolfmqtt-awsiot-external
+      cancel-in-progress: false
     #
     #   case 1: default bundle (Amazon Root CA 1 + Starfield G2), wolfSSL
     #           built WITHOUT WOLFSSL_NO_ASN_STRICT. Strict ASN parsing

--- a/.github/workflows/ubuntu-check.yml
+++ b/.github/workflows/ubuntu-check.yml
@@ -123,3 +123,123 @@ jobs:
       run: |
         cat test-suite.log
         cat scripts/*.log
+
+  aws-ca-regression:
+    # Exercises examples/aws/awsiot.c trust-anchor handling in three
+    # configurations. Uses the real AWS IoT ATS endpoint hard-coded in
+    # the demo, so this job needs external network access (same as the
+    # `build` job's `make check`).
+    #
+    # `needs: build` serializes AWS IoT access: the `build` job already
+    # invokes scripts/awsiot.test via `make check`, and both jobs share
+    # the same hard-coded MQTT client ID "demoDevice". Running them in
+    # parallel causes AWS IoT to drop connections ("MQTT Connect: Error
+    # (Network) (-8)") from client-id collisions, which looks like a
+    # test failure but is unrelated to the CA changes this job checks.
+    needs: build
+    #
+    #   case 1: default bundle (Amazon Root CA 1 + Starfield G2), wolfSSL
+    #           built WITHOUT WOLFSSL_NO_ASN_STRICT. Strict ASN parsing
+    #           drops Starfield G2 (serial=0); the verify callback's
+    #           accept-anyway branch keeps the test passing.  Expect PASS.
+    #
+    #   case 2: default bundle, wolfSSL built WITH WOLFSSL_NO_ASN_STRICT.
+    #           Full bundle loads, chain verifies cleanly, callback
+    #           never has to mask an error.  Expect PASS.
+    #
+    #   case 3: legacy VeriSign G5 bundle (via
+    #           -DWOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA), wolfSSL built WITH
+    #           WOLFSSL_NO_ASN_STRICT. The strict callback rejects the
+    #           unanchored chain.  Expect FAIL.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Install dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y mosquitto bubblewrap
+      - name: Setup mosquitto broker
+        run: |
+          sudo service mosquitto stop
+          sleep 1
+
+      # --- case 1: wolfSSL built with DEFAULT strict ASN parsing ---
+      - uses: actions/checkout@master
+        with:
+          repository: wolfssl/wolfssl
+          path: wolfssl
+      - name: wolfssl autogen (strict ASN default)
+        working-directory: ./wolfssl
+        run: ./autogen.sh
+      - name: wolfssl configure (strict ASN default)
+        working-directory: ./wolfssl
+        run: ./configure --enable-enckeys
+      - name: wolfssl make
+        working-directory: ./wolfssl
+        run: make
+      - name: wolfssl make install
+        working-directory: ./wolfssl
+        run: sudo make install
+
+      - uses: actions/checkout@master
+      - name: wolfmqtt autogen
+        run: ./autogen.sh
+      - name: case 1 - wolfmqtt configure (default bundle, strict ASN)
+        run: ./configure --enable-tls --enable-examples
+      - name: case 1 - wolfmqtt make
+        run: make
+      - name: case 1 - awsiot.test expect PASS
+        run: ./scripts/awsiot.test
+
+      # --- cases 2 + 3: wolfSSL rebuilt with WOLFSSL_NO_ASN_STRICT ---
+      # The wolfmqtt checkout above wiped the workspace, so the wolfssl
+      # source tree is gone even though /usr/local/lib/libwolfssl.* is
+      # still installed. Re-checkout to get a fresh source tree for the
+      # NO_ASN_STRICT rebuild.
+      - uses: actions/checkout@master
+        with:
+          repository: wolfssl/wolfssl
+          path: wolfssl
+      - name: wolfssl autogen (NO_ASN_STRICT build)
+        working-directory: ./wolfssl
+        run: ./autogen.sh
+      - name: wolfssl configure with -DWOLFSSL_NO_ASN_STRICT
+        working-directory: ./wolfssl
+        run: ./configure --enable-enckeys CFLAGS=-DWOLFSSL_NO_ASN_STRICT
+      - name: wolfssl rebuild
+        working-directory: ./wolfssl
+        run: make
+      - name: wolfssl reinstall
+        working-directory: ./wolfssl
+        run: sudo make install
+
+      - name: case 2 - wolfmqtt configure (default bundle, WOLFSSL_NO_ASN_STRICT)
+        run: |
+          make clean
+          ./configure --enable-tls --enable-examples
+      - name: case 2 - wolfmqtt make
+        run: make
+      - name: case 2 - awsiot.test expect PASS
+        run: ./scripts/awsiot.test
+
+      - name: case 3 - wolfmqtt configure (legacy VeriSign, WOLFSSL_NO_ASN_STRICT)
+        run: |
+          make clean
+          ./configure --enable-tls --enable-examples \
+            CPPFLAGS=-DWOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA
+      - name: case 3 - wolfmqtt make
+        run: make
+      - name: case 3 - awsiot.test expect FAIL
+        run: |
+          if ./scripts/awsiot.test; then
+            echo "case 3 unexpectedly PASSED - legacy VeriSign should not verify AWS IoT chain"
+            exit 1
+          fi
+          echo "case 3 FAILED as expected (legacy VeriSign trust anchor rejected)"
+
+      - name: Show logs on failure
+        if: failure() || cancelled()
+        run: |
+          cat test-suite.log || true
+          cat scripts/*.log || true

--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -76,8 +76,27 @@ static int mTestDone = 0;
 
 #define AWSIOT_PUBLISH_MSG_SZ   400
 
-/* Demo Certificates */
+/* Demo Certificates
+ *
+ * Default: Amazon Root CA 1 + Starfield Services Root CA G2, the trust
+ * anchors AWS IoT documents for ATS endpoints. Sources:
+ *   https://www.amazontrust.com/repository/AmazonRootCA1.pem
+ *   https://www.amazontrust.com/repository/SFSRootCAG2.pem
+ *
+ * Note: Starfield Services Root CA G2 has serialNumber=0, so wolfSSL's
+ * default strict ASN parser drops it. Builds that need real chain
+ * verification against AWS IoT must define WOLFSSL_NO_ASN_STRICT.
+ *
+ * Regression toggle: define WOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA at build
+ * time to restore the pre-fix VeriSign Class 3 G5 root. That CA was
+ * deprecated by AWS IoT Core (see AWS server-authentication docs) and
+ * no longer verifies any AWS IoT chain; the toggle exists so the test
+ * can assert that strict verification rejects the old anchor.
+ */
+#ifdef WOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA
 WOLFMQTT_EXAMPLE_CERT const char* root_ca =
+/* VeriSign Class 3 Public Primary Certification Authority - G5
+ * (deprecated by AWS IoT Core; preserved only for regression testing). */
 "-----BEGIN CERTIFICATE-----\n"
 "MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB\n"
 "yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL\n"
@@ -106,6 +125,55 @@ WOLFMQTT_EXAMPLE_CERT const char* root_ca =
 "4fQRbxC1lfznQgUy286dUV4otp6F01vvpX1FQHKOtw5rDgb7MzVIcbidJ4vEZV8N\n"
 "hnacRHr2lVz2XTIIM6RUthg/aFzyQkqFOFSDX9HoLPKsEdao7WNq\n"
 "-----END CERTIFICATE-----";
+#else
+WOLFMQTT_EXAMPLE_CERT const char* root_ca =
+/* Amazon Root CA 1 */
+"-----BEGIN CERTIFICATE-----\n"
+"MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF\n"
+"ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6\n"
+"b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL\n"
+"MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv\n"
+"b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj\n"
+"ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM\n"
+"9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw\n"
+"IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6\n"
+"VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L\n"
+"93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm\n"
+"jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC\n"
+"AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA\n"
+"A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI\n"
+"U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs\n"
+"N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv\n"
+"o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU\n"
+"5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy\n"
+"rqXRfboQnoZsG4q5WTP468SQvvG5\n"
+"-----END CERTIFICATE-----\n"
+/* Starfield Services Root Certificate Authority - G2 */
+"-----BEGIN CERTIFICATE-----\n"
+"MIID7zCCAtegAwIBAgIBADANBgkqhkiG9w0BAQsFADCBmDELMAkGA1UEBhMCVVMx\n"
+"EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxJTAjBgNVBAoT\n"
+"HFN0YXJmaWVsZCBUZWNobm9sb2dpZXMsIEluYy4xOzA5BgNVBAMTMlN0YXJmaWVs\n"
+"ZCBTZXJ2aWNlcyBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5\n"
+"MDkwMTAwMDAwMFoXDTM3MTIzMTIzNTk1OVowgZgxCzAJBgNVBAYTAlVTMRAwDgYD\n"
+"VQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMSUwIwYDVQQKExxTdGFy\n"
+"ZmllbGQgVGVjaG5vbG9naWVzLCBJbmMuMTswOQYDVQQDEzJTdGFyZmllbGQgU2Vy\n"
+"dmljZXMgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIwDQYJKoZI\n"
+"hvcNAQEBBQADggEPADCCAQoCggEBANUMOsQq+U7i9b4Zl1+OiFOxHz/Lz58gE20p\n"
+"OsgPfTz3a3Y4Y9k2YKibXlwAgLIvWX/2h/klQ4bnaRtSmpDhcePYLQ1Ob/bISdm2\n"
+"8xpWriu2dBTrz/sm4xq6HZYuajtYlIlHVv8loJNwU4PahHQUw2eeBGg6345AWh1K\n"
+"Ts9DkTvnVtYAcMtS7nt9rjrnvDH5RfbCYM8TWQIrgMw0R9+53pBlbQLPLJGmpufe\n"
+"hRhJfGZOozptqbXuNC66DQO4M99H67FrjSXZm86B0UVGMpZwh94CDklDhbZsc7tk\n"
+"6mFBrMnUVN+HL8cisibMn1lUaJ/8viovxFUcdUBgF4UCVTmLfwUCAwEAAaNCMEAw\n"
+"DwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJxfAN+q\n"
+"AdcwKziIorhtSpzyEZGDMA0GCSqGSIb3DQEBCwUAA4IBAQBLNqaEd2ndOxmfZyMI\n"
+"bw5hyf2E3F/YNoHN2BtBLZ9g3ccaaNnRbobhiCPPE95Dz+I0swSdHynVv/heyNXB\n"
+"ve6SbzJ08pGCL72CQnqtKrcgfU28elUSwhXqvfdqlS5sdJ/PHLTyxQGjhdByPq1z\n"
+"qwubdQxtRbeOlKyWN7Wg0I8VRw7j6IPdj/3vQQF3zCepYoUz8jcI73HPdwbeyBkd\n"
+"iEDPfUYd/x7H4c7/I9vG+o1VTqkC50cRRj70/b17KSa7qWFiNyi2LSr2EIZkyXCn\n"
+"0q23KXB56jzaYyWf/Wi3MOxw+3WKt21gZ7IeyLnp2KhvAotnDU0mV3HaIPzBSlCN\n"
+"sSi6\n"
+"-----END CERTIFICATE-----";
+#endif /* WOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA */
 
 #if 0
 static const char* device_pub_key =
@@ -214,9 +282,21 @@ static int mqtt_aws_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
     PRINTF("  Subject's domain name is %s", store->domain);
 
     if (store->error != 0) {
-        /* Allowing to continue */
-        /* Should check certificate and return 0 if not okay */
+#ifdef WOLFSSL_NO_ASN_STRICT
+        /* With WOLFSSL_NO_ASN_STRICT the full AWS IoT trust bundle
+         * (Amazon Root CA 1 + Starfield Services Root CA G2) loads and
+         * a real chain must verify. Treat any error as a hard failure
+         * so regressions in the trust bundle or the server chain are
+         * caught by scripts/awsiot.test instead of being masked. */
+        PRINTF("  Rejecting cert: verification must succeed under"
+               " WOLFSSL_NO_ASN_STRICT");
+        return 0;
+#else
+        /* Strict ASN parsing drops Starfield Services Root CA G2
+         * (serialNumber=0), so chain verification can legitimately
+         * fail here. Keep the demo running. */
         PRINTF("  Allowing cert anyways");
+#endif
     }
 
     return 1;
@@ -226,6 +306,10 @@ static int mqtt_aws_tls_verify_cb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 static int mqtt_aws_tls_cb(MqttClient* client)
 {
     int rc = WOLFSSL_FAILURE;
+
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
 
     /* Use highest available and allow downgrade. If wolfSSL is built with
      * old TLS support, it is possible for a server to force a downgrade to


### PR DESCRIPTION
## Problem

`examples/aws/awsiot.c` ships VeriSign Class 3 Public Primary G5 as its AWS IoT root CA. AWS IoT no longer chains to that CA. The demo only passes because `mqtt_aws_tls_verify_cb()` returns `1` on every error and "allows the cert anyway".

AWS IoT Developer Guide, *Server authentication*:

> Use `iot:Data-ATS` endpoints. Symantec and Verisign certificates have been deprecated and are no longer supported by AWS IoT Core.

Source: <https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#endpoint-types>

Current chain (per AWS Security Blog, 2024-06-27): AWS-issued certs terminate at Starfield Services G2, with Amazon Root CAs 1-4 cross-signed by it. Source: <https://aws.amazon.com/blogs/security/acm-will-no-longer-cross-sign-certificates-with-starfield-class-2-starting-august-2024/>

## Fix

- Replace the VeriSign G5 PEM with **Amazon Root CA 1** + **Starfield Services Root CA G2**, the anchors AWS documents for ATS endpoints (<https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs>).
- In `mqtt_aws_tls_verify_cb()`, under `#ifdef WOLFSSL_NO_ASN_STRICT` return `0` on any verify error so regressions actually fail the test. Strict-ASN builds keep the existing accept-anyway path because they cannot load the Starfield G2 anchor.

## Why VeriSign cannot verify this chain

AWS IoT's TLS Certificate message carries three certs: leaf `*.iot.<region>.amazonaws.com`, intermediate `Amazon RSA 2048 M04`, root `Amazon Root CA 1`. wolfSSL's `ProcessPeerCerts` (`src/internal.c`) walks this chain top-down and, for each cert, looks up the *Issuer name* in the trust store to fetch the public key that will verify that cert's signature. Verification is signature math, not list membership: cert N's signature can only be checked with the public key of the CA named in cert N's Issuer. Nothing in the AWS chain is signed by VeriSign's private key, so VeriSign's public key cannot verify any cert in it.

Both runs see the same three certs from the server. The debug output identifies each one:

- top (cert[2]): `Amazon Root CA 1` - wolfSSL reports `Verified CA from chain and already had it`, confirming the server placed this root at the top of its chain and it matches an entry already in the trust store.
- middle (cert[1]): `Amazon RSA 2048 M04`, issued by `Amazon Root CA 1` - wolfSSL logs `Parsed new CA` with `issuer: /CN=Amazon Root CA 1` / `subject: /CN=Amazon RSA 2048 M04`, then verifies its signature and adds it.
- leaf (cert[0]): the peer - wolfSSL logs `Verifying Peer's cert`; its issuer is the intermediate above and its subject is `CN=*.iot.<region>.amazonaws.com`.

The divergence is in `ProcessPeerCerts` at the top of the chain. Debug output captured with `--enable-debug -DWOLFSSL_DEBUG_TLS`:

Amazon Root CA 1 + Starfield G2 loaded (default):

```
processing certificate
wolfSSL Entering DoCertificate
wolfSSL Entering ProcessPeerCerts
Loading peer's cert chain
    Put another cert into chain
    Put another cert into chain
    Put another cert into chain
...
CA found
wolfSSL Entering ConfirmSignature
wolfSSL Leaving ConfirmSignature, return 0
Verified CA from chain and already had it
...
CA found
wolfSSL Leaving ConfirmSignature, return 0
Adding CA from chain
    Parsed new CA
    -  issuer:  '/C=US/O=Amazon/CN=Amazon Root CA 1'
    -  subject: '/C=US/O=Amazon/CN=Amazon RSA 2048 M04'
Verifying Peer's cert
wolfSSL Leaving ConfirmSignature, return 0
Verified Peer's cert
wolfSSL Leaving ProcessPeerCerts, return 0
```

The top cert's issuer `Amazon Root CA 1` matches a trust-store entry; its signature verifies; the intermediate signed by it is accepted and cached; the leaf signed by the intermediate is accepted.

VeriSign G5 loaded (legacy repro via `-DWOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA`):

```
processing certificate
wolfSSL Entering DoCertificate
wolfSSL Entering ProcessPeerCerts
Loading peer's cert chain
    Put another cert into chain
    Put another cert into chain
    Put another cert into chain
...
No CA signer to verify with
Failed to verify CA from chain
Consider enabling WOLFSSL_ALT_CERT_CHAINS to resolve ASN_NO_SIGNER_E
wolfSSL error occurred, error = -188
wolfSSL Entering SendAlert
SendAlert: 48 unknown_ca
Data to send
    15 03 03 00 02 02 30
wolfSSL Leaving ProcessPeerCerts, return -188
```

Same three certs; the top one names `Amazon Root CA 1` as its issuer; the trust store contains only VeriSign G5 whose name and key do not match; `ConfirmSignature` is never reached. The client emits a TLS `unknown_ca` fatal alert (bytes `15 03 03 00 02 02 30` = alert record, fatal level, alert 48) and drops the connection.

wolfSSL also logs the hint `Consider enabling WOLFSSL_ALT_CERT_CHAINS to resolve ASN_NO_SIGNER_E`. Enabling that flag does NOT rescue this case. Verified empirically by rebuilding wolfSSL with `CFLAGS="-DWOLFSSL_NO_ASN_STRICT -DWOLFSSL_ALT_CERT_CHAINS"` and rerunning the legacy variant. `ALT_CERT_CHAINS` makes `ProcessPeerCerts` try each received cert as a potential anchor rather than only the top; the debug then shows the same failure three times:

```
    Put another cert into chain
    Put another cert into chain
    Put another cert into chain
...
No CA signer to verify with
Failed to verify CA from chain
...
No CA signer to verify with
Failed to verify CA from chain
...
No CA signer to verify with
Failed to verify Peer's cert
wolfSSL error occurred, error = -188
SendAlert: 48 unknown_ca
```

The flag changes *where* in the chain an anchor is looked for; it does not change the signature math, which still requires a trust-store public key that matches some cert's issuer. VeriSign's key matches none of them, so every alternative path fails with `-188` and the outcome is identical.

## Build note

Starfield G2 has `serialNumber=0`. RFC 5280 4.1.2.2 requires a positive serial, so wolfSSL's default strict ASN parser drops it. Builds that want real chain verification need `WOLFSSL_NO_ASN_STRICT`.

## Verification via `scripts/awsiot.test`

A build-time toggle `WOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA` keeps the old VeriSign G5 PEM in the source (off by default) so the test can prove the deprecated CA is rejected:

| Build | `root_ca` bundle | Callback output | Test exit |
|---|---|---|---|
| `-DWOLFSSL_NO_ASN_STRICT` (default awsiot.c) | Amazon + SFS G2 | callback never hits error path | pass |
| `-DWOLFSSL_NO_ASN_STRICT -DWOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA` | VeriSign G5 | `PreVerify 0, Error -188` + "Rejecting cert: verification must succeed under WOLFSSL_NO_ASN_STRICT" | **fail** ("AWS IoT MQTT Client failed! TLS=On, QoS=0") |

Error -188 is `ASN_NO_SIGNER_E`. Under strict ASN parsing (no `WOLFSSL_NO_ASN_STRICT`), `scripts/awsiot.test` still passes in both modes because the tightened callback only rejects when the full bundle is actually loadable.

## Reproduce

Build wolfSSL with `WOLFSSL_NO_ASN_STRICT` (needed to load Starfield G2) and install. Then from the wolfmqtt source root:

```
./configure --enable-tls --enable-examples && make && ./scripts/awsiot.test
# -> AWS IoT MQTT Client Tests Passed (chain verifies against Amazon + Starfield G2)

make clean && ./configure --enable-tls --enable-examples CPPFLAGS=-DWOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA \
  && make && ./scripts/awsiot.test
# -> Error -188 (ASN no signer), "Rejecting cert: verification must succeed under WOLFSSL_NO_ASN_STRICT",
#    "AWS IoT MQTT Client failed! TLS=On, QoS=0"
```

To see the handshake and cert processing described in the previous section, rebuild wolfSSL with wolfSSL's embedded TLS debugger and rerun:

```
# wolfSSL:
./configure --enable-debug --enable-static CFLAGS="-DWOLFSSL_NO_ASN_STRICT -DWOLFSSL_DEBUG_TLS"
make && make install

# wolfmqtt: build both variants as above, then for each run:
./examples/aws/awsiot -T -t -q 0 2>&1 \
  | grep -E 'Put another cert|CA found|Verified CA from chain|Verified Peer|No CA signer|Failed to verify|error = -188|SendAlert: [0-9]+'
```

The demo calls `wolfSSL_Debugging_ON()` behind `#ifdef DEBUG_WOLFSSL`, so that single wolfSSL rebuild is enough to surface the handshake on stderr in both variants.

## Files changed

- `examples/aws/awsiot.c`
  - `root_ca` PEM replaced with Amazon Root CA 1 + Starfield Services Root CA G2. Legacy VeriSign PEM kept under `#ifdef WOLFMQTT_AWSIOT_LEGACY_VERISIGN_CA` for regression proof.
  - Verify-callback error branch gated on `WOLFSSL_NO_ASN_STRICT` (hard-fail when the full bundle is loadable; accept-anyway otherwise to preserve existing behavior).
  - `wolfSSL_Debugging_ON()` call in `mqtt_aws_tls_cb()` behind `#ifdef DEBUG_WOLFSSL` so debug-built wolfSSL actually prints the handshake.
