### PR TITLE
Fenrir fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,16 @@
       detected on the write-only path (the publish appears successful), matching
       prior behavior; use `MqttClient_Publish`/`_ex` for reliable detection.
 
+* Fixes
+    - `SN_Client_Unsubscribe` now registers its pending UNSUBACK response under
+      the real Packet Identifier instead of a hard-coded `0`. In
+      `WOLFMQTT_MULTITHREAD` builds where a dedicated reader thread processes the
+      UNSUBACK first, `MqttClient_RespList_Find` matches on the decoded packet
+      id, so the id-0 entry never matched and the response was consumed into the
+      generic object, leaving the unsubscribing thread blocked until
+      `cmd_timeout_ms`. The registration now matches `SN_Client_Subscribe`,
+      `SN_Client_Register`, and `SN_Client_Publish`.
+
 ### v2.0.0 (03/20/2026)
 Release 2.0.0 has been developed according to wolfSSL's development and QA
 process (see link below) and successfully passed the quality criteria.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -58,6 +58,22 @@
       `cmd_timeout_ms`. A QoS 1 PUBACK or QoS 2 PUBCOMP rejection is NOT
       detected on the write-only path (the publish appears successful), matching
       prior behavior; use `MqttClient_Publish`/`_ex` for reliable detection.
+    - An incoming PUBLISH received by a client with no message callback
+      registered (`msg_cb == NULL`) now returns `MQTT_CODE_ERROR_CALLBACK`
+      (-13) instead of `MQTT_CODE_SUCCESS`. Previously the payload was silently
+      read and discarded, and for QoS 1/2 a PUBACK/PUBREC was still sent,
+      falsely telling the broker the message was delivered while the application
+      never saw it. `MqttClient_HandlePacket` no longer populates an ACK in this
+      case, so no false acknowledgement is sent. This affects standard MQTT
+      (`MqttClient_Publish_ReadPayload`) and MQTT-SN (`SN_Client_HandlePacket`).
+      A registered `msg_cb` is now required to receive a PUBLISH; this includes
+      the receive-into-object pattern via `MqttClient_WaitMessage_ex` /
+      `SN_Client_WaitMessage_ex`, which previously returned success after
+      decoding into the caller-supplied object without a callback. A NULL
+      callback is still valid for a publish-only client that never receives
+      messages; the error surfaces only if such a client is actually pushed a
+      PUBLISH. The built-in broker is unaffected (it handles incoming PUBLISH
+      through its own path, not this one).
 
 * Fixes
     - `SN_Client_Unsubscribe` now registers its pending UNSUBACK response under

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,26 @@
       because [MQTT-3.1.3.5] defines Password as Binary Data, not a UTF-8
       string. A binary password containing bytes that are not valid UTF-8
       (e.g., `0xC0`, `0xFF`) would otherwise be incorrectly rejected.
+    - `MqttClient_Publish` / `MqttClient_Publish_ex` now return the new
+      `MQTT_CODE_ERROR_PUBLISH_REJECTED` (-21) when a v5 broker rejects a
+      QoS>0 PUBLISH via a PUBACK (QoS 1), PUBREC, or PUBCOMP (QoS 2) reason
+      code >= 0x80 (e.g. Not authorized, Quota exceeded, Topic Name invalid,
+      Payload format invalid). Previously these were reported as
+      `MQTT_CODE_SUCCESS`, so the application proceeded as if the broker had
+      accepted the message. The specific reason is available in
+      `MqttPublish.resp.reason_code`. For QoS 2, a PUBREC reason code >= 0x80
+      now ends the exchange without sending PUBREL per [MQTT-4.3.3] instead of
+      timing out. v3.1.1 publishes are unaffected, as is the return value of
+      the fire-and-forget `MqttClient_Publish_WriteOnly` call itself. Callers
+      that treat any non-success return as fatal may need to handle this code.
+      In `WOLFMQTT_MULTITHREAD` builds where a dedicated thread drives reads,
+      that reading thread now returns `MQTT_CODE_ERROR_PUBLISH_REJECTED` when it
+      processes a QoS 2 PUBREC rejection (instead of advancing the handshake
+      with an illegal PUBREL); the originating write-only publish's pending
+      response is not auto-completed in that case, so it blocks until
+      `cmd_timeout_ms`. A QoS 1 PUBACK or QoS 2 PUBCOMP rejection is NOT
+      detected on the write-only path (the publish appears successful), matching
+      prior behavior; use `MqttClient_Publish`/`_ex` for reliable detection.
 
 ### v2.0.0 (03/20/2026)
 Release 2.0.0 has been developed according to wolfSSL's development and QA

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,15 @@
       connection on malformed packets, which the broker's existing decode-
       error path enforces. The check covers ClientId, Will Topic, Topic Name,
       Topic Filter, Username, and v5 STRING/STRING_PAIR property values.
+    - The broker now requires `auth_user` and `auth_pass` to be configured as
+      a pair. Previously, setting only one (e.g. the `-u` CLI flag without
+      `-P`) silently enabled single-factor authentication: the unconfigured
+      side was never checked, so any password authenticated against a matching
+      username (or any username against a matching password). `MqttBroker_Start`
+      now rejects a partial credential configuration with
+      `MQTT_CODE_ERROR_BAD_ARG`, and the connect-time gate fails closed as a
+      defense in depth if only one credential is set. Leaving both NULL still
+      disables authentication.
 
 * API / Behavior Changes
     - `MqttDecode_String` may now return `MQTT_CODE_ERROR_MALFORMED_DATA`

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -5421,7 +5421,36 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                  * PUBLISH is fully received and decoded before we
                  * reach the fan-out); BrokerOutPub_Alloc deep-copies
                  * pub.total_len from that buffer. */
-                {
+                if (sub->client->out_q_count >=
+                        BROKER_MAX_QUEUED_MSGS_PER_SUB) {
+                    /* DoS guard: bound the connected subscriber's outbound
+                     * queue depth. The inflight cap above only limits bytes on
+                     * the wire; a subscriber that stops acking lets QUEUED
+                     * entries accumulate one heap-copied PUBLISH at a time
+                     * until the broker exhausts memory. Disconnect the slow /
+                     * abusive subscriber rather than growing out_q or silently
+                     * dropping accepted QoS 1/2 messages. A persistent session
+                     * is reclaimable on reconnect via the (capped) offline
+                     * queue. Mirrors the static partial-write teardown: tear
+                     * the socket down and clear connected so the match guard
+                     * above skips this client's remaining subscriptions; the
+                     * main loop reaps it on the next read error. */
+                    WBLOG_ERR(broker,
+                        "broker: out_q full (%d) -> disconnect sock=%d "
+                        "(from sock=%d)", sub->client->out_q_count,
+                        (int)sub->client->sock, (int)bc->sock);
+                #ifdef WOLFMQTT_V5
+                    (void)BrokerSend_Disconnect(sub->client,
+                        MQTT_REASON_QUOTA_EXCEEDED);
+                #endif
+                    if (sub->client->sock != BROKER_SOCKET_INVALID) {
+                        broker->net.close(broker->net.ctx,
+                            sub->client->sock);
+                        sub->client->sock = BROKER_SOCKET_INVALID;
+                    }
+                    sub->client->connected = 0;
+                }
+                else {
                     BrokerOutPub* e = BrokerOutPub_Alloc(topic, payload,
                                           pub.total_len);
                     if (e == NULL) {

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -4585,6 +4585,14 @@ static int BrokerHandle_Connect(BrokerClient* bc, int rx_len,
     }
     if (broker->auth_user || broker->auth_pass) {
         int auth_ok = 1;
+        /* Defense in depth: MqttBroker_Start rejects a partial credential
+         * config, but MqttBroker struct fields are public and a caller may
+         * set them after start or ignore the start error. If only one of the
+         * pair is configured, fail closed rather than authenticating on the
+         * configured half and accepting any value for the missing one. */
+        if (broker->auth_user == NULL || broker->auth_pass == NULL) {
+            auth_ok = 0;
+        }
         if (broker->auth_user && (
         #ifndef WOLFMQTT_STATIC_MEMORY
             bc->username == NULL ||
@@ -6309,6 +6317,19 @@ int MqttBroker_Start(MqttBroker* broker)
 
 #ifdef WOLFMQTT_BROKER_AUTH
     if (broker->auth_user || broker->auth_pass) {
+        /* Username and password are a credential pair: configuring only one
+         * silently downgrades to single-factor auth, because the unconfigured
+         * side is never checked and any client-supplied value for it is
+         * accepted. Reject the partial config at startup so the operator sees
+         * the mistake instead of shipping a bypassable broker. */
+        if (broker->auth_user == NULL || broker->auth_pass == NULL) {
+            WBLOG_ERR(broker,
+                "broker: auth requires both auth_user and auth_pass "
+                "(user=%s pass=%s)",
+                broker->auth_user ? "set" : "(null)",
+                broker->auth_pass ? "set" : "(null)");
+            return MQTT_CODE_ERROR_BAD_ARG;
+        }
         /* Reject configured credentials that would be silently rejected
          * by BrokerStrCompare's cmp_len guard. Catching this at startup
          * avoids a confusing state where every client auth fails. */
@@ -6328,8 +6349,8 @@ int MqttBroker_Start(MqttBroker* broker)
                 BROKER_MAX_PASSWORD_LEN);
             return MQTT_CODE_ERROR_BAD_ARG;
         }
-        WBLOG_INFO(broker, "broker: auth enabled user=%s",
-            broker->auth_user ? broker->auth_user : "(null)");
+        WBLOG_INFO(broker, "broker: auth enabled (user+password) user=%s",
+            broker->auth_user);
     #ifdef ENABLE_MQTT_TLS
     #ifndef WOLFMQTT_BROKER_NO_INSECURE
         if (broker->use_tls &&

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -5443,20 +5443,30 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                      * the socket down and clear connected so the match guard
                      * above skips this client's remaining subscriptions; the
                      * main loop reaps it on the next read error. */
+                    /* Cache the client before BrokerSend_Disconnect below: that
+                     * write can drive an lws_service spin whose
+                     * LWS_CALLBACK_CLOSED frees this subscriber's BrokerSub
+                     * nodes re-entrantly (the same hazard the next_sub snapshot
+                     * guards against), leaving `sub` dangling. The BrokerClient
+                     * itself survives the write - its free is deferred while the
+                     * WS context is marked processing - so the post-write socket
+                     * teardown must reach it through this cached pointer, never
+                     * through the freed sub node. */
+                    BrokerClient* c = sub->client;
                     WBLOG_ERR(broker,
                         "broker: out_q full (%d) -> disconnect sock=%d "
-                        "(from sock=%d)", sub->client->out_q_count,
-                        (int)sub->client->sock, (int)bc->sock);
+                        "(from sock=%d)", c->out_q_count,
+                        (int)c->sock, (int)bc->sock);
                 #ifdef WOLFMQTT_V5
-                    (void)BrokerSend_Disconnect(sub->client,
+                    (void)BrokerSend_Disconnect(c,
                         MQTT_REASON_QUOTA_EXCEEDED);
                 #endif
-                    if (sub->client->sock != BROKER_SOCKET_INVALID) {
+                    if (c->sock != BROKER_SOCKET_INVALID) {
                         broker->net.close(broker->net.ctx,
-                            sub->client->sock);
-                        sub->client->sock = BROKER_SOCKET_INVALID;
+                            c->sock);
+                        c->sock = BROKER_SOCKET_INVALID;
                     }
-                    sub->client->connected = 0;
+                    c->connected = 0;
                 }
                 else {
                     BrokerOutPub* e = BrokerOutPub_Alloc(topic, payload,

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -972,17 +972,33 @@ static int MqttClient_HandlePacket(MqttClient* client,
             }
 
             rc = MqttClient_Publish_ReadPayload(client, publish, timeout_ms);
-            if (rc < 0) {
+
+            /* MQTT_CODE_CONTINUE means the payload is not fully read yet. Return
+             * to the caller and keep publish->props and the read state intact so
+             * the non-blocking re-entry can resume. */
+            if (rc == MQTT_CODE_CONTINUE) {
                 break;
             }
-            /* Note: Getting here means the Publish Read is done */
-            publish->stat.read = MQTT_MSG_BEGIN; /* reset state */
 
+            /* The publish read is terminal here, whether it succeeded or failed
+             * to deliver (e.g. no msg_cb, or the callback returned an error).
+             * Reset the read state and free the retained V5 property list for
+             * every terminal result: the properties are intentionally kept
+             * through decode/callback and were previously freed only on the
+             * success path, so an error return would leak the property pool
+             * (or heap, under WOLFMQTT_DYN_PROP). Also resetting the read state
+             * keeps a caller that logs the error and retries from re-entering on
+             * stale MQTT_MSG_PAYLOAD2 state. */
+            publish->stat.read = MQTT_MSG_BEGIN; /* reset state */
         #ifdef WOLFMQTT_V5
             /* Free the properties */
             MqttProps_Free(publish->props);
             publish->props = NULL;
         #endif
+
+            if (rc < 0) {
+                break;
+            }
 
             /* Handle QoS */
             if (packet_qos == MQTT_QOS_0) {
@@ -2042,6 +2058,15 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
             }
         }
     } while (!msg_done);
+
+    /* No message callback registered to deliver this incoming PUBLISH. The
+     * payload was drained above to keep the stream in sync, but the application
+     * never saw it. Return a distinct error instead of success so the caller is
+     * notified and, for QoS 1/2, MqttClient_HandlePacket does not falsely ACK
+     * the message as delivered. */
+    if (rc == MQTT_CODE_SUCCESS && client->msg_cb == NULL) {
+        rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_CALLBACK);
+    }
 
     return rc;
 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1030,6 +1030,28 @@ static int MqttClient_HandlePacket(MqttClient* client,
                 break;
             }
 
+        #ifdef WOLFMQTT_V5
+            /* A v5 broker rejects a QoS 2 PUBLISH at the PUBREC stage with a
+             * reason code >= 0x80 (e.g. not authorized, quota exceeded, topic
+             * name invalid, payload format invalid). Per [MQTT-4.3.3] the
+             * exchange is then complete and the sender MUST NOT send a PUBREL.
+             * Surface the rejection instead of advancing the handshake, which
+             * would emit an illegal PUBREL and then block waiting for a PUBCOMP
+             * the broker will never send. The QoS 1 PUBACK and the QoS 2
+             * PUBCOMP reason codes are checked by the caller after the wait.
+             * Note (WOLFMQTT_MULTITHREAD): when a separate thread drives reads
+             * and processes this PUBREC, it receives this error directly and
+             * the publishing thread's PUBCOMP pending response is not marked
+             * done, so that publish blocks until cmd_timeout_ms. This matches
+             * the pre-existing behavior (which left the publisher waiting on a
+             * PUBCOMP after an illegal PUBREL) and is not made worse here. */
+            if (packet_type == MQTT_PACKET_TYPE_PUBLISH_REC &&
+                client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+                (((MqttPublishResp*)packet_obj)->reason_code & 0x80)) {
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PUBLISH_REJECTED);
+            }
+        #endif
+
             /* Populate information needed for ack */
             resp->packet_type = packet_type+1; /* next ack */
             resp->packet_id = packet_id;
@@ -2324,6 +2346,26 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     /* Wait for publish response packet */
                     rc = MqttClient_WaitType(client, &publish->resp, resp_type,
                         publish->packet_id, client->cmd_timeout_ms);
+
+                #ifdef WOLFMQTT_V5
+                    /* A v5 broker can acknowledge a QoS>0 PUBLISH at the
+                     * protocol layer yet still reject the message via a
+                     * PUBACK/PUBCOMP reason code >= 0x80 (e.g. not authorized,
+                     * quota exceeded, topic name invalid, payload format
+                     * invalid). Surface that as an error so the caller does not
+                     * treat a rejected message as delivered. Mirrors the
+                     * CONNECT/SUBSCRIBE/UNSUBSCRIBE rejection handling. The
+                     * protocol_level guard avoids misreading a stale byte for
+                     * v3.1.1 ACKs, which carry no reason code (same guard the
+                     * PUBREC check in MqttClient_HandlePacket uses). */
+                    if (rc == MQTT_CODE_SUCCESS &&
+                        client->protocol_level >=
+                            MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+                        (publish->resp.reason_code & 0x80)) {
+                        rc = MQTT_TRACE_ERROR(
+                            MQTT_CODE_ERROR_PUBLISH_REJECTED);
+                    }
+                #endif
                 }
 
             #if defined(WOLFMQTT_NONBLOCK) || defined(WOLFMQTT_MULTITHREAD)
@@ -3202,6 +3244,8 @@ const char* MqttClient_ReturnCodeToString(int return_code)
             return "Error (Broker rejected subscription)";
         case MQTT_CODE_ERROR_UNSUBSCRIBE_REJECTED:
             return "Error (Broker rejected unsubscribe)";
+        case MQTT_CODE_ERROR_PUBLISH_REJECTED:
+            return "Error (Broker rejected publish)";
 #if defined(ENABLE_MQTT_CURL)
         case MQTT_CODE_ERROR_CURL:
             return "Error (libcurl)";

--- a/src/mqtt_sn_client.c
+++ b/src/mqtt_sn_client.c
@@ -205,6 +205,13 @@ static int SN_Client_HandlePacket(MqttClient* client, SN_MsgType packet_type,
                     return rc;
                 };
             }
+            else {
+                /* No callback registered to deliver this PUBLISH. Return a
+                 * distinct error instead of reporting success: for QoS 0 this
+                 * replaces a silent discard, and for QoS>0 it also avoids
+                 * falsely ACKing a message the application never saw. */
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_CALLBACK);
+            }
 
             /* Handle Qos */
             if (p_pub->qos > MQTT_QOS_0) {

--- a/src/mqtt_sn_client.c
+++ b/src/mqtt_sn_client.c
@@ -1837,7 +1837,8 @@ int SN_Client_Unsubscribe(MqttClient *client, SN_Unsubscribe *unsubscribe)
             /* inform other threads of expected response */
             rc = MqttClient_RespList_Add(client,
                     (MqttPacketType)SN_MSG_TYPE_UNSUBACK,
-                    0, &unsubscribe->pendResp, &unsubscribe->ack);
+                    unsubscribe->packet_id, &unsubscribe->pendResp,
+                    &unsubscribe->ack);
             wm_SemUnlock(&client->lockClient);
         }
         if (rc != 0) {

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -647,6 +647,132 @@ TEST(connect_unauth_client_id_does_not_take_over_victim)
     MqttBroker_Stop(&broker);
     MqttBroker_Free(&broker);
 }
