### PR TITLE
Coverity fixes

### DIFF
--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -172,11 +172,13 @@ static int NetRead(void *context, byte* buf, int buf_len,
         rc = MQTT_CODE_ERROR_NETWORK;
     }
     else {
-        rc = bytes;
-        /* Clamp to requested length so the return value cannot overflow */
-        if (rc > buf_len) {
-            rc = buf_len;
+        /* Bound the byte count to buf_len before narrowing to int: this
+         * guards against a callback reporting more than was requested and
+         * keeps the word32->int cast within range */
+        if (bytes > (word32)buf_len) {
+            bytes = (word32)buf_len;
         }
+        rc = (int)bytes;
     }
 
     return rc;
@@ -1855,7 +1857,8 @@ exit:
     }
     else {
         rc = bytes;
-        /* Clamp to requested length so the return value cannot overflow */
+        /* Never report more than the caller requested; guards against a
+         * read callback that returns more bytes than buf_len */
         if (rc > buf_len) {
             rc = buf_len;
         }

--- a/examples/mqttnet.c
+++ b/examples/mqttnet.c
@@ -173,6 +173,10 @@ static int NetRead(void *context, byte* buf, int buf_len,
     }
     else {
         rc = bytes;
+        /* Clamp to requested length so the return value cannot overflow */
+        if (rc > buf_len) {
+            rc = buf_len;
+        }
     }
 
     return rc;
@@ -1851,6 +1855,10 @@ exit:
     }
     else {
         rc = bytes;
+        /* Clamp to requested length so the return value cannot overflow */
+        if (rc > buf_len) {
+            rc = buf_len;
+        }
     }
 
     return rc;

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -4042,6 +4042,11 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
                 if (rc <= 0) {
                     return MqttPacket_HandleNetError(client, rc);
                 }
+                /* Socket read must not return more than requested */
+                if (rc > remain_read) {
+                    return MqttPacket_HandleNetError(client,
+                        MQTT_TRACE_ERROR(MQTT_CODE_ERROR_NETWORK));
+                }
                 remain_read = rc;
             }
             break;

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -356,7 +356,8 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
         /* return length read and reset position */
         rc = client->read.pos;
         client->read.pos = 0;
-        /* Clamp to requested length so the return value cannot overflow */
+        /* Never report more than the caller requested; guards against a
+         * read callback that returns more bytes than buf_len */
         if (rc > buf_len) {
             rc = buf_len;
         }

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -356,6 +356,10 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
         /* return length read and reset position */
         rc = client->read.pos;
         client->read.pos = 0;
+        /* Clamp to requested length so the return value cannot overflow */
+        if (rc > buf_len) {
+            rc = buf_len;
+        }
     }
 
     return rc;


### PR DESCRIPTION
Coverity flagged the return values of the network read functions as potentially overflowed. Each returns a byte count derived from a socket read, and the checker models that count as unbounded.

Clamp the returned value to the requested length on the success path, right before it is returned:

- MqttPacket_Read: reject a socket read that exceeds remain_read.
- MqttSocket_Read: clamp rc to buf_len.
- NetRead_ex and the FreeRTOS NetRead variant: clamp rc to buf_len.

These bounds are already guaranteed by the read logic; the explicit clamps make them local to each return so the analysis can prove no overflow occurs.
