### PR TITLE
fix use-after-free on next_sub in broker fan-out loops

### DIFF
--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -2959,6 +2959,29 @@ static void BrokerSubs_Remove(MqttBroker* broker, BrokerClient* bc,
 #endif
 }
 
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* Confirm a fan-out loop's snapshotted successor is still linked in
+ * broker->subs. A peer-initiated WS LWS_CALLBACK_CLOSED delivered during a
+ * fan-out write runs BrokerSubs_RemoveClient, which frees every BrokerSub
+ * owned by the closing subscriber - and that can include the node a loop saved
+ * as next_sub. The pending_remove deferral keeps the BrokerClient struct alive
+ * across the spin, but the sub nodes are freed regardless, so snapshotting
+ * next_sub guards only against sub->next moving, not against next_sub itself
+ * being freed. Re-check it before the next dereference, mirroring the
+ * client-list revalidation in MqttBroker_Step. */
+static int BrokerSubs_StillLinked(MqttBroker* broker, const BrokerSub* node)
+{
+    BrokerSub* cur = broker->subs;
+    while (cur != NULL) {
+        if (cur == node) {
+            return 1;
+        }
+        cur = cur->next;
+    }
+    return 0;
+}
+#endif
+
 /* -------------------------------------------------------------------------- */
 /* Packet ID generation                                                        */
 /* -------------------------------------------------------------------------- */
@@ -4067,6 +4090,11 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
             }
         }
 #ifndef WOLFMQTT_STATIC_MEMORY
+        /* The write above can drive a re-entrant WS close that frees next_sub;
+         * stop the walk if it is gone. */
+        if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+            break;
+        }
         sub = next_sub;
 #endif
     }
@@ -5475,6 +5503,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                             pub.total_len, eff_qos, 0);
                     }
                 }
+            }
+            /* The fan-out write above can drive a re-entrant WS close that
+             * frees next_sub; stop the walk if it is gone. */
+            if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+                break;
             }
             sub = next_sub;
 #endif


### PR DESCRIPTION
Use-after-free in the two broker subscription fan-out loops when a WebSocket subscriber's peer closes during a fan-out write:
- BrokerHandle_Publish and BrokerClient_PublishWillImmediate snapshot next_sub, but the write to a WS subscriber spins lws_service and a re-entrant LWS_CALLBACK_CLOSED runs BrokerSubs_RemoveClient, freeing that subscriber's BrokerSub nodes
- pending_remove keeps the BrokerClient alive across the spin, but the sub nodes are freed regardless, so a subscriber with two adjacent matching filters has its snapshotted next_sub freed under the loop, then sub = next_sub dereferences it
- revalidate next_sub against broker->subs after the write, the same walk MqttBroker_Step already does for the client list
- static-memory builds use array indices and are unaffected