+
+/* Regression (issue 3393): configuring only auth_user leaves the password
+ * side unchecked, so any (or no) password authenticates as long as the
+ * username matches. MqttBroker_Start must reject the partial config instead
+ * of silently enabling single-factor auth. */
+TEST(connect_auth_user_only_start_rejected)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    broker.auth_user = "user";
+    broker.auth_pass = NULL;
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, MqttBroker_Start(&broker));
+
+    MqttBroker_Free(&broker);
+}
+
+/* Symmetric case: only auth_pass configured must also be rejected at start. */
+TEST(connect_auth_pass_only_start_rejected)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    broker.auth_user = NULL;
+    broker.auth_pass = "pass";
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, MqttBroker_Start(&broker));
+
+    MqttBroker_Free(&broker);
+}
+
+/* Defense in depth: the MqttBroker struct is public, so a caller can set
+ * auth_user after a successful no-auth start (or ignore the start error),
+ * bypassing the MqttBroker_Start pairing check. The connect-time gate must
+ * still fail closed when only one credential is configured. A CONNECT whose
+ * username matches but carries no password must be refused, not accepted on
+ * the username alone. */
+TEST(connect_auth_partial_config_fails_closed)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    /* CONNECT v3.1.1, ClientId "id", Username "user", no password.
+     * connect_flags 0x82 = username + clean session. */
+    static const byte connect[] = {
+        0x10, 20,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04,
+        0x82,
+        0x00, 0x3C,
+        0x00, 0x02, 'i', 'd',
+        0x00, 0x04, 'u', 's', 'e', 'r'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    /* Start with auth disabled, then enable only the username post-start. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+    broker.auth_user = "user";
+
+    reset_mock_state(connect, sizeof(connect));
+    run_broker_one_connect(&broker);
+
+    /* Pre-fix the username matched and the absent password was never
+     * checked, so the broker accepted (return code 0x00). The gate must now
+     * refuse with 0x05 (Bad user/pass) and close the connection. */
+    ASSERT_TRUE(g_out_len >= 4);
+    ASSERT_EQ(0x20, g_out_buf[0]);
+    ASSERT_EQ(0x02, g_out_buf[1]);
+    ASSERT_EQ(0x00, g_out_buf[2]);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_REFUSED_BAD_USER_PWD, g_out_buf[3]);
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* Symmetric defense-in-depth case: only auth_pass set post-start. Without the
+ * gate, any username with a matching password authenticates (the username side
+ * is never checked). A CONNECT carrying the matching password under an
+ * arbitrary username must be refused, not accepted on the password alone. */
+TEST(connect_auth_partial_pass_only_fails_closed)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    /* CONNECT v3.1.1, ClientId "id", Username "anyone", Password "pass".
+     * connect_flags 0xC2 = username + password + clean session. */
+    static const byte connect[] = {
+        0x10, 28,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04,
+        0xC2,
+        0x00, 0x3C,
+        0x00, 0x02, 'i', 'd',
+        0x00, 0x06, 'a', 'n', 'y', 'o', 'n', 'e',
+        0x00, 0x04, 'p', 'a', 's', 's'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    /* Start with auth disabled, then enable only the password post-start. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+    broker.auth_pass = "pass";
+
+    reset_mock_state(connect, sizeof(connect));
+    run_broker_one_connect(&broker);
+
+    /* Pre-fix the password matched and the username was never checked, so the
+     * broker accepted (return code 0x00). The gate must now refuse with 0x05
+     * (Bad user/pass) and close the connection. */
+    ASSERT_TRUE(g_out_len >= 4);
+    ASSERT_EQ(0x20, g_out_buf[0]);
+    ASSERT_EQ(0x02, g_out_buf[1]);
+    ASSERT_EQ(0x00, g_out_buf[2]);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_REFUSED_BAD_USER_PWD, g_out_buf[3]);
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
 #endif /* WOLFMQTT_BROKER_AUTH */
 
 #ifdef WOLFMQTT_V5
@@ -3076,6 +3202,10 @@ int main(int argc, char** argv)
     RUN_TEST(connect_v311_binary_password_with_embedded_nul_refused);
     RUN_TEST(connect_v311_binary_password_exact_match_accepted);
     RUN_TEST(connect_unauth_client_id_does_not_take_over_victim);
+    RUN_TEST(connect_auth_user_only_start_rejected);
+    RUN_TEST(connect_auth_pass_only_start_rejected);
+    RUN_TEST(connect_auth_partial_config_fails_closed);
+    RUN_TEST(connect_auth_partial_pass_only_fails_closed);
 #endif
 #ifdef WOLFMQTT_V5
     RUN_TEST(connect_v5_emptyid_assigned_id_emitted);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -782,6 +782,68 @@ static int count_packets_of_type(const byte* buf, size_t len, byte target)
     return count;
 }
 
