### PR TITLE
Coverity and fenrir fixes

### DIFF
--- a/examples/aws/awsiot.c
+++ b/examples/aws/awsiot.c
@@ -822,8 +822,9 @@ int awsiot_test(MQTTCtx *mqttCtx)
                     }
                 #else
                     /* The core client sends keep-alive PINGREQ automatically, so
-                     * an idle timeout just means no message arrived. */
-                    rc = MQTT_CODE_SUCCESS;
+                     * an idle timeout just means no message arrived; keep
+                     * waiting. */
+                    continue;
                 #endif
                 }
                 else if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/azure/azureiothub.c
+++ b/examples/azure/azureiothub.c
@@ -531,7 +531,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
                     if (mqttCtx->test_mode) {
                         mTestDone = 1;
                     }
-                    rc = MQTT_CODE_SUCCESS;
+                    continue;
                 #endif
                 }
                 else if (rc != MQTT_CODE_SUCCESS) {
@@ -544,6 +544,10 @@ int azureiothub_test(MQTTCtx *mqttCtx)
         }
         FALL_THROUGH;
 
+    #ifdef WOLFMQTT_NO_TIME
+        /* Manual keep-alive ping. With automatic keep-alive compiled in, the
+         * core client sends PINGREQ itself and WMQ_WAIT_MSG never breaks out to
+         * this state, so it is only compiled for WOLFMQTT_NO_TIME builds. */
         case WMQ_PING:
         {
             mqttCtx->stat = WMQ_PING;
@@ -568,6 +572,7 @@ int azureiothub_test(MQTTCtx *mqttCtx)
             }
         }
         FALL_THROUGH;
+    #endif /* WOLFMQTT_NO_TIME */
 
         case WMQ_DISCONNECT:
         {
@@ -607,6 +612,9 @@ int azureiothub_test(MQTTCtx *mqttCtx)
         }
 
         case WMQ_UNSUB: /* not used */
+    #ifndef WOLFMQTT_NO_TIME
+        case WMQ_PING: /* handled inline via automatic keep-alive */
+    #endif
         default:
             rc = MQTT_CODE_ERROR_STAT;
             goto exit;

--- a/examples/mqttsimple/mqttsimple.c
+++ b/examples/mqttsimple/mqttsimple.c
@@ -459,7 +459,7 @@ int mqttsimple_test(void)
         #else
             /* The core client sends keep-alive PINGREQ automatically, so an
              * idle timeout just means no message arrived; keep waiting. */
-            rc = MQTT_CODE_SUCCESS;
+            continue;
         #endif
         }
         else if (rc != MQTT_CODE_SUCCESS) {

--- a/examples/wiot/wiot.c
+++ b/examples/wiot/wiot.c
@@ -354,7 +354,7 @@ int wiot_test(MQTTCtx *mqttCtx)
             if (mqttCtx->test_mode) {
                 mTestDone = 1;
             }
-            rc = MQTT_CODE_SUCCESS;
+            continue;
         #endif
         }
         else if (rc != MQTT_CODE_SUCCESS) {

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -3859,7 +3859,7 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
         if (BrokerTopicMatch(filter, rm->topic)) {
             MqttPublish out_pub;
             MqttQoS eff_qos = (rm->qos < sub_qos) ? rm->qos : sub_qos;
-            int enc_rc;
+            int enc_rc, wr_rc;
             XMEMSET(&out_pub, 0, sizeof(out_pub));
             out_pub.topic_name = rm->topic;
             out_pub.qos = eff_qos;
@@ -3880,13 +3880,15 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     "len=%u qos=%d", (int)bc->sock,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
-                /* Only scrub after a fully completed write: MqttPacket_Write
-                 * returns the encoded length on success, but in non-blocking /
-                 * TLS-async mode it can return MQTT_CODE_CONTINUE with the send
-                 * still referencing bc->tx_buf - zeroing then would corrupt the
-                 * in-progress write. Residue from a partial/failed write is
-                 * cleared by the next full write or by BrokerClient_Free. */
-                if (MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc) == enc_rc) {
+                wr_rc = MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
+                /* Scrub after a completed write and after a hard failure - both
+                 * leave bc->tx_buf idle. Skip only the in-progress case: in
+                 * non-blocking / TLS-async mode MqttPacket_Write returns
+                 * MQTT_CODE_CONTINUE with the send still referencing bc->tx_buf,
+                 * so zeroing then would corrupt it (that residue is cleared by
+                 * the next full write or by BrokerClient_Free). */
+                if (wr_rc == enc_rc ||
+                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
                     /* Scrub the retained (possibly retained-will) payload from
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
@@ -3938,7 +3940,7 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
         if (rm->topic != NULL && BrokerTopicMatch(filter, rm->topic)) {
             MqttPublish out_pub;
             MqttQoS eff_qos = (rm->qos < sub_qos) ? rm->qos : sub_qos;
-            int enc_rc;
+            int enc_rc, wr_rc;
             XMEMSET(&out_pub, 0, sizeof(out_pub));
             out_pub.topic_name = rm->topic;
             out_pub.qos = eff_qos;
@@ -3959,13 +3961,15 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     "len=%u qos=%d", (int)bc->sock,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
-                /* Only scrub after a fully completed write: MqttPacket_Write
-                 * returns the encoded length on success, but in non-blocking /
-                 * TLS-async mode it can return MQTT_CODE_CONTINUE with the send
-                 * still referencing bc->tx_buf - zeroing then would corrupt the
-                 * in-progress write. Residue from a partial/failed write is
-                 * cleared by the next full write or by BrokerClient_Free. */
-                if (MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc) == enc_rc) {
+                wr_rc = MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
+                /* Scrub after a completed write and after a hard failure - both
+                 * leave bc->tx_buf idle. Skip only the in-progress case: in
+                 * non-blocking / TLS-async mode MqttPacket_Write returns
+                 * MQTT_CODE_CONTINUE with the send still referencing bc->tx_buf,
+                 * so zeroing then would corrupt it (that residue is cleared by
+                 * the next full write or by BrokerClient_Free). */
+                if (wr_rc == enc_rc ||
+                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
                     /* Scrub the retained (possibly retained-will) payload from
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
@@ -4104,7 +4108,7 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
             BrokerTopicMatch(sub->filter, topic)) {
             MqttPublish out_pub;
             MqttQoS eff_qos;
-            int enc_rc;
+            int enc_rc, wr_rc;
             XMEMSET(&out_pub, 0, sizeof(out_pub));
             out_pub.topic_name = (char*)topic;
             eff_qos = (qos < sub->qos) ? qos : sub->qos;
@@ -4122,11 +4126,16 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
             enc_rc = MqttEncode_Publish(sub->client->tx_buf,
                 BROKER_CLIENT_TX_SZ(sub->client), &out_pub, 0);
             if (enc_rc > 0) {
-                /* Only scrub after a fully completed write; a non-blocking /
-                 * TLS-async MQTT_CODE_CONTINUE leaves the send referencing
-                 * tx_buf, so zeroing then would corrupt the in-progress write. */
-                if (MqttPacket_Write(&sub->client->client,
-                        sub->client->tx_buf, enc_rc) == enc_rc) {
+                wr_rc = MqttPacket_Write(&sub->client->client,
+                        sub->client->tx_buf, enc_rc);
+                /* Scrub after a completed write and after a hard failure - both
+                 * leave tx_buf idle. Skip only the in-progress case: in
+                 * non-blocking / TLS-async mode MqttPacket_Write returns
+                 * MQTT_CODE_CONTINUE with the send still referencing tx_buf, so
+                 * zeroing then would corrupt it. Scrubbing on the error path
+                 * preserves the F-4524 immediate-will scrub guarantee. */
+                if (wr_rc == enc_rc ||
+                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
                     BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);
                 }
             }

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -3881,6 +3881,10 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
                 (void)MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
+                /* Scrub the retained (possibly retained-will) payload from the
+                 * subscriber tx_buf, mirroring the will fan-out mitigation, so
+                 * a sensitive payload does not linger until the next write. */
+                BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
             }
         }
     }
