### PR TITLE
reject oversized websocket origin in callback_broker_mqtt

### DIFF
--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -1016,10 +1016,17 @@ static int callback_broker_mqtt(struct lws *wsi,
             char origin[256];
             int olen = lws_hdr_copy(wsi, origin, (int)sizeof(origin),
                 WSI_TOKEN_ORIGIN);
-            if (olen > 0 &&
-                    XSTRCMP(origin, broker->ws_allowed_origin) != 0) {
+            /* lws_hdr_copy returns <= 0 both when no Origin header is sent
+             * (native client, allowed) and when a present Origin is too long
+             * for the buffer. Deciding on olen alone lets an attacker-chosen
+             * Origin longer than the buffer be treated as absent and slip past
+             * the allowlist. Use the header's real length to tell the two
+             * apart and reject a present-but-unverifiable Origin. */
+            if (lws_hdr_total_length(wsi, WSI_TOKEN_ORIGIN) > 0 &&
+                    (olen <= 0 ||
+                     XSTRCMP(origin, broker->ws_allowed_origin) != 0)) {
                 WBLOG_ERR(broker, "broker: ws origin rejected: %s",
-                    BrokerLog_Sanitize(origin));
+                    BrokerLog_Sanitize(olen > 0 ? origin : "(oversized)"));
                 return -1;
             }
         }


### PR DESCRIPTION
**WebSocket Origin allowlist fails open on an oversized header**
When `ws_allowed_origin` is configured, a present Origin header longer than the 256-byte copy buffer makes `lws_hdr_copy` return <= 0, so the gate reads it as "no Origin" and lets the connection through, bypassing the CSWSH allowlist. A browser served from an attacker-controlled origin string over 255 bytes hits this path. Keyed the allow/deny on `lws_hdr_total_length` so a present-but-unverifiable Origin is rejected while a genuinely absent one still passes for native clients.