+/* find_broker_client / the out_q-cap tests below inspect dynamic-mode-only
+ * BrokerClient state (the linked client list, out_q_count); guard the whole
+ * group so static-memory broker builds (where MqttBroker.clients is an array
+ * and BrokerClient has no next/out_q_count) still compile. */
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* Find the broker-side BrokerClient with the given client_id, walking the
+ * dynamic-mode client list. Returns NULL if absent. Used to inspect internal
+ * per-subscriber queue state (out_q_count) that has no wire-visible signal. */
+static BrokerClient* find_broker_client(MqttBroker* broker, const char* id)
+{
+    BrokerClient* c = broker->clients;
+    while (c != NULL) {
+        if (c->client_id != NULL && XSTRCMP(c->client_id, id) == 0) {
+            return c;
+        }
+        c = c->next;
+    }
+    return NULL;
+}
+
+#ifdef WOLFMQTT_V5
+/* Return the Reason Code byte of the first DISCONNECT packet in a captured
+ * stream, or -1 if none carries a reason code. A v5 DISCONNECT with a
+ * non-success reason and no properties encodes as 0xE0 <remain> <reason>;
+ * the reason is the first byte of the variable header. Only referenced by the
+ * v5 cap test, so it lives under WOLFMQTT_V5 to avoid an unused-function
+ * warning (the build runs with -Werror -Wunused). */
+static int first_disconnect_reason(const byte* buf, size_t len)
+{
+    size_t pos = 0;
+    while (pos < len) {
+        byte type = (byte)((buf[pos] >> 4) & 0x0F);
+        size_t remain = 0;
+        size_t mult = 1;
+        size_t hdr_len = 1;
+        int vbi_complete = 0;
+        while (pos + hdr_len < len && hdr_len <= 5) {
+            byte b = buf[pos + hdr_len];
+            remain += (size_t)(b & 0x7F) * mult;
+            hdr_len++;
+            if ((b & 0x80) == 0) { vbi_complete = 1; break; }
+            mult *= 128;
+        }
+        if (!vbi_complete) {
+            break;
+        }
+        if (type == MQTT_PACKET_TYPE_DISCONNECT) {
+            if (remain >= 1 && pos + hdr_len < len) {
+                return buf[pos + hdr_len];
+            }
+            return -1;
+        }
+        if (remain > len - pos - hdr_len) {
+            break;
+        }
+        pos += hdr_len + remain;
+    }
+    return -1;
+}
+#endif /* WOLFMQTT_V5 */
+#endif /* !WOLFMQTT_STATIC_MEMORY */
+
 /* [MQTT-4.3.3] / Method B: when the broker receives a duplicate QoS 2
  * PUBLISH carrying a packet ID that's still awaiting PUBREL, it MUST send
  * another PUBREC to the publisher but MUST NOT re-deliver the application
@@ -1028,6 +1090,26 @@ static size_t build_qos2_pub(byte* out, word16 packet_id)
     out[7] = 'p';
     return 8;
 }
+
+/* Build a v3.1.1 QoS 1 PUBLISH to topic "x" (payload "p") with the given
+ * packet_id. Used to flood a slow subscriber's outbound queue. The v3.1.1
+ * wire form has no property field, so the encoding is identical to the QoS 2
+ * helper except for the QoS bits in the fixed header. Returns length (8).
+ * Only used by the dynamic-mode out_q-cap tests, so guarded to avoid an
+ * unused-function warning under -Werror in static-memory builds. */
+#ifndef WOLFMQTT_STATIC_MEMORY
+static size_t build_qos1_pub(byte* out, word16 packet_id)
+{
+    /* remain = topic_len(2) + topic(1) + packet_id(2) + payload(1) = 6 */
+    out[0] = 0x32; /* PUBLISH, QoS 1 */
+    out[1] = 0x06;
+    out[2] = 0x00; out[3] = 0x01; out[4] = 'x';
+    out[5] = (byte)(packet_id >> 8);
+    out[6] = (byte)(packet_id & 0xFF);
+    out[7] = 'p';
+    return 8;
+}
+#endif /* !WOLFMQTT_STATIC_MEMORY */
 
 /* The per-client cap on in-flight QoS 2 packet IDs (BROKER_MAX_INBOUND_QOS2,
  * default 16) MUST disconnect a client that exceeds it. Without the cap, a
@@ -1349,6 +1431,257 @@ TEST(qos2_publish_then_abrupt_close_offline_subscriber)
     MqttBroker_Stop(&broker);
     MqttBroker_Free(&broker);
 }
+
+/* The out_q-cap tests are dynamic-memory-only (they inspect out_q_count and
+ * the linked client list); the v5 variant additionally uses the v5-only
+ * MQTT_REASON_QUOTA_EXCEEDED. Guard accordingly so the non-V5 and
+ * static-memory broker CI matrix entries compile. */
+#ifndef WOLFMQTT_STATIC_MEMORY
+#ifdef WOLFMQTT_V5
+/* Issue 6222: a connected QoS>=1 subscriber that stops acking must NOT be able
+ * to grow its outbound queue without bound. The inflight cap only limits
+ * PUBLISHes on the wire; entries beyond it sit QUEUED and, pre-fix, were
+ * appended to out_q with no depth limit - one heap-copied PUBLISH (topic +
+ * attacker-sized payload) per matching message, until the broker OOMs.
+ *
+ * Repro: subscriber subscribes to "x" at QoS 1 and then never PUBACKs; a
+ * publisher floods more than BROKER_MAX_QUEUED_MSGS_PER_SUB matching QoS 1
+ * PUBLISHes. The fix bounds out_q_count at the cap and disconnects the slow
+ * subscriber (v5: DISCONNECT reason 0x97 Quota Exceeded). We assert the queue
+ * stopped growing at the cap, the subscriber's socket was torn down, and at
+ * most the inflight window ever reached the wire. */
+TEST(online_qos1_flood_disconnects_slow_v5_subscriber)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    int flood = BROKER_MAX_QUEUED_MSGS_PER_SUB + 8;
+    int sub_pubs;
+    int sub_disconnects;
+    BrokerClient* sub_bc;
+
+    /* Subscriber CONNECT: v5, ClientId "S", clean_session=1. */
+    static const byte connect_sub[] = {
+        0x10, 0x0E,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x05, 0x02, 0x00, 0x3C,
+        0x00,                   /* properties length = 0 */
+        0x00, 0x01, 'S'
+    };
+    /* SUBSCRIBE (v5): packet_id=1, props_len=0, filter "x", QoS 1. */
+    static const byte subscribe_x[] = {
+        0x82, 0x07,
+        0x00, 0x01,
+        0x00,                   /* properties length = 0 */
+        0x00, 0x01, 'x',
+        0x01
+    };
+    /* Publisher CONNECT: v3.1.1, ClientId "P", clean_session=1. */
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    byte pub_buf[8];
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+
+    /* Phase 1: subscriber connects and subscribes (and stays connected).
+     * Establish the subscription before the flood so every published message
+     * matches and is fanned out to this subscriber. */
+    mock_client_input_append(0, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(0, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+    ASSERT_TRUE(sub_bc->connected);
+
+    /* Phase 2: publisher connects and floods QoS 1 PUBLISHes to "x". The
+     * subscriber never PUBACKs, so the inflight window saturates and every
+     * further message is queued (pre-fix: forever). */
+    mock_client_input_append(1, connect_pub, sizeof(connect_pub));
+    for (i = 0; i < flood; i++) {
+        size_t n = build_qos1_pub(pub_buf, (word16)(i + 1));
+        mock_client_input_append(1, pub_buf, n);
+    }
+    for (i = 0; i < flood + 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* The subscriber's queue must have stopped growing at the cap rather than
+     * tracking the flood size, and the broker must have torn the socket down. */
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+    ASSERT_EQ(BROKER_MAX_QUEUED_MSGS_PER_SUB, sub_bc->out_q_count);
+    ASSERT_FALSE(sub_bc->connected);
+    ASSERT_TRUE(g_clients[0].closed);
+
+    /* Only the inflight window ever reached the wire - far fewer than the
+     * flood, proving the cap bounds wire traffic too. */
+    sub_pubs = count_packets_of_type(g_clients[0].out_buf,
+        g_clients[0].out_len, MQTT_PACKET_TYPE_PUBLISH);
+    ASSERT_TRUE(sub_pubs >= 1);
+    ASSERT_TRUE(sub_pubs <= BROKER_MAX_INFLIGHT_PER_SUB);
+
+    /* v5 subscriber gets a DISCONNECT with reason 0x97 Quota Exceeded. */
+    sub_disconnects = count_packets_of_type(g_clients[0].out_buf,
+        g_clients[0].out_len, MQTT_PACKET_TYPE_DISCONNECT);
+    ASSERT_EQ(1, sub_disconnects);
+    ASSERT_EQ(MQTT_REASON_QUOTA_EXCEEDED,
+        first_disconnect_reason(g_clients[0].out_buf, g_clients[0].out_len));
+
+    /* The publisher is a separate, well-behaved client and must be untouched. */
+    ASSERT_FALSE(g_clients[1].closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+#endif /* WOLFMQTT_V5 */
+
+/* Same overflow scenario with a v3.1.1 subscriber. v3.1.1 has no
+ * DISCONNECT-with-reason path, so the broker simply closes the socket; the
+ * queue must still be bounded at the cap. */
+TEST(online_qos1_flood_disconnects_slow_v311_subscriber)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    int flood = BROKER_MAX_QUEUED_MSGS_PER_SUB + 8;
+    int sub_disconnects;
+    BrokerClient* sub_bc;
+
+    /* Subscriber CONNECT: v3.1.1, ClientId "S", clean_session=1. */
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* SUBSCRIBE (v3.1.1): packet_id=1, filter "x", QoS 1. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x01
+    };
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    byte pub_buf[8];
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(0, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+    ASSERT_TRUE(sub_bc->connected);
+
+    mock_client_input_append(1, connect_pub, sizeof(connect_pub));
+    for (i = 0; i < flood; i++) {
+        size_t n = build_qos1_pub(pub_buf, (word16)(i + 1));
+        mock_client_input_append(1, pub_buf, n);
+    }
+    for (i = 0; i < flood + 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+    ASSERT_EQ(BROKER_MAX_QUEUED_MSGS_PER_SUB, sub_bc->out_q_count);
+    ASSERT_FALSE(sub_bc->connected);
+    ASSERT_TRUE(g_clients[0].closed);
+
+    /* v3.1.1 has no DISCONNECT reason code: the broker closes silently. */
+    sub_disconnects = count_packets_of_type(g_clients[0].out_buf,
+        g_clients[0].out_len, MQTT_PACKET_TYPE_DISCONNECT);
+    ASSERT_EQ(0, sub_disconnects);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* Boundary check: a slow subscriber that reaches but does not exceed the cap
+ * stays connected. Publishing exactly BROKER_MAX_QUEUED_MSGS_PER_SUB messages
+ * fills out_q to the cap; only the (cap+1)th would trip the disconnect. Guards
+ * the >= comparison against an off-by-one that would evict at the cap. */
+TEST(online_qos1_at_cap_keeps_subscriber)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    int at_cap = BROKER_MAX_QUEUED_MSGS_PER_SUB;
+    BrokerClient* sub_bc;
+
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    static const byte subscribe_x[] = {
+        0x82, 0x06, 0x00, 0x01, 0x00, 0x01, 'x', 0x01
+    };
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    byte pub_buf[8];
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(0, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+
+    mock_client_input_append(1, connect_pub, sizeof(connect_pub));
+    for (i = 0; i < at_cap; i++) {
+        size_t n = build_qos1_pub(pub_buf, (word16)(i + 1));
+        mock_client_input_append(1, pub_buf, n);
+    }
+    for (i = 0; i < at_cap + 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_TRUE(sub_bc != NULL);
+    ASSERT_EQ(BROKER_MAX_QUEUED_MSGS_PER_SUB, sub_bc->out_q_count);
+    ASSERT_TRUE(sub_bc->connected);
+    ASSERT_FALSE(g_clients[0].closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* !WOLFMQTT_STATIC_MEMORY */
 
 #ifdef WOLFMQTT_V5
 /* v5 variant: same orphan-then-publish-then-disconnect pattern but the
@@ -2756,6 +3089,13 @@ int main(int argc, char** argv)
     RUN_TEST(qos2_pubrel_unknown_id_still_pubcomps);
     RUN_TEST(qos2_publish_with_offline_durable_subscriber);
     RUN_TEST(qos2_publish_then_abrupt_close_offline_subscriber);
+#ifndef WOLFMQTT_STATIC_MEMORY
+#ifdef WOLFMQTT_V5
+    RUN_TEST(online_qos1_flood_disconnects_slow_v5_subscriber);
+#endif /* WOLFMQTT_V5 */
+    RUN_TEST(online_qos1_flood_disconnects_slow_v311_subscriber);
+    RUN_TEST(online_qos1_at_cap_keeps_subscriber);
+#endif /* !WOLFMQTT_STATIC_MEMORY */
 #ifdef WOLFMQTT_V5
     RUN_TEST(qos2_publish_v5_props_with_offline_durable_subscriber);
 #endif

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -302,6 +302,10 @@ static byte connect_mock_sent[TEST_TX_BUF_SIZE];
  * QoS 2 handshake either did or did not emit one. */
 static int g_pubrel_written;
 
+/* Set when a PUBACK (type 4) or PUBREC (type 5) is written, so tests can assert
+ * that an incoming QoS>0 PUBLISH was (or was not) acknowledged to the broker. */
+static int g_pubresp_written;
+
 static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
     int timeout_ms)
 {
@@ -314,6 +318,11 @@ static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
     if (buf != NULL && buf_len > 0 &&
         (buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_REL << 4)) {
         g_pubrel_written = 1;
+    }
+    if (buf != NULL && buf_len > 0 &&
+        ((buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_ACK << 4) ||
+         (buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_REC << 4))) {
+        g_pubresp_written = 1;
     }
     /* Pretend the full packet was sent so MqttClient_Connect reaches the
      * CLIENT_FORCE_ZERO step. */
@@ -1108,6 +1117,197 @@ TEST(wait_message_null_client)
     ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
 }
 
+/* Stage `frame` as a server-pushed packet and drive MqttClient_WaitMessage to
+ * completion against the canned-response mock. The client is initialized with a
+ * NULL msg_cb (test_init_client passes NULL). Returns the terminal result. */
+static int run_wait_message_with_frame(const byte* frame, int frame_len)
+{
+    int rc;
+    int i;
+
+    rc = test_init_client();
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+#ifdef WOLFMQTT_V5
+    /* Decode the v3.1.1-format frame below without expecting v5 properties. */
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_pubresp_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, frame, (size_t)frame_len);
+    g_canned_len = frame_len;
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+    return rc;
+}
+
+/* #6217: a client initialized with a NULL msg_cb that receives a QoS 1 PUBLISH
+ * used to silently drain and discard the payload, return MQTT_CODE_SUCCESS, and
+ * then send a PUBACK telling the broker the message was delivered. The
+ * application never saw the message yet the broker considered it acknowledged.
+ * MqttClient_Publish_ReadPayload now returns MQTT_CODE_ERROR_CALLBACK when no
+ * callback is registered, so MqttClient_HandlePacket does not populate an ACK
+ * and no PUBACK is sent. */
+TEST(wait_message_qos1_null_msg_cb_errors_no_ack)
+{
+    int rc;
+    /* v3.1.1 QoS1 PUBLISH: type|qos1=0x32, remain=7, topic "a" (0x0001 'a'),
+     * packet_id=7 (0x0007), payload "hi". */
+    static const byte publish_qos1[] = { 0x32, 0x07, 0x00, 0x01, 'a',
+                                         0x00, 0x07, 'h', 'i' };
+
+    rc = run_wait_message_with_frame(publish_qos1, (int)sizeof(publish_qos1));
+
+    /* Pre-fix this returned MQTT_CODE_SUCCESS. */
+    ASSERT_EQ(MQTT_CODE_ERROR_CALLBACK, rc);
+    /* The broker must NOT be told the message was delivered. Pre-fix a PUBACK
+     * was emitted here, falsely confirming delivery of a dropped message. */
+    ASSERT_FALSE(g_pubresp_written);
+}
+
+/* #6217 (QoS 0 half): a QoS 0 PUBLISH carries no acknowledgement, so the false
+ * ACK does not apply, but with a NULL msg_cb the message was still silently
+ * dropped with MQTT_CODE_SUCCESS. The caller now receives a distinct error
+ * instead of believing nothing arrived. */
+TEST(wait_message_qos0_null_msg_cb_errors)
+{
+    int rc;
+    /* v3.1.1 QoS0 PUBLISH: type=0x30, remain=5, topic "a" (0x0001 'a'),
+     * payload "hi" (no packet id for QoS 0). */
+    static const byte publish_qos0[] = { 0x30, 0x05, 0x00, 0x01, 'a', 'h', 'i' };
+
+    rc = run_wait_message_with_frame(publish_qos0, (int)sizeof(publish_qos0));
+
+    /* Pre-fix this returned MQTT_CODE_SUCCESS while discarding the message. */
+    ASSERT_EQ(MQTT_CODE_ERROR_CALLBACK, rc);
+    /* QoS 0 never acknowledges, with or without the fix. */
+    ASSERT_FALSE(g_pubresp_written);
+}
+
+/* #6217 (QoS 2): a QoS 2 incoming PUBLISH with no msg_cb must error without
+ * sending the PUBREC. QoS 2 is where the suppressed acknowledgement matters
+ * most: a false PUBREC starts a delivery handshake the broker then completes
+ * for a message the application never received. */
+TEST(wait_message_qos2_null_msg_cb_errors_no_ack)
+{
+    int rc;
+    /* v3.1.1 QoS2 PUBLISH: type|qos2=0x34, remain=7, topic "a" (0x0001 'a'),
+     * packet_id=9 (0x0009), payload "hi". */
+    static const byte publish_qos2[] = { 0x34, 0x07, 0x00, 0x01, 'a',
+                                         0x00, 0x09, 'h', 'i' };
+
+    rc = run_wait_message_with_frame(publish_qos2, (int)sizeof(publish_qos2));
+
+    /* Pre-fix this returned MQTT_CODE_SUCCESS. */
+    ASSERT_EQ(MQTT_CODE_ERROR_CALLBACK, rc);
+    /* No PUBREC may be sent: pre-fix one was, falsely starting a QoS 2
+     * handshake for a dropped message. */
+    ASSERT_FALSE(g_pubresp_written);
+}
+
+#ifdef WOLFMQTT_V5
+/* #6217 property-leak regression: a v5 incoming PUBLISH carrying properties must
+ * not leak its retained property list when there is no msg_cb. The decoder keeps
+ * the property list to be freed after the callback; on the no-callback error
+ * path MqttClient_HandlePacket must still free it (skipping the free leaked the
+ * static property pool, or the heap under WOLFMQTT_DYN_PROP). Asserts the error
+ * is returned, no PUBACK is sent, and the retained property list was released.
+ * Uses protocol level 5 so the property bytes are actually parsed (the shared
+ * helper forces level 4 to keep its frames v3.1.1). */
+TEST(wait_message_v5_props_null_msg_cb_frees_props)
+{
+    int rc;
+    int i;
+    /* v5 QoS1 PUBLISH: type|qos1=0x32, remain=0x0A, topic "a" (0x0001 'a'),
+     * packet_id=9 (0x0009), prop_len=2, Payload Format Indicator (0x01)=0,
+     * payload "hi". */
+    static const byte publish_v5[] = { 0x32, 0x0A, 0x00, 0x01, 'a',
+                                       0x00, 0x09, 0x02, 0x01, 0x00,
+                                       'h', 'i' };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    g_pubresp_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, publish_v5, sizeof(publish_v5));
+    g_canned_len = (int)sizeof(publish_v5);
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_CALLBACK, rc);
+    ASSERT_FALSE(g_pubresp_written);
+    /* The retained v5 property list must have been freed on the error path;
+     * pre-fix it leaked, leaving publish->props non-NULL. */
+    ASSERT_NULL(test_client.msg.publish.props);
+}
+#endif /* WOLFMQTT_V5 */
+
+/* Counts deliveries for the positive-control test below. */
+static int g_msg_cb_calls;
+static int test_accept_message_cb(MqttClient* client, MqttMessage* msg,
+    byte msg_new, byte msg_done)
+{
+    (void)client; (void)msg; (void)msg_new; (void)msg_done;
+    g_msg_cb_calls++;
+    return MQTT_CODE_SUCCESS;
+}
+
+/* Positive control for #6217: with a real msg_cb registered, an incoming QoS 1
+ * PUBLISH must still be delivered to the callback AND acknowledged with a
+ * PUBACK. The no-callback error is gated on msg_cb == NULL, so the normal
+ * acknowledge path must be unchanged. Without this, every new test runs with a
+ * NULL callback and only asserts the FALSE direction of g_pubresp_written, so a
+ * regression that suppressed ACKs outright would go unnoticed. */
+TEST(wait_message_qos1_with_msg_cb_delivers_and_acks)
+{
+    int rc;
+    int i;
+    /* v3.1.1 QoS1 PUBLISH: type|qos1=0x32, remain=7, topic "a" (0x0001 'a'),
+     * packet_id=7 (0x0007), payload "hi". */
+    static const byte publish_qos1[] = { 0x32, 0x07, 0x00, 0x01, 'a',
+                                         0x00, 0x07, 'h', 'i' };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    /* Register a real callback so the normal deliver-and-ACK path is taken. */
+    test_client.msg_cb = test_accept_message_cb;
+    g_msg_cb_calls = 0;
+
+    g_pubresp_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, publish_qos1, sizeof(publish_qos1));
+    g_canned_len = (int)sizeof(publish_qos1);
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    /* The message was delivered to the callback and the PUBACK was sent. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_TRUE(g_msg_cb_calls > 0);
+    ASSERT_TRUE(g_pubresp_written);
+}
+
 /* ============================================================================
  * MqttClient_ReturnCodeToString Tests
  * ============================================================================ */
@@ -1240,6 +1440,13 @@ void run_mqtt_client_tests(void)
 
     /* MqttClient_WaitMessage tests */
     RUN_TEST(wait_message_null_client);
+    RUN_TEST(wait_message_qos1_null_msg_cb_errors_no_ack);
+    RUN_TEST(wait_message_qos0_null_msg_cb_errors);
+    RUN_TEST(wait_message_qos2_null_msg_cb_errors_no_ack);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(wait_message_v5_props_null_msg_cb_frees_props);
+#endif
+    RUN_TEST(wait_message_qos1_with_msg_cb_delivers_and_acks);
 
 #ifndef WOLFMQTT_NO_ERROR_STRINGS
     /* MqttClient_ReturnCodeToString tests */

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -459,6 +459,85 @@ static int mock_net_read_canned(void *context, byte* buf, int buf_len,
     return n;
 }
 
+/* A broker that accepts the connection returns a CONNACK whose return code is
+ * MQTT_CONNECT_ACK_CODE_ACCEPTED (0). MqttClient_Connect must surface this as
+ * MQTT_CODE_SUCCESS. Paired with the refusal test below so a boundary mutation
+ * of the return-code check cannot pass both cases. */
+TEST(connect_accepted_connack_returns_success)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v3.1.1: type=0x20, remain=2, flags=0x00, return_code=0x00. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_ACCEPTED, connect.ack.return_code);
+}
+
+/* A broker that refuses the connection returns a CONNACK whose return code is
+ * non-zero (0x05 = not authorized here). MqttClient_Connect must surface this
+ * as MQTT_CODE_ERROR_CONNECT_REFUSED rather than MQTT_CODE_SUCCESS, else an
+ * application using the connect result as its authentication gate would treat a
+ * rejected login as a live session. This pins detection that previously had no
+ * round-trip test. */
+TEST(connect_refused_connack_returns_connect_refused)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v3.1.1: type=0x20, remain=2, flags=0x00, return_code=0x05
+     * (not authorized). */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x05 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_CONNECT_REFUSED, rc);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_REFUSED_NOT_AUTH, connect.ack.return_code);
+}
+
 /* A broker that rejects a subscription returns a SUBACK whose
  * per-topic return code has the high bit set (0x80 in v3.1.1, any reason
  * code >= 0x80 in v5). MqttClient_Subscribe must surface this as
@@ -1617,6 +1696,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_both_null);
     RUN_TEST(connect_with_mock_network);
     RUN_TEST(connect_clears_tx_buf_credentials);
+    RUN_TEST(connect_accepted_connack_returns_success);
+    RUN_TEST(connect_refused_connack_returns_connect_refused);
 
     /* MqttClient_Disconnect tests */
     RUN_TEST(disconnect_null_client);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -298,6 +298,10 @@ TEST(connect_with_mock_network)
 static int connect_mock_xfer;
 static byte connect_mock_sent[TEST_TX_BUF_SIZE];
 