@@ -3950,6 +3954,10 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
                 (void)MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
+                /* Scrub the retained (possibly retained-will) payload from the
+                 * subscriber tx_buf, mirroring the will fan-out mitigation, so
+                 * a sensitive payload does not linger until the next write. */
+                BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
             }
         }
         rm_prev = rm;

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -4133,7 +4133,7 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                  * non-blocking / TLS-async mode MqttPacket_Write returns
                  * MQTT_CODE_CONTINUE with the send still referencing tx_buf, so
                  * zeroing then would corrupt it. Scrubbing on the error path
-                 * preserves the F-4524 immediate-will scrub guarantee. */
+                 * keeps the will payload from lingering after a failed send. */
                 if (wr_rc == enc_rc ||
                         (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
                     BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -3880,11 +3880,17 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     "len=%u qos=%d", (int)bc->sock,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
-                (void)MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
-                /* Scrub the retained (possibly retained-will) payload from the
-                 * subscriber tx_buf, mirroring the will fan-out mitigation, so
-                 * a sensitive payload does not linger until the next write. */
-                BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+                /* Only scrub after a fully completed write: MqttPacket_Write
+                 * returns the encoded length on success, but in non-blocking /
+                 * TLS-async mode it can return MQTT_CODE_CONTINUE with the send
+                 * still referencing bc->tx_buf - zeroing then would corrupt the
+                 * in-progress write. Residue from a partial/failed write is
+                 * cleared by the next full write or by BrokerClient_Free. */
+                if (MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc) == enc_rc) {
+                    /* Scrub the retained (possibly retained-will) payload from
+                     * the subscriber tx_buf, mirroring the will fan-out. */
+                    BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+                }
             }
         }
     }
@@ -3953,11 +3959,17 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                     "len=%u qos=%d", (int)bc->sock,
                     BrokerLog_Sanitize(rm->topic),
                     (unsigned)rm->payload_len, (int)eff_qos);
-                (void)MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
-                /* Scrub the retained (possibly retained-will) payload from the
-                 * subscriber tx_buf, mirroring the will fan-out mitigation, so
-                 * a sensitive payload does not linger until the next write. */
-                BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+                /* Only scrub after a fully completed write: MqttPacket_Write
+                 * returns the encoded length on success, but in non-blocking /
+                 * TLS-async mode it can return MQTT_CODE_CONTINUE with the send
+                 * still referencing bc->tx_buf - zeroing then would corrupt the
+                 * in-progress write. Residue from a partial/failed write is
+                 * cleared by the next full write or by BrokerClient_Free. */
+                if (MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc) == enc_rc) {
+                    /* Scrub the retained (possibly retained-will) payload from
+                     * the subscriber tx_buf, mirroring the will fan-out. */
+                    BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+                }
             }
         }
         rm_prev = rm;
@@ -4110,9 +4122,13 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
             enc_rc = MqttEncode_Publish(sub->client->tx_buf,
                 BROKER_CLIENT_TX_SZ(sub->client), &out_pub, 0);
             if (enc_rc > 0) {
-                (void)MqttPacket_Write(&sub->client->client,
-                    sub->client->tx_buf, enc_rc);
-                BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);
+                /* Only scrub after a fully completed write; a non-blocking /
+                 * TLS-async MQTT_CODE_CONTINUE leaves the send referencing
+                 * tx_buf, so zeroing then would corrupt the in-progress write. */
+                if (MqttPacket_Write(&sub->client->client,
+                        sub->client->tx_buf, enc_rc) == enc_rc) {
+                    BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);
+                }
             }
         }
 #ifndef WOLFMQTT_STATIC_MEMORY

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -629,6 +629,17 @@ static int Utf8WellFormed(const byte* s, word16 len)
     }
     return 1;
 }
+
+/* [MQTT-1.5.3-1] Returns 1 if an MQTT UTF-8 string field is well-formed
+ * (RFC 3629) and therefore safe for the encoder to emit, 0 otherwise. Empty
+ * strings are well-formed. Encoders call this in their length-computation pass
+ * so ill-formed input is rejected with a clean local error before any bytes
+ * are written, symmetric with MqttDecode_String on the receive side. */
+static int MqttEncode_Utf8Ok(const char* str, size_t len)
+{
+    return (len == 0) ||
+           ((str != NULL) && Utf8WellFormed((const byte*)str, (word16)len));
+}
 #endif /* !WOLFMQTT_NO_UTF8_VALIDATION */
 
 /* Returns pointer to string (which is not guaranteed to be null terminated).
@@ -682,7 +693,11 @@ int MqttEncode_String(byte *buf, const char *str)
     int str_len = (int)XSTRLEN(str);
     int len;
 
-    /* MQTT UTF-8 strings are limited to 65535 bytes [MQTT-1.5.3] */
+    /* MQTT UTF-8 strings are limited to 65535 bytes [MQTT-1.5.3]. Callers
+     * validate UTF-8 well-formedness in their length-computation pass (where
+     * the error propagates), mirroring the wildcard/length checks; the
+     * CONNECT Password is Binary Data [MQTT-3.1.3.5] and uses MqttEncode_Data
+     * so it is deliberately excluded from that check. */
     if (str_len > (int)0xFFFF) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
@@ -798,6 +813,15 @@ int MqttEncode_Props(MqttPacketType packet, MqttProp* props, byte* buf)
                             MQTT_CONNECT_PROTOCOL_LEVEL_5)) {
                     return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
                 }
+            #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+                /* [MQTT-1.5.3-1] The property value is an MQTT UTF-8 string;
+                 * reject ill-formed UTF-8 before emitting so it round-trips
+                 * through MqttDecode_Props. */
+                if (!MqttEncode_Utf8Ok(cur_prop->data_str.str,
+                        cur_prop->data_str.len)) {
+                    return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+                }
+            #endif
                 tmp = MqttEncode_Data(buf,
                         (const byte*)cur_prop->data_str.str,
                         cur_prop->data_str.len);