+/* Set when a PUBREL (fixed header type 6) is written, so tests can assert the
+ * QoS 2 handshake either did or did not emit one. */
+static int g_pubrel_written;
+
 static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
     int timeout_ms)
 {
@@ -306,6 +310,10 @@ static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
         buf_len <= (int)sizeof(connect_mock_sent)) {
         XMEMCPY(connect_mock_sent, buf, (size_t)buf_len);
         connect_mock_xfer = buf_len;
+    }
+    if (buf != NULL && buf_len > 0 &&
+        (buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_REL << 4)) {
+        g_pubrel_written = 1;
     }
     /* Pretend the full packet was sent so MqttClient_Connect reaches the
      * CLIENT_FORCE_ZERO step. */
@@ -634,6 +642,313 @@ TEST(publish_null_publish)
     ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
 }
 
+#ifdef WOLFMQTT_V5
+/* Drives one QoS>0 publish to completion against the canned-response mock and
+ * returns the final MqttClient_Publish result. The caller stages the broker's
+ * PUBACK/PUBCOMP (plus any intermediate PUBREC for QoS 2) in g_canned_buf. */
+static int run_publish_with_canned_resp(MqttPublish* publish,
+    const byte* resp, int resp_len, byte proto_level)
+{
+    int rc;
+    int i;
+
+    rc = test_init_client();
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+    test_client.protocol_level = proto_level;
+
+    g_pubrel_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, resp, (size_t)resp_len);
+    g_canned_len = resp_len;
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, publish);
+    }
+    return rc;
+}
+
+/* A v5 broker can ACK a QoS 1 PUBLISH at the protocol layer yet still reject
+ * the message with a PUBACK reason code >= 0x80 (ACL deny, quota, invalid
+ * topic/payload). MqttClient_Publish must surface that as
+ * MQTT_CODE_ERROR_PUBLISH_REJECTED rather than MQTT_CODE_SUCCESS, else the
+ * application proceeds as if the message was delivered. This pins the
+ * detection that the publish path previously lacked (known issue 3626). */
+TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBACK: type=0x40, remain=3, packet_id=7, reason=0x87 NOT_AUTHORIZED */
+    static const byte puback[] = { 0x40, 0x03, 0x00, 0x07, 0x87 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 7;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, puback, (int)sizeof(puback),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+    ASSERT_EQ(MQTT_REASON_NOT_AUTHORIZED, publish.resp.reason_code);
+}
+
+/* A v5 PUBACK with reason code Success (0x00) means the broker accepted the
+ * message; MqttClient_Publish must still return success and not false-trip the
+ * new rejection check. */
+TEST(publish_qos1_v5_success_returns_success)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBACK: type=0x40, remain=3, packet_id=8, reason=0x00 Success */
+    static const byte puback[] = { 0x40, 0x03, 0x00, 0x08, 0x00 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 8;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, puback, (int)sizeof(puback),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
+}
+
+/* Not every non-zero v5 reason code is a rejection: the high bit distinguishes
+ * error (>= 0x80) from success-class codes. A broker legitimately returns
+ * 0x10 No matching subscribers for a QoS 1 PUBLISH that matched no
+ * subscriptions, and the message WAS accepted. The check uses
+ * (reason_code & 0x80) precisely so 0x10 stays a success; this pins that
+ * boundary against a regression to e.g. (reason_code != 0). */
+TEST(publish_qos1_v5_no_matching_subscribers_returns_success)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBACK: type=0x40, remain=3, packet_id=12, reason=0x10 No match sub */
+    static const byte puback[] = { 0x40, 0x03, 0x00, 0x0C, 0x10 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 12;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, puback, (int)sizeof(puback),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_REASON_NO_MATCH_SUB, publish.resp.reason_code);
+}
+
+/* QoS 2 completes the PUBLISH -> PUBREC -> PUBREL -> PUBCOMP handshake. A v5
+ * broker can reject at the PUBCOMP with a reason code >= 0x80 (e.g. 0x92
+ * Packet Identifier not found); MqttClient_Publish must surface that as
+ * MQTT_CODE_ERROR_PUBLISH_REJECTED. The mock serves a success PUBREC followed
+ * by the failing PUBCOMP, and accepts the client's PUBREL. */
+TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* PUBREC (success, no reason byte): type=0x50, remain=2, packet_id=9.
+     * PUBCOMP (reject): type=0x70, remain=3, packet_id=9, reason=0x92. */
+    static const byte resp[] = {
+        0x50, 0x02, 0x00, 0x09,
+        0x70, 0x03, 0x00, 0x09, 0x92
+    };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 9;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, resp, (int)sizeof(resp),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+    ASSERT_EQ(MQTT_REASON_PACKET_ID_NOT_FOUND, publish.resp.reason_code);
+    /* The PUBREC succeeded, so the handshake must have advanced to PUBREL
+     * before the PUBCOMP rejection arrived. */
+    ASSERT_TRUE(g_pubrel_written);
+}
+
+/* QoS 2 full happy path: success PUBREC -> PUBREL -> success PUBCOMP must
+ * return MQTT_CODE_SUCCESS. The post-wait rejection check now runs for every
+ * v5 QoS 2 publish, so this pins that a terminal success PUBCOMP is not
+ * false-tripped and that the handshake emits a PUBREL. */
+TEST(publish_qos2_v5_success_returns_success)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* PUBREC success (no reason byte): type=0x50, remain=2, packet_id=14.
+     * PUBCOMP success (no reason byte): type=0x70, remain=2, packet_id=14. */
+    static const byte resp[] = {
+        0x50, 0x02, 0x00, 0x0E,
+        0x70, 0x02, 0x00, 0x0E
+    };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 14;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, resp, (int)sizeof(resp),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
+    ASSERT_TRUE(g_pubrel_written);
+}
+
+/* The primary QoS 2 rejection point is the PUBREC: a v5 broker reports
+ * authorization/quota/topic/payload failures there with a reason code >= 0x80.
+ * Per [MQTT-4.3.3] the sender must not send PUBREL and the exchange is
+ * complete, so MqttClient_Publish must return MQTT_CODE_ERROR_PUBLISH_REJECTED
+ * directly from the PUBREC rather than emitting an illegal PUBREL and blocking
+ * for a PUBCOMP that never arrives. The mock serves only the failing PUBREC. */
+TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBREC: type=0x50, remain=3, packet_id=11, reason=0x87 NOT_AUTHORIZED */
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x0B, 0x87 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 11;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, pubrec, (int)sizeof(pubrec),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+    ASSERT_EQ(MQTT_REASON_NOT_AUTHORIZED, publish.resp.reason_code);
+    /* Per [MQTT-4.3.3] a PUBREC reason code >= 0x80 ends the exchange: the
+     * client must NOT emit a PUBREL. Directly pin that no PUBREL was written. */
+    ASSERT_FALSE(g_pubrel_written);
+}
+
+/* A v3.1.1 PUBACK carries no reason code, so the rejection check must not run
+ * for protocol level < 5. Pre-seed resp.reason_code with a failure byte to
+ * prove the protocol_level guard prevents a stale value from being misread as
+ * a broker rejection. */
+TEST(publish_v311_ack_not_misread_as_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v3.1.1 PUBACK: type=0x40, remain=2, packet_id=10 (no reason code). */
+    static const byte puback[] = { 0x40, 0x02, 0x00, 0x0A };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 10;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+    /* Stale failure byte that must be ignored for a v3.1.1 ACK. */
+    publish.resp.reason_code = MQTT_REASON_NOT_AUTHORIZED;
+
+    rc = run_publish_with_canned_resp(&publish, puback, (int)sizeof(puback),
+        MQTT_CONNECT_PROTOCOL_LEVEL_4);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+/* Pins the documented WOLFMQTT_MULTITHREAD divergence for a QoS 2 PUBREC
+ * rejection. A write-only publish registers a pending response for the PUBCOMP
+ * and returns without reading; a separate "reading thread" (simulated here by
+ * MqttClient_WaitMessage) then processes the rejecting PUBREC. Expected, per
+ * the code comment in MqttClient_HandlePacket and the ChangeLog:
+ *   - the reading thread receives MQTT_CODE_ERROR_PUBLISH_REJECTED directly;
+ *   - no PUBREL is emitted ([MQTT-4.3.3]);
+ *   - the PUBREC reason code is decoded into the shared client->msg object, not
+ *     the publisher's MqttPublish, because RespList_Find matches PUBREC against
+ *     the PUBCOMP-keyed pendResp and finds nothing — so the publisher's
+ *     publish.resp is left untouched and it must rely on the reader to observe
+ *     the rejection. This test locks that behavior so a future change can't
+ *     silently alter it. */
+TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
+{
+    int rc;
+    int i;
+    /* static so the registered pendResp does not point into freed stack after
+     * the call returns (the client is zeroed by setup() before the next test;
+     * MqttClient_DeInit does not walk the pending-response list). */
+    static MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBREC: type=0x50, remain=3, packet_id=13, reason=0x87 NOT_AUTHORIZED */
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x0D, 0x87 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    g_pubrel_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+
+    /* Write-only QoS 2 publish: sends PUBLISH, registers the PUBCOMP pending
+     * response, returns CONTINUE without reading (response is another thread's
+     * job). */
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 13;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
+
+    /* Reading thread processes the rejecting PUBREC. */
+    XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
+    g_canned_len = (int)sizeof(pubrec);
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+    ASSERT_FALSE(g_pubrel_written);
+    /* The publisher's own struct is NOT updated on this path. */
+    ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
+}
+#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
+#endif /* WOLFMQTT_V5 */
+
 /* Regression test for MQTT Packet Identifier in-use collision check. The
  * MQTT spec (3.1.1 section 2.3.1, 5.0 section 2.2.1) requires that a new QoS-related
  * Control Packet use a Packet Identifier that is not currently in use;
@@ -906,6 +1221,18 @@ void run_mqtt_client_tests(void)
     /* MqttClient_Publish tests */
     RUN_TEST(publish_null_client);
     RUN_TEST(publish_null_publish);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected);
+    RUN_TEST(publish_qos1_v5_success_returns_success);
+    RUN_TEST(publish_qos1_v5_no_matching_subscribers_returns_success);
+    RUN_TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected);
+    RUN_TEST(publish_qos2_v5_success_returns_success);
+    RUN_TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected);
+    RUN_TEST(publish_v311_ack_not_misread_as_rejected);
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+    RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
+#endif
+#endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
     RUN_TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id);
     RUN_TEST(subscribe_in_flight_blocks_publish_with_same_packet_id);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -538,6 +538,153 @@ TEST(connect_refused_connack_returns_connect_refused)
     ASSERT_EQ(MQTT_CONNECT_ACK_CODE_REFUSED_NOT_AUTH, connect.ack.return_code);
 }
 
+#if defined(WOLFMQTT_V5)
+/* MQTT v5: an accepted CONNACK (return code 0) that advertises server
+ * properties must latch them into long-lived client state so the publish and
+ * packet-size guards stay meaningful without a registered property callback.
+ * Feeds Maximum QoS=1, Retain Available=0 and Maximum Packet Size=1024 and
+ * asserts each field was updated. Paired with the refusal test below so the
+ * accept-only gate that guards this mutation is exercised from both sides. */
+TEST(connect_accepted_connack_latches_v5_props)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v5: type=0x20, remain=0x0C, flags=0x00, return_code=0x00,
+     * prop_len=0x09, [0x24 0x01]=Max QoS 1, [0x25 0x00]=Retain Avail 0,
+     * [0x27 00 00 04 00]=Max Packet Size 1024. */
+    static const byte connack[] = {
+        0x20, 0x0C, 0x00, 0x00, 0x09,
+        0x24, 0x01,
+        0x25, 0x00,
+        0x27, 0x00, 0x00, 0x04, 0x00
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_ACCEPTED, connect.ack.return_code);
+    /* Advertised Max QoS 1 is narrowed against this build's WOLFMQTT_MAX_QOS,
+     * so a QoS-capped (WOLFMQTT_MAX_QOS=0) build latches 0 rather than 1. */
+    ASSERT_EQ((WOLFMQTT_MAX_QOS < MQTT_QOS_1) ? (byte)WOLFMQTT_MAX_QOS :
+              MQTT_QOS_1, test_client.max_qos);
+    ASSERT_EQ(0, test_client.retain_avail);
+    ASSERT_EQ(1024, test_client.packet_sz_max);
+}
+
+/* MQTT v5: a refused CONNACK (non-zero return code) must NOT mutate long-lived
+ * client state even when it carries server properties, otherwise a rejected or
+ * malicious broker could shrink the client's packet-size cap or lower its QoS
+ * ceiling and have those corrupted limits persist onto a later reconnect on the
+ * same client struct. Feeds the same properties as the acceptance test but with
+ * a not-authorized return code and asserts every field keeps its pre-CONNACK
+ * default. Deleting the accept-only gate, or flipping its equality test, would
+ * latch these values and fail this test. */
+TEST(connect_refused_connack_preserves_v5_defaults)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* Same properties as the acceptance test, but return_code=0x05
+     * (not authorized). */
+    static const byte connack[] = {
+        0x20, 0x0C, 0x00, 0x05, 0x09,
+        0x24, 0x01,
+        0x25, 0x00,
+        0x27, 0x00, 0x00, 0x04, 0x00
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_CONNECT_REFUSED, rc);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_REFUSED_NOT_AUTH, connect.ack.return_code);
+    /* Pre-CONNACK defaults established by MqttClient_Connect must be intact. */
+    ASSERT_EQ((byte)WOLFMQTT_MAX_QOS, test_client.max_qos);
+    ASSERT_EQ(1, test_client.retain_avail);
+    ASSERT_EQ(0, test_client.packet_sz_max);
+}
+
+/* MQTT v5 [3.1.2.11.6]: only Max QoS 0 or 1 are legal. A non-conforming or
+ * malicious broker that advertises a larger value (2 here) must be clamped to
+ * MQTT_QOS_1 before being narrowed against this build's WOLFMQTT_MAX_QOS, so the
+ * client-side publish guard cannot be tricked into permitting QoS 2. Exercises
+ * the clamp branch that the in-spec acceptance test above does not reach. */
+TEST(connect_accepted_connack_clamps_illegal_max_qos)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v5 with an out-of-spec Max QoS of 2: type=0x20, remain=0x05,
+     * flags=0x00, return_code=0x00, prop_len=0x02, [0x24 0x02]=Max QoS 2. */
+    static const byte connack[] = {
+        0x20, 0x05, 0x00, 0x00, 0x02,
+        0x24, 0x02
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_ACCEPTED, connect.ack.return_code);
+    /* Illegal QoS 2 is clamped to 1, then narrowed against WOLFMQTT_MAX_QOS. */
+    ASSERT_EQ((WOLFMQTT_MAX_QOS < MQTT_QOS_1) ? (byte)WOLFMQTT_MAX_QOS :
+              MQTT_QOS_1, test_client.max_qos);
+}
+#endif /* WOLFMQTT_V5 */
+
 /* A broker that rejects a subscription returns a SUBACK whose
  * per-topic return code has the high bit set (0x80 in v3.1.1, any reason
  * code >= 0x80 in v5). MqttClient_Subscribe must surface this as
@@ -1698,6 +1845,11 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_clears_tx_buf_credentials);
     RUN_TEST(connect_accepted_connack_returns_success);
     RUN_TEST(connect_refused_connack_returns_connect_refused);
+#if defined(WOLFMQTT_V5)
+    RUN_TEST(connect_accepted_connack_latches_v5_props);
+    RUN_TEST(connect_refused_connack_preserves_v5_defaults);
+    RUN_TEST(connect_accepted_connack_clamps_illegal_max_qos);
+#endif
 
     /* MqttClient_Disconnect tests */
     RUN_TEST(disconnect_null_client);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -318,6 +318,11 @@ static int g_last_ack_written;
  * the 4..7 range that g_last_ack_written tracks. */
 static int g_frames_written;
 