@@ -839,6 +863,16 @@ int MqttEncode_Props(MqttPacketType packet, MqttProp* props, byte* buf)
             {
                 /* String is prefixed with a Two Byte Integer length field that
                    gives the number of bytes */
+            #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+                /* [MQTT-1.5.3-1] Both the name and value of a User Property are
+                 * MQTT UTF-8 strings; reject ill-formed UTF-8 before emitting. */
+                if (!MqttEncode_Utf8Ok(cur_prop->data_str.str,
+                        cur_prop->data_str.len) ||
+                    !MqttEncode_Utf8Ok(cur_prop->data_str2.str,
+                        cur_prop->data_str2.len)) {
+                    return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+                }
+            #endif
                 tmp = MqttEncode_Data(buf,
                         (const byte*)cur_prop->data_str.str,
                         cur_prop->data_str.len);
@@ -1261,6 +1295,12 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
         if (str_len > (size_t)0xFFFF) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
         }
+    #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+        /* [MQTT-1.5.3-1] Client Identifier is an MQTT UTF-8 string. */
+        if (!MqttEncode_Utf8Ok(mc_connect->client_id, str_len)) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
+    #endif
         remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
     }
     if (mc_connect->enable_lwt) {
@@ -1282,6 +1322,12 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
                 (word16)str_len, mc_connect->protocol_level)) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
         }
+    #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+        /* [MQTT-1.5.3-1] Will Topic is an MQTT UTF-8 string. */
+        if (!MqttEncode_Utf8Ok(mc_connect->lwt_msg->topic_name, str_len)) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
+    #endif
         if (mc_connect->lwt_msg->qos > MQTT_QOS_2) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
         }
@@ -1319,6 +1365,12 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
         if (str_len > (size_t)0xFFFF) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
         }
+    #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+        /* [MQTT-1.5.3-1] User Name is an MQTT UTF-8 string. */
+        if (!MqttEncode_Utf8Ok(mc_connect->username, str_len)) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
+    #endif
         remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
     }
     if (mc_connect->password) {
@@ -1420,7 +1472,14 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
         tx_payload += MqttEncode_String(tx_payload, mc_connect->username);
     }
     if (mc_connect->password) {
-        tx_payload += MqttEncode_String(tx_payload, mc_connect->password);
+        /* [MQTT-3.1.3.5] The Password is Binary Data, not a UTF-8 string, so
+         * encode it as binary (byte-identical wire format) instead of via
+         * MqttEncode_String. This keeps it out of encode-side UTF-8 validation
+         * and matches the decode path, which reads it as raw bytes. The length
+         * bound was already enforced above. */
+        tx_payload += MqttEncode_Data(tx_payload,
+            (const byte*)mc_connect->password,
+            (word16)XSTRLEN(mc_connect->password));
     }
     (void)tx_payload;
 
@@ -1966,6 +2025,12 @@ int MqttEncode_Publish(byte *tx_buf, int tx_buf_len, MqttPublish *publish,
                                        (word16)str_len, level)) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
         }
+    #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+        /* [MQTT-1.5.3-1] PUBLISH Topic Name is an MQTT UTF-8 string. */
+        if (!MqttEncode_Utf8Ok(publish->topic_name, str_len)) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
+    #endif
     #ifdef WOLFMQTT_V5
         /* [MQTT-3.3.2-8] An empty v5 Topic Name requires a Topic Alias so the
          * decoder (and any conformant broker) can resolve the topic. */
@@ -2513,6 +2578,12 @@ int MqttEncode_Subscribe(byte *tx_buf, int tx_buf_len,
                     (word16)str_len)) {
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
             }
+        #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+            /* [MQTT-1.5.3-1] Topic Filter is an MQTT UTF-8 string. */
+            if (!MqttEncode_Utf8Ok(topic->topic_filter, str_len)) {
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+            }
+        #endif
             remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
             remain_len++; /* For QoS */
         }
@@ -2933,6 +3004,12 @@ int MqttEncode_Unsubscribe(byte *tx_buf, int tx_buf_len,
                     (word16)str_len)) {
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
             }
+        #ifndef WOLFMQTT_NO_UTF8_VALIDATION
+            /* [MQTT-1.5.3-1] Topic Filter is an MQTT UTF-8 string. */
+            if (!MqttEncode_Utf8Ok(topic->topic_filter, str_len)) {
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+            }
+        #endif
             remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
         }
         else {
@@ -3623,6 +3700,14 @@ int MqttEncode_Auth(byte *tx_buf, int tx_buf_len, MqttAuth *auth)
     else
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PROPERTY);
 
+    /* [MQTT-3.15.2.2] A Success AUTH with no Properties is encoded with a
+     * Remaining Length of 0 (the Reason Code and Property Length are omitted).
+     * Emit that canonical short form so MqttDecode_Auth round-trips it instead
+     * of rejecting the 2-byte body as malformed. */
+    if ((auth->reason_code == MQTT_REASON_SUCCESS) && (props_len == 0)) {
+        remain_len = 0;
+    }
+
     /* Encode fixed header */
     header_len = MqttEncode_FixedHeader(tx_buf, tx_buf_len, remain_len,
                   MQTT_PACKET_TYPE_AUTH, 0, 0, 0);
@@ -3636,8 +3721,13 @@ int MqttEncode_Auth(byte *tx_buf, int tx_buf_len, MqttAuth *auth)
     tx_payload = &tx_buf[header_len];
 
     /* Encode variable header. [MQTT-3.15.2.1] Success (0x00) is valid too and
-     * is accepted by MqttDecode_Auth, so encode it to keep the roundtrip. */
-    if ((auth->reason_code == MQTT_REASON_SUCCESS) ||
+     * is accepted by MqttDecode_Auth, so encode it to keep the roundtrip. A
+     * Success AUTH with no Properties uses the Remaining Length 0 short form
+     * (selected above) and has no variable header to emit. */
+    if (remain_len == 0) {
+        /* Success short form: nothing further to encode. */
+    }
+    else if ((auth->reason_code == MQTT_REASON_SUCCESS) ||
         (auth->reason_code == MQTT_REASON_CONT_AUTH) ||
         (auth->reason_code == MQTT_REASON_REAUTH)) {
 
@@ -4065,8 +4155,14 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
     /* reset state */
     client->packet.stat = MQTT_PK_BEGIN;
 
-    /* Return read length */
-    return client->packet.header_len + remain_read;
+    /* Return read length. header_len and remain_read are each bounded by
+     * rx_buf_len above, so their sum cannot exceed it; clamp to keep the
+     * returned length provably in range for static analysis. */
+    rc = client->packet.header_len + remain_read;
+    if (rc > rx_buf_len) {
+        rc = rx_buf_len;
+    }
+    return rc;
 }
 
 #ifndef WOLFMQTT_NO_ERROR_STRINGS

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -62,6 +62,7 @@ typedef struct MockClient {
     size_t out_len;
     int    closed;
     int    read_err; /* when set, mock_read returns a network error (peer RST) */
+    int    write_err; /* when set, mock_write returns a network error */
 } MockClient;
 
 static MockClient g_clients[MOCK_MAX_CLIENTS];
@@ -150,8 +151,14 @@ static int mock_write(void* ctx, BROKER_SOCKET_T sock,
     if (mc->out_len + (size_t)buf_len > sizeof(mc->out_buf)) {
         return MQTT_CODE_ERROR_NETWORK;
     }
+    /* Capture the bytes handed to the socket even when simulating a failure,
+     * so a test can positively assert what the broker produced (i.e. that a
+     * scrub target was actually written) before checking it was scrubbed. */
     XMEMCPY(mc->out_buf + mc->out_len, buf, (size_t)buf_len);
     mc->out_len += (size_t)buf_len;
+    if (mc->write_err) {
+        return MQTT_CODE_ERROR_NETWORK; /* simulate a hard write failure */
+    }
     return buf_len;
 }
 
@@ -2261,6 +2268,161 @@ TEST(broker_publish_before_connect_closes)
     MqttBroker_Free(&broker);
 }
 