+/* Packet id carried by the most recent PUBLISH-response frame written to the
+ * wire. For a v3.1.1 ack the two-byte id sits right after the fixed header, so a
+ * test can confirm the client echoed the id of the PUBLISH it is acknowledging. */
+static int g_last_ack_id;
+
 static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
     int timeout_ms)
 {
@@ -349,6 +354,9 @@ static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
             ack_type == MQTT_PACKET_TYPE_PUBLISH_REL ||
             ack_type == MQTT_PACKET_TYPE_PUBLISH_COMP) {
             g_last_ack_written = ack_type;
+            if (buf_len >= 4) {
+                g_last_ack_id = (buf[2] << 8) | buf[3];
+            }
         }
     }
     /* Pretend the full packet was sent so MqttClient_Connect reaches the
@@ -1337,6 +1345,113 @@ TEST(wait_message_qos1_with_msg_cb_delivers_and_acks)
     ASSERT_TRUE(g_pubresp_written);
 }
 
+/* Stage `frame` as a server-pushed PUBLISH and drive MqttClient_WaitMessage
+ * with a real msg_cb registered, so the message is delivered and the QoS
+ * acknowledgement (if any) reaches the wire. The shared run_wait_message_with_
+ * frame helper leaves msg_cb NULL, which now short-circuits with an error before
+ * the ack selector runs, so it cannot observe which ack a received PUBLISH
+ * produces; this variant can. Returns the terminal result. */
+static int run_wait_publish_delivered(const byte* frame, int frame_len)
+{
+    int rc;
+    int i;
+
+    rc = test_init_client();
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+#ifdef WOLFMQTT_V5
+    /* Decode the v3.1.1-format frames below without expecting v5 properties. */
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    test_client.msg_cb = test_accept_message_cb;
+    g_msg_cb_calls = 0;
+
+    g_pubresp_written = 0;
+    g_last_ack_written = MQTT_PACKET_TYPE_RESERVED;
+    g_last_ack_id = 0;
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, frame, (size_t)frame_len);
+    g_canned_len = frame_len;
+    g_canned_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+    return rc;
+}
+
+/* An incoming PUBLISH is acknowledged, and with which packet type, purely by its
+ * QoS. MqttClient_HandlePacket decides this in two steps: it short-circuits with
+ * `if (packet_qos == MQTT_QOS_0) break;` before any ack, then selects the ack
+ * type with `resp->packet_type = (packet_qos == MQTT_QOS_1) ? PUBACK : PUBREC`.
+ * The three tests below pin one QoS each and assert the exact ack the client put
+ * on the wire. The mutations they catch:
+ *   - `== MQTT_QOS_0` -> `!= MQTT_QOS_0`: a QoS 1/2 PUBLISH takes the no-ack
+ *     break and is never acknowledged (caught by the QoS 1 and QoS 2 cases),
+ *     while a QoS 0 PUBLISH falls through to emit a spurious PUBREC (caught by
+ *     the QoS 0 case).
+ *   - `== MQTT_QOS_1` -> `== MQTT_QOS_2`: a QoS 1 PUBLISH is acknowledged with a
+ *     PUBREC, breaking the QoS 1 handshake (caught by the QoS 1 case).
+ *   - Swapping the selector branches: QoS 1 emits PUBREC and QoS 2 emits PUBACK
+ *     (caught by both the QoS 1 and QoS 2 cases).
+ * The QoS 1 positive control above only checks g_pubresp_written, which both
+ * PUBACK and PUBREC set, so it cannot tell the two ack types apart; these read
+ * back the exact type and the echoed packet id. */
+TEST(wait_message_qos0_publish_no_ack)
+{
+    int rc;
+    /* v3.1.1 QoS0 PUBLISH: type=0x30, remain=5, topic "a" (0x0001 'a'),
+     * payload "hi" (no packet id for QoS 0). */
+    static const byte publish_qos0[] = { 0x30, 0x05, 0x00, 0x01, 'a', 'h', 'i' };
+
+    rc = run_wait_publish_delivered(publish_qos0, (int)sizeof(publish_qos0));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_TRUE(g_msg_cb_calls > 0);
+    /* QoS 0 carries no acknowledgement. Nothing of any type may reach the
+     * wire; inverting the QoS 0 guard would emit a spurious PUBREC here. */
+    ASSERT_EQ(MQTT_PACKET_TYPE_RESERVED, g_last_ack_written);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+TEST(wait_message_qos1_publish_acks_puback)
+{
+    int rc;
+    /* v3.1.1 QoS1 PUBLISH: type|qos1=0x32, remain=7, topic "a" (0x0001 'a'),
+     * packet_id=7 (0x0007), payload "hi". */
+    static const byte publish_qos1[] = { 0x32, 0x07, 0x00, 0x01, 'a',
+                                         0x00, 0x07, 'h', 'i' };
+
+    rc = run_wait_publish_delivered(publish_qos1, (int)sizeof(publish_qos1));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_TRUE(g_msg_cb_calls > 0);
+    /* QoS 1 completes in one step: a PUBACK echoing the PUBLISH packet id. */
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_ACK, g_last_ack_written);
+    ASSERT_EQ(7, g_last_ack_id);
+}
+
+TEST(wait_message_qos2_publish_acks_pubrec)
+{
+    int rc;
+    /* v3.1.1 QoS2 PUBLISH: type|qos2=0x34, remain=7, topic "a" (0x0001 'a'),
+     * packet_id=9 (0x0009), payload "hi". */
+    static const byte publish_qos2[] = { 0x34, 0x07, 0x00, 0x01, 'a',
+                                         0x00, 0x09, 'h', 'i' };
+
+    rc = run_wait_publish_delivered(publish_qos2, (int)sizeof(publish_qos2));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_TRUE(g_msg_cb_calls > 0);
+    /* QoS 2 opens the handshake with a PUBREC echoing the PUBLISH packet id. */
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_REC, g_last_ack_written);
+    ASSERT_EQ(9, g_last_ack_id);
+}
+
 /* The four PUBLISH-response packet types (PUBACK 4, PUBREC 5, PUBREL 6,
  * PUBCOMP 7) all decode through the same branch of MqttClient_HandlePacket, but
  * only PUBREC and PUBREL may advance the QoS handshake. The branch gates this
@@ -1554,6 +1669,9 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_v5_props_null_msg_cb_frees_props);
 #endif
     RUN_TEST(wait_message_qos1_with_msg_cb_delivers_and_acks);
+    RUN_TEST(wait_message_qos0_publish_no_ack);
+    RUN_TEST(wait_message_qos1_publish_acks_puback);
+    RUN_TEST(wait_message_qos2_publish_acks_pubrec);
     RUN_TEST(wait_message_pubrec_emits_pubrel);
     RUN_TEST(wait_message_pubrel_emits_pubcomp);
     RUN_TEST(wait_message_puback_emits_no_ack);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -306,23 +306,50 @@ static int g_pubrel_written;
  * that an incoming QoS>0 PUBLISH was (or was not) acknowledged to the broker. */
 static int g_pubresp_written;
 
+/* Records the fixed-header packet type (4..7) of the most recent PUBLISH
+ * response frame written to the wire, or MQTT_PACKET_TYPE_RESERVED when none was
+ * written. Lets a test assert exactly which QoS acknowledgement (if any)
+ * MqttClient_HandlePacket emitted for an incoming PUBLISH response. */
+static int g_last_ack_written;
+
+/* Counts every frame the client writes to the wire, of any type. A "no ack"
+ * test asserts this stayed zero, which is stronger than only checking that no
+ * known ack type was recorded: it also catches a frame whose type falls outside
+ * the 4..7 range that g_last_ack_written tracks. */
+static int g_frames_written;
+
 static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
     int timeout_ms)
 {
+    byte ack_type;
     (void)context; (void)timeout_ms;
-    if (buf != NULL && buf_len > 0 &&
-        buf_len <= (int)sizeof(connect_mock_sent)) {
-        XMEMCPY(connect_mock_sent, buf, (size_t)buf_len);
-        connect_mock_xfer = buf_len;
-    }
-    if (buf != NULL && buf_len > 0 &&
-        (buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_REL << 4)) {
-        g_pubrel_written = 1;
-    }
-    if (buf != NULL && buf_len > 0 &&
-        ((buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_ACK << 4) ||
-         (buf[0] & 0xF0) == (MQTT_PACKET_TYPE_PUBLISH_REC << 4))) {
-        g_pubresp_written = 1;
+    if (buf != NULL && buf_len > 0) {
+        ack_type = (byte)((buf[0] & 0xF0) >> 4);
+
+        if (buf_len <= (int)sizeof(connect_mock_sent)) {
+            XMEMCPY(connect_mock_sent, buf, (size_t)buf_len);
+            connect_mock_xfer = buf_len;
+        }
+
+        /* Count the frame regardless of type. */
+        g_frames_written++;
+
+        if (ack_type == MQTT_PACKET_TYPE_PUBLISH_REL) {
+            g_pubrel_written = 1;
+        }
+        if (ack_type == MQTT_PACKET_TYPE_PUBLISH_ACK ||
+            ack_type == MQTT_PACKET_TYPE_PUBLISH_REC) {
+            g_pubresp_written = 1;
+        }
+        /* Record which QoS acknowledgement reached the wire. The PUBREC/PUBREL
+         * filter in MqttClient_HandlePacket decides this, so a test can read
+         * back the exact ack type and catch a spurious or wrong-type frame. */
+        if (ack_type == MQTT_PACKET_TYPE_PUBLISH_ACK ||
+            ack_type == MQTT_PACKET_TYPE_PUBLISH_REC ||
+            ack_type == MQTT_PACKET_TYPE_PUBLISH_REL ||
+            ack_type == MQTT_PACKET_TYPE_PUBLISH_COMP) {
+            g_last_ack_written = ack_type;
+        }
     }
     /* Pretend the full packet was sent so MqttClient_Connect reaches the
      * CLIENT_FORCE_ZERO step. */
@@ -1135,6 +1162,8 @@ static int run_wait_message_with_frame(const byte* frame, int frame_len)
 #endif
 
     g_pubresp_written = 0;
+    g_last_ack_written = MQTT_PACKET_TYPE_RESERVED;
+    g_frames_written = 0;
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_canned;
     XMEMCPY(g_canned_buf, frame, (size_t)frame_len);
@@ -1308,6 +1337,84 @@ TEST(wait_message_qos1_with_msg_cb_delivers_and_acks)
     ASSERT_TRUE(g_pubresp_written);
 }
 
+/* The four PUBLISH-response packet types (PUBACK 4, PUBREC 5, PUBREL 6,
+ * PUBCOMP 7) all decode through the same branch of MqttClient_HandlePacket, but
+ * only PUBREC and PUBREL may advance the QoS handshake. The branch gates this
+ * with `if (type != PUBREC && type != PUBREL) break;` before the
+ * `resp->packet_type = type + 1` next-ack arithmetic, so an incoming:
+ *   - PUBREC  (5) must emit a PUBREL  (6),
+ *   - PUBREL  (6) must emit a PUBCOMP (7),
+ *   - PUBACK  (4) must emit nothing (a QoS 1 transaction is already complete;
+ *     advancing would put a spurious PUBREC on the wire), and
+ *   - PUBCOMP (7) must emit nothing (a QoS 2 transaction is complete).
+ * Each test drives one response type through MqttClient_WaitMessage and checks
+ * the exact ack the client wrote. The mutations these catch:
+ *   - Deleting the filter is caught by the PUBACK case: type 4 then advances to
+ *     type 5 PUBREC, a valid pub-resp frame, which is written to the wire.
+ *   - Widening the filter (&& -> ||, or == in place of one !=) is caught by the
+ *     PUBREC and PUBREL cases: the handshake stops advancing and no PUBREL or
+ *     PUBCOMP is emitted.
+ * The PUBCOMP case cannot detect filter deletion on its own: a deleted filter
+ * computes type 8 SUBSCRIBE, which the MqttIsPubRespPacket gate in
+ * MqttClient_WaitType (src/mqtt_client.c) refuses to write, so nothing reaches
+ * the wire either way. It still pins the correct terminal no-ack behavior and,
+ * via g_frames_written, would catch any change that turned a PUBCOMP into an
+ * outbound frame. The shared helper forces protocol level 4 so these v3.1.1
+ * frames carry no reason code or properties. */
+TEST(wait_message_pubrec_emits_pubrel)
+{
+    int rc;
+    /* PUBREC v3.1.1: type=0x50, remain=2, packet_id=5. */
+    static const byte pubrec[] = { 0x50, 0x02, 0x00, 0x05 };
+
+    rc = run_wait_message_with_frame(pubrec, (int)sizeof(pubrec));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_REL, g_last_ack_written);
+}
+
+TEST(wait_message_pubrel_emits_pubcomp)
+{
+    int rc;
+    /* PUBREL v3.1.1: type=0x62 (reserved flags 0x2 are required for PUBREL),
+     * remain=2, packet_id=6. */
+    static const byte pubrel[] = { 0x62, 0x02, 0x00, 0x06 };
+
+    rc = run_wait_message_with_frame(pubrel, (int)sizeof(pubrel));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_COMP, g_last_ack_written);
+}
+
+TEST(wait_message_puback_emits_no_ack)
+{
+    int rc;
+    /* PUBACK v3.1.1: type=0x40, remain=2, packet_id=4. */
+    static const byte puback[] = { 0x40, 0x02, 0x00, 0x04 };
+
+    rc = run_wait_message_with_frame(puback, (int)sizeof(puback));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_PACKET_TYPE_RESERVED, g_last_ack_written);
+    /* Nothing of any type may reach the wire. Pre-fix (filter deleted) a
+     * spurious PUBREC was emitted here. */
+    ASSERT_EQ(0, g_frames_written);
+}
+
+TEST(wait_message_pubcomp_emits_no_ack)
+{
+    int rc;
+    /* PUBCOMP v3.1.1: type=0x70, remain=2, packet_id=7. */
+    static const byte pubcomp[] = { 0x70, 0x02, 0x00, 0x07 };
+
+    rc = run_wait_message_with_frame(pubcomp, (int)sizeof(pubcomp));
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_PACKET_TYPE_RESERVED, g_last_ack_written);
+    /* A completed QoS 2 transaction emits no further frame of any type. */
+    ASSERT_EQ(0, g_frames_written);
+}
+
 /* ============================================================================
  * MqttClient_ReturnCodeToString Tests
  * ============================================================================ */
@@ -1447,6 +1554,10 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_v5_props_null_msg_cb_frees_props);
 #endif
     RUN_TEST(wait_message_qos1_with_msg_cb_delivers_and_acks);
+    RUN_TEST(wait_message_pubrec_emits_pubrel);
+    RUN_TEST(wait_message_pubrel_emits_pubcomp);
+    RUN_TEST(wait_message_puback_emits_no_ack);
+    RUN_TEST(wait_message_pubcomp_emits_no_ack);
 
 #ifndef WOLFMQTT_NO_ERROR_STRINGS
     /* MqttClient_ReturnCodeToString tests */

--- a/tests/test_mqtt_sn_client.c
+++ b/tests/test_mqtt_sn_client.c
@@ -254,6 +254,12 @@ static const byte PUBCOMP_FRAME[] = { 0x04, SN_MSG_TYPE_PUBCOMP,
 static const byte UNSUBACK_FRAME[] = { 0x04, SN_MSG_TYPE_UNSUBACK,
                                        0x00, SN_TEST_UNSUB_PACKET_ID };
 
+/* Server-pushed QoS1 PUBLISH: total_len=9, type, flags=QoS1|NORMAL (0x20),
+ * topicId=0x000A, packet_id=0x0007, payload(2). */
+static const byte SN_PUBLISH_QOS1_FRAME[] = { 0x09, SN_MSG_TYPE_PUBLISH,
+                                              0x20, 0x00, 0x0A,
+                                              0x00, 0x07, 0x01, 0x02 };
+
 /* ============================================================================
  * Test fixtures
  * ============================================================================ */
@@ -883,6 +889,37 @@ TEST(sn_unsubscribe_no_continue)
     ASSERT_NO_PENDRESP();
 }
 
+/* ============================================================================
+ * SN incoming-PUBLISH with no message callback (#6217)
+ *
+ * The SN test harness initializes the client with a NULL msg_cb. An SN client
+ * that receives a PUBLISH used to decode and discard it, return success, and
+ * (for QoS>0) send a PUBACK/PUBREC falsely confirming delivery to the gateway.
+ * SN_Client_HandlePacket now returns MQTT_CODE_ERROR_CALLBACK when no callback
+ * is registered, so the message is reported as undeliverable and not ACKed.
+ * Runs in every SN build (the fix is independent of NONBLOCK/MULTITHREAD).
+ * ============================================================================ */
+TEST(sn_publish_incoming_null_msg_cb_errors_no_ack)
+{
+    int rc, i;
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, sn_client_init(0 /* no CONTINUE */));
+
+    mock_net_push(&g_mock, SN_PUBLISH_QOS1_FRAME,
+            (int)sizeof(SN_PUBLISH_QOS1_FRAME));
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = SN_Client_WaitMessage(&g_client, 1000);
+    }
+
+    /* Pre-fix this returned MQTT_CODE_SUCCESS. */
+    ASSERT_EQ(MQTT_CODE_ERROR_CALLBACK, rc);
+    /* The gateway must NOT be told the QoS1 message was delivered: pre-fix a
+     * PUBACK was written here, falsely confirming a dropped message. */
+    ASSERT_EQ(0, g_mock.write_calls);
+}
+
 /* The non-blocking retry behavior is the actual regression and only applies
  * when WOLFMQTT_NONBLOCK is built (otherwise SN_Client_WaitType blocks and
  * never returns MQTT_CODE_CONTINUE). */
@@ -1395,6 +1432,7 @@ int main(int argc, char** argv)
     RUN_TEST(sn_publish_qos2_no_continue);
     RUN_TEST(sn_publish_qos0_no_pendresp);
     RUN_TEST(sn_unsubscribe_no_continue);
+    RUN_TEST(sn_publish_incoming_null_msg_cb_errors_no_ack);
     RUN_TEST(sn_ping_no_continue);
     RUN_TEST(sn_ping_null_no_continue);
 

--- a/tests/test_mqtt_sn_client.c
+++ b/tests/test_mqtt_sn_client.c
@@ -249,6 +249,11 @@ static const byte PUBREC_FRAME[]  = { 0x04, SN_MSG_TYPE_PUBREC,
 static const byte PUBCOMP_FRAME[] = { 0x04, SN_MSG_TYPE_PUBCOMP,
                                       0x00, SN_TEST_PUB_PACKET_ID };
 
+/* Scripted UNSUBACK echoing packet_id 1: total_len=4, type, packet_id(2). */
+#define SN_TEST_UNSUB_PACKET_ID 1
+static const byte UNSUBACK_FRAME[] = { 0x04, SN_MSG_TYPE_UNSUBACK,
+                                       0x00, SN_TEST_UNSUB_PACKET_ID };
+
 /* ============================================================================
  * Test fixtures
  * ============================================================================ */
@@ -384,6 +389,36 @@ static int sn_publish_pump(SN_Publish* p, int* iters)
     const int max_iters = 50;
     for (i = 0; i < max_iters; i++) {
         rc = SN_Client_Publish(&g_client, p);
+        if (rc != MQTT_CODE_CONTINUE) {
+            break;
+        }
+    }
+    if (iters) {
+        *iters = i + 1;
+    }
+    return rc;
+}
+
+static void sn_unsubscribe_setup(SN_Unsubscribe* u)
+{
+    XMEMSET(u, 0, sizeof(*u));
+    u->duplicate = 0;
+    u->qos = MQTT_QOS_0;
+    u->topic_type = SN_TOPIC_ID_TYPE_NORMAL;
+    u->topicNameId = "wolf/topic";
+    u->packet_id = SN_TEST_UNSUB_PACKET_ID;
+}
+
+/* Drive SN_Client_Unsubscribe until it returns something other than CONTINUE,
+ * or until we exceed a sane iteration cap. Returns the terminal code and the
+ * number of iterations through *iters. */
+static int sn_unsubscribe_pump(SN_Unsubscribe* u, int* iters)
+{
+    int rc = MQTT_CODE_CONTINUE;
+    int i;
+    const int max_iters = 50;
+    for (i = 0; i < max_iters; i++) {
+        rc = SN_Client_Unsubscribe(&g_client, u);
         if (rc != MQTT_CODE_CONTINUE) {
             break;
         }
@@ -808,6 +843,46 @@ TEST(sn_publish_qos0_no_pendresp)
     ASSERT_NO_PENDRESP();
 }
 
+/* ============================================================================
+ * SN unsubscribe pending-response lifecycle tests (#6047)
+ *
+ * SN_Client_Unsubscribe registers &unsubscribe->pendResp in
+ * client->firstPendResp (MULTITHREAD) so a reader thread can route the UNSUBACK
+ * back to the unsubscribing thread. The entry must be keyed by the real Packet
+ * Identifier: MqttClient_RespList_Find matches on (packet_type, packet_id), and
+ * an UNSUBACK echoes the MsgId that SN_Decode_UnsubscribeAck recovers as the
+ * non-zero packet_id. Pre-fix the entry was added with a hard-coded id of 0, so
+ * a reader thread's RespList_Find(UNSUBACK, real_id) never matched and the
+ * UNSUBACK was swallowed into the generic object, leaving the unsubscribing
+ * thread blocked until cmd_timeout_ms. The same-thread case was masked because
+ * SN_Client_WaitType also matches directly on wait_packet_id, so the
+ * cross-thread test below is the one that pins the fix.
+ * ============================================================================ */
+
+/* Happy path: UNSUBACK is immediately available and read by the unsubscribing
+ * call itself. Runs in every SN build and guards that the pending response is
+ * removed once the unsubscribe completes. */
+TEST(sn_unsubscribe_no_continue)
+{
+    SN_Unsubscribe unsub;
+    int rc;
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, sn_client_init(0 /* no CONTINUE */));
+
+    mock_net_push(&g_mock, UNSUBACK_FRAME, (int)sizeof(UNSUBACK_FRAME));
+
+    sn_unsubscribe_setup(&unsub);
+
+    rc = sn_unsubscribe_pump(&unsub, NULL);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(SN_TEST_UNSUB_PACKET_ID, unsub.ack.packet_id);
+    /* The client sent UNSUBSCRIBE. */
+    ASSERT_TRUE(g_mock.write_calls >= 1);
+    /* No pending response may be left dangling once unsubscribe completes. */
+    ASSERT_NO_PENDRESP();
+}
+
 /* The non-blocking retry behavior is the actual regression and only applies
  * when WOLFMQTT_NONBLOCK is built (otherwise SN_Client_WaitType blocks and
  * never returns MQTT_CODE_CONTINUE). */
@@ -1096,6 +1171,65 @@ TEST(sn_publish_qos1_many_continues)
     ASSERT_NO_PENDRESP();
 }
 