+#if !defined(WOLFMQTT_STATIC_MEMORY) && \
+    (defined(WOLFMQTT_BROKER_RETAINED) || defined(WOLFMQTT_BROKER_WILL))
+/* Return 1 if the byte sequence `needle` (nlen bytes) occurs within the first
+ * hlen bytes of `hay`, else 0. Used to prove a delivered payload was scrubbed
+ * from a broker-side tx_buf. */
+static int scrub_region_contains(const byte* hay, int hlen,
+    const char* needle, int nlen)
+{
+    int i;
+    if (hay == NULL || nlen <= 0 || hlen < nlen) {
+        return 0;
+    }
+    for (i = 0; i + nlen <= hlen; i++) {
+        if (XMEMCMP(hay + i, needle, (size_t)nlen) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif
+
+#if defined(WOLFMQTT_BROKER_RETAINED) && !defined(WOLFMQTT_STATIC_MEMORY)
+/* f-6950: after a retained message is delivered on a completed write, the
+ * plaintext payload must not linger in the subscriber's broker-side tx_buf.
+ * Deliver a distinctive retained payload, let the mock write complete, and
+ * assert the payload reached the wire but was scrubbed from tx_buf. Deleting
+ * the BROKER_FORCE_ZERO would leave the payload resident and trip this. */
+TEST(broker_retained_scrub_after_completed_write)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    /* v3.1.1 CONNECT, ClientId "P" / "S", clean_session=1. */
+    static const byte connect_pub[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C, 0x00, 0x01, 'P'
+    };
+    static const byte connect_sub[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C, 0x00, 0x01, 'S'
+    };
+    /* Retained PUBLISH: topic "r/q", payload "RETAINSECRET" (QoS 0, retain). */
+    static const byte publish[] = {
+        0x31, 0x11, 0x00, 0x03, 'r', '/', 'q',
+        'R', 'E', 'T', 'A', 'I', 'N', 'S', 'E', 'C', 'R', 'E', 'T'
+    };
+    /* SUBSCRIBE to "r/q" at QoS 0. */
+    static const byte subscribe[] = {
+        0x82, 0x08, 0x00, 0x01, 0x00, 0x03, 'r', '/', 'q', 0x00
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    /* Publisher stores the retained message before the subscriber attaches. */
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(0, publish, sizeof(publish));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe, sizeof(subscribe));
+    for (i = 0; i < 16; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* The retained PUBLISH reached the subscriber's wire... */
+    ASSERT_EQ(1, scrub_region_contains(g_clients[1].out_buf,
+        (int)g_clients[1].out_len, "RETAINSECRET", 12));
+    /* ...but the plaintext was scrubbed from the broker-side tx_buf. */
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+    ASSERT_EQ(0, scrub_region_contains(sub_bc->tx_buf, sub_bc->tx_buf_len,
+        "RETAINSECRET", 12));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_BROKER_RETAINED && !WOLFMQTT_STATIC_MEMORY */
+
+#if defined(WOLFMQTT_BROKER_WILL) && !defined(WOLFMQTT_STATIC_MEMORY)
+/* f-6950 / F-4524: the immediate-will fan-out must scrub the subscriber tx_buf
+ * even when the delivery write fails hard (only the in-progress
+ * MQTT_CODE_CONTINUE case is skipped). Connect and subscribe first (writes
+ * succeed), then force the subscriber's writes to fail and trigger the
+ * publisher's abnormal disconnect so the will fan-out write returns a network
+ * error. With the error-path scrub the will plaintext is gone from tx_buf;
+ * without it (a scrub gated only on wr == enc_rc) it would linger. */
+TEST(broker_will_scrub_after_failed_write)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    /* Subscriber v3.1.1 CONNECT "S" (clean) then SUBSCRIBE to "lwt". */
+    static const byte sub_connect[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C, 0x00, 0x01, 'S'
+    };
+    static const byte sub_subscribe[] = {
+        0x82, 0x08, 0x00, 0x01, 0x00, 0x03, 'l', 'w', 't', 0x00
+    };
+    /* Publisher v3.1.1 CONNECT "P" with LWT: flags 0x06 (will | clean),
+     * will_topic "lwt", will_payload "WILLSECRET" (10 bytes). */
+    static const byte pub_connect[] = {
+        0x10, 0x1E, 0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x06, 0x00, 0x3C, 0x00, 0x01, 'P',
+        0x00, 0x03, 'l', 'w', 't',
+        0x00, 0x0A, 'W', 'I', 'L', 'L', 'S', 'E', 'C', 'R', 'E', 'T'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    /* Establish both clients; the will has not fired yet. */
+    mock_client_input_append(0, sub_connect, sizeof(sub_connect));
+    mock_client_input_append(0, sub_subscribe, sizeof(sub_subscribe));
+    mock_client_input_append(1, pub_connect, sizeof(pub_connect));
+    for (i = 0; i < 12; i++) {
+        MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* Force the subscriber's writes to fail, then drop the publisher's socket
+     * so its will fans out to the subscriber over the failing write. */
+    g_clients[0].write_err = 1;
+    g_clients[1].read_err = 1;
+    for (i = 0; i < 8; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* Positive control: the will was encoded and handed to the (failing) write,
+     * so the scrub path genuinely had plaintext to remove. Without this the
+     * scrub assertion below could pass vacuously if the will never reached the
+     * subscriber's tx_buf (e.g. a topic-match or fan-out regression). */
+    ASSERT_EQ(1, scrub_region_contains(g_clients[0].out_buf,
+        (int)g_clients[0].out_len, "WILLSECRET", 10));
+
+    /* The will fan-out does not tear the subscriber down on a failed write, so
+     * it is still present - and its tx_buf must not retain the will plaintext. */
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+    ASSERT_EQ(0, scrub_region_contains(sub_bc->tx_buf, sub_bc->tx_buf_len,
+        "WILLSECRET", 10));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_BROKER_WILL && !WOLFMQTT_STATIC_MEMORY */
+
 #if defined(WOLFMQTT_BROKER_RETAINED) && !defined(WOLFMQTT_STATIC_MEMORY)
 /* The dynamic retained-message list must be bounded. A client that
  * publishes RETAIN=1 to more than BROKER_MAX_RETAINED distinct topics must not
@@ -3366,11 +3528,15 @@ int main(int argc, char** argv)
     RUN_TEST(disconnect_v311_nonzero_remain_len_fires_will);
 #endif
     RUN_TEST(disconnect_invalid_fixed_header_flags_fires_will);
+#if defined(WOLFMQTT_BROKER_WILL) && !defined(WOLFMQTT_STATIC_MEMORY)
+    RUN_TEST(broker_will_scrub_after_failed_write);
+#endif
     RUN_TEST(broker_unhandled_packet_type_closes);
     RUN_TEST(broker_publish_before_connect_closes);
 #if defined(WOLFMQTT_BROKER_RETAINED) && !defined(WOLFMQTT_STATIC_MEMORY)
     RUN_TEST(broker_retained_list_capped);
     RUN_TEST(broker_retained_clock_rollback_not_expired);
+    RUN_TEST(broker_retained_scrub_after_completed_write);
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
     RUN_TEST(broker_per_client_subscription_cap);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -2290,11 +2290,8 @@ static int scrub_region_contains(const byte* hay, int hlen,
 #endif
 
 #if defined(WOLFMQTT_BROKER_RETAINED) && !defined(WOLFMQTT_STATIC_MEMORY)
-/* f-6950: after a retained message is delivered on a completed write, the
- * plaintext payload must not linger in the subscriber's broker-side tx_buf.
- * Deliver a distinctive retained payload, let the mock write complete, and
- * assert the payload reached the wire but was scrubbed from tx_buf. Deleting
- * the BROKER_FORCE_ZERO would leave the payload resident and trip this. */
+/* After a completed retained delivery the payload must be scrubbed from the
+ * subscriber's tx_buf: assert it reached the wire but not tx_buf. */
 TEST(broker_retained_scrub_after_completed_write)
 {
     MqttBroker broker;
@@ -2350,13 +2347,10 @@ TEST(broker_retained_scrub_after_completed_write)
 #endif /* WOLFMQTT_BROKER_RETAINED && !WOLFMQTT_STATIC_MEMORY */
 
 #if defined(WOLFMQTT_BROKER_WILL) && !defined(WOLFMQTT_STATIC_MEMORY)
-/* f-6950 / F-4524: the immediate-will fan-out must scrub the subscriber tx_buf
- * even when the delivery write fails hard (only the in-progress
- * MQTT_CODE_CONTINUE case is skipped). Connect and subscribe first (writes
- * succeed), then force the subscriber's writes to fail and trigger the
- * publisher's abnormal disconnect so the will fan-out write returns a network
- * error. With the error-path scrub the will plaintext is gone from tx_buf;
- * without it (a scrub gated only on wr == enc_rc) it would linger. */
+/* The immediate-will fan-out must scrub the subscriber tx_buf even when the
+ * delivery write fails hard (only an in-progress MQTT_CODE_CONTINUE is
+ * skipped). Force the subscriber's write to fail during the will fan-out and
+ * assert the will plaintext is gone from tx_buf. */
 TEST(broker_will_scrub_after_failed_write)
 {
     MqttBroker broker;

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -963,7 +963,7 @@ TEST(publish_null_publish)
     ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
 }
 
-/* f-6805 streaming-publish chunk regression. The payload is larger than the
+/* Streaming-publish chunk regression. The payload is larger than the
  * client tx buffer and its length is not a multiple of it, so the callback loop
  * must send a short final chunk. The backing buffer holds the valid payload
  * followed by a guard region; the guard bytes must never reach the wire. */
@@ -1016,7 +1016,7 @@ static int pub_stream_cb(MqttPublish* publish)
     return PUB_STREAM_VALID_LEN;
 }
 
-/* f-6805: the streaming-publish callback loop must copy only the bytes that
+/* The streaming-publish callback loop must copy only the bytes that
  * remain on the final chunk. Before the fix the last copy reused the clamped
  * tx_buf_len and read past publish->buffer, leaking adjacent memory onto the
  * wire and over-sending the payload. Drive a 300-byte payload through a 256-byte
@@ -1061,7 +1061,7 @@ TEST(publish_stream_cb_final_chunk_no_overrun)
     ASSERT_TRUE(pub_stream_wire_len <= PUB_STREAM_VALID_LEN + 16);
 }
 
-/* f-6805 multi-fill coverage: when total_len > buffer_len the callback is
+/* Multi-fill coverage: when total_len > buffer_len the callback is
  * invoked repeatedly, so the outer loop must advance buffer_pos by each fill and
  * recompute intBuf_cb_len per fill. Drive a 700-byte payload through a 300-byte
  * callback buffer and 256-byte tx buffer; assert the whole payload is
@@ -1127,7 +1127,7 @@ static int mock_net_write_resume(void *context, const byte* buf, int buf_len,
     return n;
 }
 
-/* f-6805 non-blocking resume: when the transport partially accepts a chunk the
+/* Non-blocking resume: when the transport partially accepts a chunk the
  * streaming publish re-enters mid-fill. The callback fill length must survive
  * that re-entry (via publish->intBuf_cb_len); otherwise the resumed loop drops
  * the payload tail and re-sends the head, over-sending and desyncing framing.

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -558,7 +558,7 @@ TEST(encode_publish_valid_utf8_topic_accepted)
 {
     byte buf[64];
     MqttPublish pub;
-    /* "caf" + U+00E9 (C3 A9) - well-formed 2-byte sequence. */
+    /* ASCII prefix followed by U+00E9 (C3 A9), a well-formed 2-byte sequence. */
     char topic[] = { 'c', 'a', 'f', (char)0xC3, (char)0xA9, '\0' };
     int rc;
 

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -969,7 +969,7 @@ TEST(encode_publish_qos2_with_dup_accepted)
     ASSERT_EQ(0xC, (int)MQTT_PACKET_FLAGS_GET(tx_buf[0]));
 }
 
-/* f-2360: topic_name with strlen > 65535 must not produce a "successful"
+/* A topic_name with strlen > 65535 must not produce a "successful"
  * encode. MqttEncode_String returns -1 for oversize strings; the encoder
  * must surface that as a negative return rather than adding -1 to the
  * tx_payload pointer and reporting header_len+remain_len as success. */
@@ -1993,7 +1993,7 @@ TEST(encode_subscribe_v5_reserved_sub_options_bit_rejected)
 }
 #endif /* WOLFMQTT_V5 */
 
-/* f-2360: topic_filter with strlen > 65535 must be rejected with a negative
+/* A topic_filter with strlen > 65535 must be rejected with a negative
  * return. Guards the unchecked tx_payload += MqttEncode_String(...) in the
  * SUBSCRIBE payload loop. */
 TEST(encode_subscribe_topic_filter_oversized_rejected)
@@ -2552,7 +2552,7 @@ TEST(encode_connect_flags_lwt_qos1_retain)
     ASSERT_EQ(0, flags & MQTT_CONNECT_FLAG_CLEAN_SESSION);
 }
 
-/* f-2360: client_id with strlen > 65535 must be rejected with a negative
+/* A client_id with strlen > 65535 must be rejected with a negative
  * return. MqttEncode_String returns -1 for such strings; the encoder must
  * not report header_len+remain_len as a successful encode while tx_payload
  * silently moves backward by one byte. */
@@ -2582,7 +2582,7 @@ TEST(encode_connect_client_id_oversized_rejected)
     ASSERT_TRUE(rc < 0);
 }
 
-/* f-2360: username with strlen > 65535. Password is supplied so the
+/* A username with strlen > 65535. Password is supplied so the
  * USERNAME+PASSWORD branch exercises both credential encodes. */
 TEST(encode_connect_username_oversized_rejected)
 {
@@ -2612,7 +2612,7 @@ TEST(encode_connect_username_oversized_rejected)
     ASSERT_TRUE(rc < 0);
 }
 
-/* f-2360: password with strlen > 65535. */
+/* A password with strlen > 65535. */
 TEST(encode_connect_password_oversized_rejected)
 {
     const int str_len = 0x10000;
@@ -2641,7 +2641,7 @@ TEST(encode_connect_password_oversized_rejected)
     ASSERT_TRUE(rc < 0);
 }
 
-/* f-2360: LWT topic_name with strlen > 65535. */
+/* An LWT topic_name with strlen > 65535. */
 TEST(encode_connect_lwt_topic_oversized_rejected)
 {
     const int str_len = 0x10000;

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -533,42 +533,6 @@ TEST(decode_string_utf8_invalid_FE_FF)
     ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
 }
 
-/* [MQTT-1.5.3-1] The encoders must reject ill-formed UTF-8 before emitting,
- * symmetric with MqttDecode_String, so a caller gets a clean local error
- * instead of a peer-side disconnect. Exercised through the public
- * MqttEncode_Publish Topic Name path (client_id, Will Topic, username, and
- * topic filters share the same MqttEncode_Utf8Ok check). */
-TEST(encode_publish_invalid_utf8_topic_rejected)
-{
-    byte buf[64];
-    MqttPublish pub;
-    /* Topic Name with a lone continuation byte 0x80 - ill-formed UTF-8, but
-     * free of wildcards so it passes MqttPacket_TopicNameValid. */
-    char topic[] = { 'a', (char)0x80, 'b', '\0' };
-    int rc;
-
-    XMEMSET(&pub, 0, sizeof(pub));
-    pub.topic_name = topic;
-    pub.qos = MQTT_QOS_0;
-    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
-    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
-}
-
-TEST(encode_publish_valid_utf8_topic_accepted)
-{
-    byte buf[64];
-    MqttPublish pub;
-    /* ASCII prefix followed by U+00E9 (C3 A9), a well-formed 2-byte sequence. */
-    char topic[] = { 'c', 'a', 'f', (char)0xC3, (char)0xA9, '\0' };
-    int rc;
-
-    XMEMSET(&pub, 0, sizeof(pub));
-    pub.topic_name = topic;
-    pub.qos = MQTT_QOS_0;
-    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
-    ASSERT_TRUE(rc > 0);
-}
-
 TEST(decode_connect_invalid_utf8_clientid_overlong)
 {
     /* CONNECT v3.1.1 with ClientId bytes 0xC0 0xAF (overlong). Reporter's
@@ -791,6 +755,43 @@ TEST(encode_publish_qos0_packet_id_zero_ok)
     pub.qos = MQTT_QOS_0;
     pub.packet_id = 0;
     rc = MqttEncode_Publish(tx_buf, (int)sizeof(tx_buf), &pub, 0);
+    ASSERT_TRUE(rc > 0);
+}
+
+/* [MQTT-1.5.3-1] The encoders must reject ill-formed UTF-8 before emitting,
+ * symmetric with MqttDecode_String, so a caller gets a clean local error
+ * instead of a peer-side disconnect. Exercised through the public
+ * MqttEncode_Publish Topic Name path (client_id, Will Topic, username, and
+ * topic filters share the same MqttEncode_Utf8Ok check). Kept outside the
+ * broker test guard so non-broker builds also cover the encoder change. */
+TEST(encode_publish_invalid_utf8_topic_rejected)
+{
+    byte buf[64];
+    MqttPublish pub;
+    /* Topic Name with a lone continuation byte 0x80 - ill-formed UTF-8, but
+     * free of wildcards so it passes MqttPacket_TopicNameValid. */
+    char topic[] = { 'a', (char)0x80, 'b', '\0' };
+    int rc;
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    pub.topic_name = topic;
+    pub.qos = MQTT_QOS_0;
+    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_publish_valid_utf8_topic_accepted)
+{
+    byte buf[64];
+    MqttPublish pub;
+    /* ASCII prefix followed by U+00E9 (C3 A9), a well-formed 2-byte sequence. */
+    char topic[] = { 'c', 'a', 'f', (char)0xC3, (char)0xA9, '\0' };
+    int rc;
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    pub.topic_name = topic;
+    pub.qos = MQTT_QOS_0;
+    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
     ASSERT_TRUE(rc > 0);
 }
 
@@ -5294,8 +5295,6 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_string_utf8_invalid_truncated_2byte);
     RUN_TEST(decode_string_utf8_invalid_truncated_4byte);
     RUN_TEST(decode_string_utf8_invalid_FE_FF);
-    RUN_TEST(encode_publish_invalid_utf8_topic_rejected);
-    RUN_TEST(encode_publish_valid_utf8_topic_accepted);
     RUN_TEST(decode_connect_invalid_utf8_clientid_overlong);
     RUN_TEST(decode_connect_clientid_contains_u0000_rejected);
     RUN_TEST(decode_connect_invalid_utf8_clientid_surrogate);
@@ -5306,6 +5305,8 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_publish_invalid_utf8_topic);
 
     /* MqttEncode_Publish */
+    RUN_TEST(encode_publish_invalid_utf8_topic_rejected);
+    RUN_TEST(encode_publish_valid_utf8_topic_accepted);
     RUN_TEST(encode_publish_qos1_packet_id_zero);
     RUN_TEST(encode_publish_qos2_packet_id_zero);
     RUN_TEST(encode_publish_qos0_packet_id_zero_ok);

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -533,6 +533,42 @@ TEST(decode_string_utf8_invalid_FE_FF)
     ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
 }
 
+/* [MQTT-1.5.3-1] The encoders must reject ill-formed UTF-8 before emitting,
+ * symmetric with MqttDecode_String, so a caller gets a clean local error
+ * instead of a peer-side disconnect. Exercised through the public
+ * MqttEncode_Publish Topic Name path (client_id, Will Topic, username, and
+ * topic filters share the same MqttEncode_Utf8Ok check). */
+TEST(encode_publish_invalid_utf8_topic_rejected)
+{
+    byte buf[64];
+    MqttPublish pub;
+    /* Topic Name with a lone continuation byte 0x80 - ill-formed UTF-8, but
+     * free of wildcards so it passes MqttPacket_TopicNameValid. */
+    char topic[] = { 'a', (char)0x80, 'b', '\0' };
+    int rc;
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    pub.topic_name = topic;
+    pub.qos = MQTT_QOS_0;
+    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_publish_valid_utf8_topic_accepted)
+{
+    byte buf[64];
+    MqttPublish pub;
+    /* "caf" + U+00E9 (C3 A9) - well-formed 2-byte sequence. */
+    char topic[] = { 'c', 'a', 'f', (char)0xC3, (char)0xA9, '\0' };
+    int rc;
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    pub.topic_name = topic;
+    pub.qos = MQTT_QOS_0;
+    rc = MqttEncode_Publish(buf, (int)sizeof(buf), &pub, 0);
+    ASSERT_TRUE(rc > 0);
+}
+
 TEST(decode_connect_invalid_utf8_clientid_overlong)
 {
     /* CONNECT v3.1.1 with ClientId bytes 0xC0 0xAF (overlong). Reporter's
@@ -2230,6 +2266,112 @@ TEST(encode_connect_username_and_password)
     ASSERT_TRUE(rc > 0);
 }
 
+/* [MQTT-3.1.3.5] The Password is Binary Data, not a UTF-8 string, so the
+ * encoder must accept a password containing bytes that are not legal UTF-8
+ * (0xC0 0xAF is an overlong sequence Utf8WellFormed rejects). Locks in that
+ * the Password field bypasses encode-side UTF-8 validation, unlike the
+ * username/client_id/topic string fields. */
+TEST(encode_connect_binary_password_accepted)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    char password[] = { 'p', (char)0xC0, (char)0xAF, '\0' };
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "test_client";
+    conn.username = "user";
+    conn.password = password;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+}
+
+/* [MQTT-1.5.3-1] Each encoder call site of MqttEncode_Utf8Ok is exercised
+ * independently so a per-site slip (wrong variable, omitted check) is caught,
+ * not just the shared helper. 0x80 is a lone continuation byte - ill-formed
+ * UTF-8 with no wildcards, so it reaches the UTF-8 check. */
+TEST(encode_connect_invalid_utf8_clientid_rejected)
+{
+    byte tx_buf[128];
+    MqttConnect conn;
+    char client_id[] = { 'a', (char)0x80, '\0' };
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = client_id;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_connect_invalid_utf8_username_rejected)
+{
+    byte tx_buf[128];
+    MqttConnect conn;
+    char username[] = { 'u', (char)0x80, '\0' };
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "test_client";
+    conn.username = username;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_connect_invalid_utf8_will_topic_rejected)
+{
+    byte tx_buf[128];
+    MqttConnect conn;
+    MqttMessage lwt;
+    char will_topic[] = { 'w', (char)0x80, '\0' };
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    XMEMSET(&lwt, 0, sizeof(lwt));
+    lwt.topic_name = will_topic;
+    conn.client_id = "test_client";
+    conn.enable_lwt = 1;
+    conn.lwt_msg = &lwt;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_subscribe_invalid_utf8_filter_rejected)
+{
+    byte tx_buf[128];
+    MqttSubscribe sub;
+    MqttTopic topic;
+    char filter[] = { 'a', (char)0x80, '\0' };
+    int rc;
+
+    XMEMSET(&sub, 0, sizeof(sub));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = filter;
+    topic.qos = MQTT_QOS_0;
+    sub.topics = &topic;
+    sub.topic_count = 1;
+    sub.packet_id = 1;
+    rc = MqttEncode_Subscribe(tx_buf, (int)sizeof(tx_buf), &sub);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+TEST(encode_unsubscribe_invalid_utf8_filter_rejected)
+{
+    byte tx_buf[128];
+    MqttUnsubscribe unsub;
+    MqttTopic topic;
+    char filter[] = { 'a', (char)0x80, '\0' };
+    int rc;
+
+    XMEMSET(&unsub, 0, sizeof(unsub));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = filter;
+    unsub.topics = &topic;
+    unsub.topic_count = 1;
+    unsub.packet_id = 1;
+    rc = MqttEncode_Unsubscribe(tx_buf, (int)sizeof(tx_buf), &unsub);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
 TEST(encode_connect_username_only)
 {
     byte tx_buf[256];
@@ -3374,6 +3516,11 @@ TEST(topic_filter_valid_helper_table)
     ASSERT_EQ(0, MqttPacket_TopicFilterValid("sport+", 6));
     ASSERT_EQ(0, MqttPacket_TopicFilterValid("sport+/player1", 14));
     ASSERT_EQ(0, MqttPacket_TopicFilterValid("a+b", 3));
+    /* '+' at a valid level-start but followed by a non-'/' byte is malformed
+     * [MQTT-4.7.1-3]. These isolate the follow-character check (filter[i+1]
+     * != '/'); the preceding-character check does not reject them. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid("+a", 2));
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid("a/+b", 4));
 
     /* Plain non-wildcard topics. */
     ASSERT_EQ(1, MqttPacket_TopicFilterValid("a", 1));
@@ -3444,11 +3591,19 @@ TEST(decode_subscribe_hash_not_last_rejected)
 /* [MQTT-4.7.1-3] '+' must occupy an entire topic level. */
 TEST(decode_subscribe_bad_plus_placement_rejected)
 {
-    /* "a+b" - '+' embedded in a level. */
+    /* "a+b" - '+' embedded in a level (preceding-character check). */
     byte rx_buf[] = {
         0x82, 0x08,
         0x00, 0x01,
         0x00, 0x03, 'a', '+', 'b',
+        0x00
+    };
+    /* "a/+b" - '+' at a valid level-start but trailed by a non-'/' byte
+     * (follow-character check). */
+    byte rx_buf2[] = {
+        0x82, 0x09,
+        0x00, 0x01,
+        0x00, 0x04, 'a', '/', '+', 'b',
         0x00
     };
     MqttSubscribe sub;
@@ -3459,6 +3614,12 @@ TEST(decode_subscribe_bad_plus_placement_rejected)
     XMEMSET(topic_arr, 0, sizeof(topic_arr));
     sub.topics = topic_arr;
     rc = MqttDecode_Subscribe(rx_buf, (int)sizeof(rx_buf), &sub);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+
+    XMEMSET(&sub, 0, sizeof(sub));
+    XMEMSET(topic_arr, 0, sizeof(topic_arr));
+    sub.topics = topic_arr;
+    rc = MqttDecode_Subscribe(rx_buf2, (int)sizeof(rx_buf2), &sub);
     ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
 }
 
@@ -4854,6 +5015,57 @@ TEST(publish_resp_v5_success_no_props_roundtrip)
     ASSERT_EQ(MQTT_REASON_SUCCESS, dec.reason_code);
 }
 
+/* [MQTT-1.5.3-1] MqttEncode_Props must reject ill-formed UTF-8 in a STRING
+ * property value before emitting, symmetric with MqttDecode_Props. Exercised
+ * in the length-computation pass (buf == NULL), where the error propagates. */
+TEST(encode_props_string_invalid_utf8_rejected)
+{
+    MqttProp prop;
+    char bad[] = { 'a', (char)0x80, '\0' }; /* lone continuation byte */
+    int rc;
+
+    XMEMSET(&prop, 0, sizeof(prop));
+    prop.type = MQTT_PROP_CONTENT_TYPE;
+    prop.data_str.str = bad;
+    prop.data_str.len = 2;
+    prop.next = NULL;
+    rc = MqttEncode_Props(MQTT_PACKET_TYPE_PUBLISH, &prop, NULL);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+/* [MQTT-1.5.3-1] Both members of a User Property (name and value) are MQTT
+ * UTF-8 strings; ill-formed UTF-8 in either must be rejected. Covers each
+ * member independently so validating only one would fail. */
+TEST(encode_props_user_prop_invalid_utf8_rejected)
+{
+    MqttProp prop;
+    char good[] = { 'k', '\0' };
+    char bad[] = { (char)0x80, '\0' };      /* lone continuation byte */
+    int rc;
+
+    /* Ill-formed value, well-formed name. */
+    XMEMSET(&prop, 0, sizeof(prop));
+    prop.type = MQTT_PROP_USER_PROP;
+    prop.data_str.str = good;
+    prop.data_str.len = 1;
+    prop.data_str2.str = bad;
+    prop.data_str2.len = 1;
+    prop.next = NULL;
+    rc = MqttEncode_Props(MQTT_PACKET_TYPE_PUBLISH, &prop, NULL);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+
+    /* Ill-formed name, well-formed value. */
+    XMEMSET(&prop, 0, sizeof(prop));
+    prop.type = MQTT_PROP_USER_PROP;
+    prop.data_str.str = bad;
+    prop.data_str.len = 1;
+    prop.data_str2.str = good;
+    prop.data_str2.len = 1;
+    prop.next = NULL;
+    rc = MqttEncode_Props(MQTT_PACKET_TYPE_PUBLISH, &prop, NULL);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
 /* ============================================================================
  * MqttEncode/Decode_Auth roundtrip
  *
@@ -4939,8 +5151,8 @@ TEST(auth_v5_reauth_decodes_without_error)
 TEST(auth_v5_success_remaining_length_zero)
 {
     /* Per MQTT 5.0 3.15.2, a Remaining Length of 0 means SUCCESS with no
-     * properties. Build that wire form directly since MqttEncode_Auth does
-     * not emit it. */
+     * properties. Build that wire form directly to guard the decoder against
+     * encoder changes masking a decoder-only regression. */
     byte buf[2];
     MqttAuth dec;
     int dec_len;
@@ -4951,6 +5163,31 @@ TEST(auth_v5_success_remaining_length_zero)
     XMEMSET(&dec, 0, sizeof(dec));
     dec_len = MqttDecode_Auth(buf, (int)sizeof(buf), &dec);
     ASSERT_EQ(2, dec_len);
+    ASSERT_EQ(MQTT_REASON_SUCCESS, dec.reason_code);
+    ASSERT_NULL(dec.props);
+}
+
+/* [MQTT-3.15.2.2] A Success AUTH with no Properties must encode to the
+ * Remaining Length 0 short form and round-trip through MqttDecode_Auth,
+ * rather than emitting a 2-byte body the decoder rejects as malformed. */
+TEST(auth_v5_success_no_props_roundtrip)
+{
+    byte buf[8];
+    MqttAuth enc, dec;
+    int enc_len, dec_len;
+
+    XMEMSET(&enc, 0, sizeof(enc));
+    enc.reason_code = MQTT_REASON_SUCCESS;
+    enc.props = NULL;
+
+    enc_len = MqttEncode_Auth(buf, (int)sizeof(buf), &enc);
+    /* Fixed header (2 bytes) + Remaining Length 0. */
+    ASSERT_EQ(2, enc_len);
+    ASSERT_EQ(0x00, buf[1]);
+
+    XMEMSET(&dec, 0, sizeof(dec));
+    dec_len = MqttDecode_Auth(buf, enc_len, &dec);
+    ASSERT_EQ(enc_len, dec_len);
     ASSERT_EQ(MQTT_REASON_SUCCESS, dec.reason_code);
     ASSERT_NULL(dec.props);
 }
@@ -5057,6 +5294,8 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_string_utf8_invalid_truncated_2byte);
     RUN_TEST(decode_string_utf8_invalid_truncated_4byte);
     RUN_TEST(decode_string_utf8_invalid_FE_FF);
+    RUN_TEST(encode_publish_invalid_utf8_topic_rejected);
+    RUN_TEST(encode_publish_valid_utf8_topic_accepted);
     RUN_TEST(decode_connect_invalid_utf8_clientid_overlong);
     RUN_TEST(decode_connect_clientid_contains_u0000_rejected);
     RUN_TEST(decode_connect_invalid_utf8_clientid_surrogate);
@@ -5161,6 +5400,12 @@ void run_mqtt_packet_tests(void)
     /* MqttEncode_Connect */
     RUN_TEST(encode_connect_password_without_username);
     RUN_TEST(encode_connect_username_and_password);
+    RUN_TEST(encode_connect_binary_password_accepted);
+    RUN_TEST(encode_connect_invalid_utf8_clientid_rejected);
+    RUN_TEST(encode_connect_invalid_utf8_username_rejected);
+    RUN_TEST(encode_connect_invalid_utf8_will_topic_rejected);
+    RUN_TEST(encode_subscribe_invalid_utf8_filter_rejected);
+    RUN_TEST(encode_unsubscribe_invalid_utf8_filter_rejected);
     RUN_TEST(encode_connect_username_only);
     RUN_TEST(encode_connect_no_credentials);
     RUN_TEST(encode_connect_fixed_header_flags);
@@ -5329,10 +5574,13 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(publish_resp_v5_success_no_props_roundtrip);
 
     /* MqttEncode/Decode_Auth */
+    RUN_TEST(encode_props_string_invalid_utf8_rejected);
+    RUN_TEST(encode_props_user_prop_invalid_utf8_rejected);
     RUN_TEST(auth_v5_cont_auth_roundtrip);
     RUN_TEST(auth_v5_reauth_roundtrip);
     RUN_TEST(auth_v5_reauth_decodes_without_error);
     RUN_TEST(auth_v5_success_remaining_length_zero);
+    RUN_TEST(auth_v5_success_no_props_roundtrip);
     RUN_TEST(auth_v5_invalid_reason_code_rejected);
     RUN_TEST(decode_auth_v5_reason_code_past_buf_rejected);
 #endif

--- a/tests/test_mqtt_sn.c
+++ b/tests/test_mqtt_sn.c
@@ -385,7 +385,7 @@ TEST(sn_gwinfo_ind_form_total_len_equals_consumed_rejected)
 
 TEST(sn_gwinfo_ind_form_poc_4byte_datagram_rejected)
 {
-    /* Exact attacker PoC from f-3632: a 4-byte IND-form GWINFO datagram.
+    /* Exact attacker PoC: a 4-byte IND-form GWINFO datagram.
      * IND header consumes 3 bytes; total_len=4 leaves room for only one of
      * the two remaining reads (type + gwId), so the gwId read (and the old
      * "total_len - 3" address copy) would walk past this 4-byte buffer.


### PR DESCRIPTION
* Coverity issues
* f-6947: topic-filter '+' follow-character check was untested; malformed single-level wildcards could slip through
* f-6948: MqttEncode_Auth emitted an undecodable AUTH for reason_code SUCCESS with NULL props (roundtrip asymmetry)
* f-6949: string encoders did not enforce the RFC 3629 UTF-8 well-formedness the decoder requires
* f-6950: retained-message payloads were left in the subscriber tx_buf after delivery (no BROKER_FORCE_ZERO)