+/* #6047 headline regression: cross-thread UNSUBACK routing. The unsubscribing
+ * thread arms a pending response and returns in-flight (CONTINUE) before the
+ * UNSUBACK arrives, then a separate reader thread (modeled by
+ * SN_Client_WaitMessage) consumes it. The fix registers the pending response
+ * under the real packet_id, so the reader's RespList_Find(UNSUBACK, real_id)
+ * matches and routes the UNSUBACK back to the unsubscribing thread; pre-fix the
+ * entry was keyed by id 0, so the match failed and the unsubscribe never
+ * resolved. Needs MULTITHREAD (the respList routing and firstPendResp only exist
+ * there) on top of NONBLOCK (to interleave the reader between the unsubscribing
+ * thread's send and wait within a single test thread). */
+#ifdef WOLFMQTT_MULTITHREAD
+TEST(sn_unsubscribe_crossthread_unsuback_routing)
+{
+    SN_Unsubscribe unsub;
+    int rc, iters = 0;
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, sn_client_init(1 /* one CONTINUE per frame */));
+
+    mock_net_push(&g_mock, UNSUBACK_FRAME, (int)sizeof(UNSUBACK_FRAME));
+
+    sn_unsubscribe_setup(&unsub);
+
+    /* First call sends UNSUBSCRIBE and registers the pending UNSUBACK response.
+     * The armed CONTINUE forces an in-flight return before the UNSUBACK is read,
+     * so the unsubscribing thread leaves without consuming it. */
+    rc = SN_Client_Unsubscribe(&g_client, &unsub);
+    ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
+
+    /* The pending response must be keyed by the real packet_id so a reader
+     * thread can route the UNSUBACK to it. Pre-fix it was added under id 0. */
+    ASSERT_NOT_NULL(g_client.firstPendResp);
+    ASSERT_EQ(SN_TEST_UNSUB_PACKET_ID, g_client.firstPendResp->packet_id);
+
+    /* Model a separate reader thread (waitMessage_task) consuming the UNSUBACK
+     * via the generic wait path. With the fix the UNSUBACK is matched by type+id
+     * to the registered pending response, handled into the unsubscribing
+     * thread's ack object, and the entry is marked done; the read therefore
+     * belongs to another thread and returns CONTINUE here. Pre-fix the id-0
+     * entry never matched the real id, so the UNSUBACK was swallowed into the
+     * reader's generic object and the entry was left pending. */
+    rc = SN_Client_WaitMessage(&g_client, 1000);
+    ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
+
+    /* The unsubscribing thread resumes. With the fix CheckPendResp finds the
+     * entry already marked done and returns SUCCESS without another read.
+     * Pre-fix the entry is still pending (the UNSUBACK was swallowed), so this
+     * would spin on CONTINUE and never resolve. */
+    rc = sn_unsubscribe_pump(&unsub, &iters);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(SN_TEST_UNSUB_PACKET_ID, unsub.ack.packet_id);
+
+    /* The reader consumed the only UNSUBACK frame and no pending response is
+     * left dangling once the unsubscribe completes. */
+    ASSERT_EQ(g_mock.in_count, g_mock.in_idx);
+    ASSERT_NO_PENDRESP();
+}
+#endif /* WOLFMQTT_MULTITHREAD */
+
 #endif /* WOLFMQTT_NONBLOCK */
 
 /* ============================================================================
@@ -1260,6 +1394,7 @@ int main(int argc, char** argv)
     RUN_TEST(sn_publish_qos1_no_continue);
     RUN_TEST(sn_publish_qos2_no_continue);
     RUN_TEST(sn_publish_qos0_no_pendresp);
+    RUN_TEST(sn_unsubscribe_no_continue);
     RUN_TEST(sn_ping_no_continue);
     RUN_TEST(sn_ping_null_no_continue);
 
@@ -1275,6 +1410,9 @@ int main(int argc, char** argv)
     RUN_TEST(sn_subscribe_rejected_nonblock);
     RUN_TEST(sn_publish_qos1_nonblock_pendresp_lifecycle);
     RUN_TEST(sn_publish_qos1_many_continues);
+#ifdef WOLFMQTT_MULTITHREAD
+    RUN_TEST(sn_unsubscribe_crossthread_unsuback_routing);
+#endif
     RUN_TEST(sn_ping_null_nonblock_no_dangling_pendresp);
     RUN_TEST(sn_ping_nonblock_pendresp_lifecycle);
 #endif

--- a/tests/test_mqtt_sn_client.c
+++ b/tests/test_mqtt_sn_client.c
@@ -313,7 +313,10 @@ static int sn_connect_pump(SN_Connect* mc, int* iters)
         }
     }
     if (iters) {
-        *iters = i + 1;
+        /* On an early break i is the 0-based index of the terminating call, so
+         * the count is i + 1; if the cap was hit (rc still CONTINUE) exactly
+         * max_iters calls ran and i already equals that count. */
+        *iters = (rc == MQTT_CODE_CONTINUE) ? i : (i + 1);
     }
     return rc;
 }
@@ -343,7 +346,10 @@ static int sn_subscribe_pump(SN_Subscribe* s, int* iters)
         }
     }
     if (iters) {
-        *iters = i + 1;
+        /* On an early break i is the 0-based index of the terminating call, so
+         * the count is i + 1; if the cap was hit (rc still CONTINUE) exactly
+         * max_iters calls ran and i already equals that count. */
+        *iters = (rc == MQTT_CODE_CONTINUE) ? i : (i + 1);
     }
     return rc;
 }
@@ -363,7 +369,10 @@ static int sn_ping_pump(SN_PingReq* ping, int* iters)
         }
     }
     if (iters) {
-        *iters = i + 1;
+        /* On an early break i is the 0-based index of the terminating call, so
+         * the count is i + 1; if the cap was hit (rc still CONTINUE) exactly
+         * max_iters calls ran and i already equals that count. */
+        *iters = (rc == MQTT_CODE_CONTINUE) ? i : (i + 1);
     }
     return rc;
 }
@@ -400,7 +409,10 @@ static int sn_publish_pump(SN_Publish* p, int* iters)
         }
     }
     if (iters) {
-        *iters = i + 1;
+        /* On an early break i is the 0-based index of the terminating call, so
+         * the count is i + 1; if the cap was hit (rc still CONTINUE) exactly
+         * max_iters calls ran and i already equals that count. */
+        *iters = (rc == MQTT_CODE_CONTINUE) ? i : (i + 1);
     }
     return rc;
 }
@@ -430,7 +442,10 @@ static int sn_unsubscribe_pump(SN_Unsubscribe* u, int* iters)
         }
     }
     if (iters) {
-        *iters = i + 1;
+        /* On an early break i is the 0-based index of the terminating call, so
+         * the count is i + 1; if the cap was hit (rc still CONTINUE) exactly
+         * max_iters calls ran and i already equals that count. */
+        *iters = (rc == MQTT_CODE_CONTINUE) ? i : (i + 1);
     }
     return rc;
 }

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -653,6 +653,11 @@ typedef struct MqttBroker {
     int     running;
     byte    log_level;
 #ifdef WOLFMQTT_BROKER_AUTH
+    /* Broker authentication credentials. auth_user and auth_pass MUST be set
+     * together: configuring only one is rejected by MqttBroker_Start, since a
+     * partial config would check only the configured half and accept any value
+     * for the other (single-factor downgrade). Leave both NULL to disable
+     * authentication. */
     const char* auth_user;
     const char* auth_pass;
 #endif

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -198,6 +198,31 @@
     #define BROKER_MAX_OFFLINE_MSGS_PER_SUB 32
 #endif
 
+/* BROKER_MAX_QUEUED_MSGS_PER_SUB bounds the total depth of a *connected*
+ * subscriber's outbound queue (out_q_count) in dynamic-memory mode.
+ *
+ * BROKER_MAX_INFLIGHT_PER_SUB (above) only bounds how many QoS>0 PUBLISHes
+ * are on the wire awaiting an ack - i.e. bytes in flight. It does NOT bound
+ * how many entries may sit QUEUED behind the inflight window. A subscriber
+ * that stops sending PUBACK/PUBREC (a slow consumer, or an attacker keeping
+ * the session alive with PINGREQ) saturates the inflight window and then
+ * every subsequent matching PUBLISH still allocates a fresh BrokerOutPub plus
+ * heap copies of the topic and payload onto out_q. Without a depth cap that
+ * queue grows without limit until the broker exhausts memory.
+ *
+ * When a fan-out would exceed this depth the broker disconnects that
+ * subscriber (v5: DISCONNECT reason 0x97 Quota Exceeded) rather than growing
+ * the heap or silently dropping accepted QoS 1/2 messages; a persistent
+ * session is then reclaimable on reconnect via the (separately capped)
+ * offline queue. The default leaves room for a full inflight window plus an
+ * offline-sized backlog of not-yet-sent entries. Override with
+ *   -DBROKER_MAX_QUEUED_MSGS_PER_SUB=N
+ * Only used in dynamic-memory mode. */
+#ifndef BROKER_MAX_QUEUED_MSGS_PER_SUB
+    #define BROKER_MAX_QUEUED_MSGS_PER_SUB \
+        (BROKER_MAX_INFLIGHT_PER_SUB + BROKER_MAX_OFFLINE_MSGS_PER_SUB)
+#endif
+
 /* Schema version stamped on every persisted record. Bump when the
  * encoding of any namespace changes incompatibly; a startup with stored
  * records carrying a different version logs a warning, wipes all

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -360,11 +360,10 @@ WOLFMQTT_API int MqttClient_Publish_ex(
 /*! \brief      Same as MqttClient_Publish_ex, however this API will only
                 perform writes and requires another thread to handle the read
                 ACK processing using MqttClient_WaitMessage_ex
- *  \note       This function that will wait for MqttNet.read to complete,
-                timeout or MQTT_CODE_CONTINUE if non-blocking.
-                    If QoS level = 1 then will wait for PUBLISH_ACK.
-                    If QoS level = 2 then will wait for PUBLISH_REC then send
-                        PUBLISH_REL and wait for PUBLISH_COMP.
+ *  \note       This function does not wait for MqttNet.read or any ACK; it only
+                writes the PUBLISH (and, for QoS 2, the PUBREL once the reading
+                thread has processed the PUBREC). The reading thread handles all
+                ACK processing via MqttClient_WaitMessage_ex.
  *  \param      client      Pointer to MqttClient structure
  *  \param      publish     Pointer to MqttPublish structure initialized
                             with message data

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -317,7 +317,10 @@ WOLFMQTT_API int MqttClient_Connect(
                             with message data
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
- *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or
+ *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking),
+                MQTT_CODE_ERROR_PUBLISH_REJECTED if a v5 broker rejected a
+                QoS>0 PUBLISH via a PUBACK (QoS 1) or PUBREC/PUBCOMP (QoS 2)
+                reason code >= 0x80 (see MqttPublish.resp.reason_code), or
                 MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish_WriteOnly
     \sa         MqttClient_Publish_ex
@@ -341,8 +344,11 @@ WOLFMQTT_API int MqttClient_Publish(
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
 *   \param      pubCb       Function pointer to callback routine
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_PUBLISH_REJECTED if a v5 broker rejected a
+                QoS>0 PUBLISH via a PUBACK (QoS 1) or PUBREC/PUBCOMP (QoS 2)
+                reason code >= 0x80 (see MqttPublish.resp.reason_code), or
+                MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Publish_ex(
     MqttClient *client,
@@ -365,6 +371,14 @@ WOLFMQTT_API int MqttClient_Publish_ex(
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
  *  \param      pubCb       Function pointer to callback routine
+ *  \note       Because this call only writes and another thread processes the
+                ACK, it never returns MQTT_CODE_ERROR_PUBLISH_REJECTED. On the
+                reading thread only a QoS 2 PUBREC rejection is surfaced (as
+                MQTT_CODE_ERROR_PUBLISH_REJECTED, returned in order to suppress
+                an illegal PUBREL per [MQTT-4.3.3]); a QoS 1 PUBACK or QoS 2
+                PUBCOMP reason code >= 0x80 is NOT detected on this path and the
+                publish appears successful. Use MqttClient_Publish/_ex when
+                reliable v5 broker-rejection detection for QoS>0 is required.
  *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or
                 MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -344,7 +344,7 @@ WOLFMQTT_API int MqttClient_Publish(
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
 *   \param      pubCb       Function pointer to callback routine
- *  \return     MQTT_CODE_SUCCESS,
+ *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking),
                 MQTT_CODE_ERROR_PUBLISH_REJECTED if a v5 broker rejected a
                 QoS>0 PUBLISH via a PUBACK (QoS 1) or PUBREC/PUBCOMP (QoS 2)
                 reason code >= 0x80 (see MqttPublish.resp.reason_code), or

--- a/wolfmqtt/mqtt_types.h
+++ b/wolfmqtt/mqtt_types.h
@@ -215,6 +215,12 @@ enum MqttPacketResponseCodes {
                                                    topic filters in an
                                                    UNSUBSCRIBE; see each reason
                                                    code in MqttUnsubscribeAck. */
+    MQTT_CODE_ERROR_PUBLISH_REJECTED = -21, /* v5 broker rejected a QoS>0
+                                               PUBLISH via a PUBACK (QoS 1) or
+                                               PUBREC/PUBCOMP (QoS 2) reason
+                                               code >= 0x80; see
+                                               MqttPublish.resp.reason_code for
+                                               the specific reason. */
 
     MQTT_CODE_CONTINUE = -101,
     MQTT_CODE_STDIN_WAKE = -102,


### PR DESCRIPTION
* Fix f-3626: v5 MqttClient_Publish returns invalid success
* Fix f-6222: broker sub queue hardening
* Fix f-3393: Broker auth when only one of auth_user/auth_pass
* Fix f-6047: SN_Client_Unsubscribe
* Fix f-6217: NULL msg_cb silently discards incoming PUBLISH
* Fix f-3391: cover PUBREC/REL ack filter in MqttClient_HandlePacket
* Fix f-3392: tests for QoS ack selector in MqttClient_HandlePacket
* Fix f-6223: tests for MqttClient_Connect refused-CONNACK
* Fix f-6487: tests for refused-CONNACK v5 property gate