### PR TITLE
Fix fenrir issues

### DIFF
--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -913,6 +913,22 @@ static void BrokerClient_Remove(MqttBroker* broker, BrokerClient* bc);
 static void BrokerClient_PublishWill(MqttBroker* broker, BrokerClient* bc);
 #endif
 
+/* Scrub and release the WebSocket outbound staging buffer. The staged copy
+ * holds plaintext MQTT payloads (forwarded PUBLISH, retained and will
+ * messages) that the source tx_buf scrub cannot reach, because the network
+ * callback deep-copies into this heap block before the caller wipes tx_buf.
+ * Zero it before returning the block, mirroring the rx_buffer scrub on the
+ * inbound side. tx_len is still valid at every call site. */
+static void BrokerWs_FreeTx(BrokerWsCtx* ws)
+{
+    if (ws->tx_pending != NULL) {
+        BROKER_FORCE_ZERO(ws->tx_pending, (word32)(LWS_PRE + ws->tx_len));
+        WOLFMQTT_FREE(ws->tx_pending);
+        ws->tx_pending = NULL;
+        ws->tx_len = 0;
+    }
+}
+
 static BrokerClient* BrokerClient_AddWs(MqttBroker* broker, struct lws *wsi)
 {
     BrokerClient* bc = NULL;
@@ -1036,14 +1052,25 @@ static int callback_broker_mqtt(struct lws *wsi,
          * no Origin header (native clients) are not browser-originated and are
          * allowed through. */
         if (broker != NULL && broker->ws_allowed_origin != NULL) {
-            char origin[256];
-            int olen = lws_hdr_copy(wsi, origin, (int)sizeof(origin),
-                WSI_TOKEN_ORIGIN);
-            if (olen > 0 &&
-                    XSTRCMP(origin, broker->ws_allowed_origin) != 0) {
-                WBLOG_ERR(broker, "broker: ws origin rejected: %s",
-                    BrokerLog_Sanitize(origin));
-                return -1;
+            /* Distinguish an absent Origin (native, non-browser client that is
+             * allowed through) from one that is present but does not fit the
+             * scratch buffer. lws_hdr_total_length() reports the true length
+             * regardless of copy-buffer size; an Origin of 256 bytes or more
+             * makes lws_hdr_copy() return -1, and the old "olen > 0" gate
+             * silently treated that as allowed - reopening the CSWSH hole the
+             * allowlist exists to close. A present Origin must therefore fail
+             * closed on any copy failure or mismatch. */
+            int tot = lws_hdr_total_length(wsi, WSI_TOKEN_ORIGIN);
+            if (tot > 0) {
+                char origin[256];
+                int olen = lws_hdr_copy(wsi, origin, (int)sizeof(origin),
+                    WSI_TOKEN_ORIGIN);
+                if (olen <= 0 ||
+                        XSTRCMP(origin, broker->ws_allowed_origin) != 0) {
+                    WBLOG_ERR(broker,
+                        "broker: ws origin rejected (len=%d)", tot);
+                    return -1;
+                }
             }
         }
     }
@@ -1099,15 +1126,11 @@ static int callback_broker_mqtt(struct lws *wsi,
             if (n < (int)ws->tx_len) {
                 WBLOG_ERR(broker, "broker: ws write failed (wsi=%p, "
                     "n=%d, len=%d)", (void*)wsi, n, (int)ws->tx_len);
-                WOLFMQTT_FREE(ws->tx_pending);
-                ws->tx_pending = NULL;
-                ws->tx_len = 0;
+                BrokerWs_FreeTx(ws);
                 ws->status = -1;
                 return -1;
             }
-            WOLFMQTT_FREE(ws->tx_pending);
-            ws->tx_pending = NULL;
-            ws->tx_len = 0;
+            BrokerWs_FreeTx(ws);
         }
     }
     else if (reason == LWS_CALLBACK_CLOSED) {
@@ -1230,11 +1253,7 @@ static int BrokerWsNetWrite(void* context, const byte* buf, int buf_len,
     }
 
     /* Free any prior unsent data */
-    if (ws->tx_pending != NULL) {
-        WOLFMQTT_FREE(ws->tx_pending);
-        ws->tx_pending = NULL;
-        ws->tx_len = 0;
-    }
+    BrokerWs_FreeTx(ws);
 
     /* Allocate buffer with LWS_PRE prefix space */
     ws->tx_pending = (byte*)WOLFMQTT_MALLOC(LWS_PRE + buf_len);
@@ -1260,9 +1279,7 @@ static int BrokerWsNetWrite(void* context, const byte* buf, int buf_len,
 
     if (ws->tx_pending != NULL) {
         /* Data was not flushed - connection may be in bad state */
-        WOLFMQTT_FREE(ws->tx_pending);
-        ws->tx_pending = NULL;
-        ws->tx_len = 0;
+        BrokerWs_FreeTx(ws);
         return MQTT_CODE_ERROR_NETWORK;
     }
 
@@ -1322,11 +1339,7 @@ static int BrokerWsNetDisconnect(void* context)
         }
     }
 
-    if (ws->tx_pending != NULL) {
-        WOLFMQTT_FREE(ws->tx_pending);
-        ws->tx_pending = NULL;
-    }
-    ws->tx_len = 0;
+    BrokerWs_FreeTx(ws);
     /* Scrub any unconsumed staged bytes (may hold credentials) before free. */
     BROKER_FORCE_ZERO(ws->rx_buffer, (word32)sizeof(ws->rx_buffer));
     ws->rx_len = 0;
@@ -2041,11 +2054,9 @@ static void BrokerClient_Free(BrokerClient* bc)
     if (bc->ws_ctx != NULL) {
         (void)BrokerWsNetDisconnect(bc);
     }
-    else
 #endif
-
 #ifdef ENABLE_MQTT_TLS
-    if (bc->client.tls.ssl) {
+    if (bc->client.tls.ssl != NULL) {
         /* Send close_notify before closing the socket, because
          * wolfSSL_shutdown uses I/O callbacks that need a valid fd */
         if (bc->tls_handshake_done) {
@@ -2055,6 +2066,9 @@ static void BrokerClient_Free(BrokerClient* bc)
         bc->client.tls.ssl = NULL;
     }
 #endif
+    /* Always attempt the socket close; BrokerNetDisconnect is internally
+     * guarded on sock != BROKER_SOCKET_INVALID, so it is a no-op for the
+     * WebSocket clients that never own a real descriptor. */
     (void)BrokerNetDisconnect(bc);
     MqttClient_DeInit(&bc->client);
 #ifdef WOLFMQTT_STATIC_MEMORY
@@ -5012,17 +5026,22 @@ send_connack:
 
     /* CONNECT accepted. Authentication is complete, and neither the plaintext
      * CONNECT still in bc->rx_buf (mc.username/mc.password were in-place
-     * pointers into it) nor the dedicated bc->password copy is read again for
-     * the life of this connection - the broker has no re-auth path. Scrub both
-     * now so credentials reside in memory only for the duration of CONNECT
-     * processing rather than the whole session. Refused/failed CONNECTs return
-     * earlier and are wiped when the caller frees the client. Mirrors the
-     * client-side CLIENT_FORCE_ZERO hardening in mqtt_client.c. */
+     * pointers into it) nor the dedicated bc->username / bc->password copies
+     * are read again for the life of this connection - the broker has no
+     * re-auth path. Scrub them all now so credentials reside in memory only
+     * for the duration of CONNECT processing rather than the whole session.
+     * Refused/failed CONNECTs return earlier and are wiped when the caller
+     * frees the client. Mirrors the client-side CLIENT_FORCE_ZERO hardening
+     * in mqtt_client.c. */
     BROKER_FORCE_ZERO(bc->rx_buf, (word32)rx_len);
 #ifdef WOLFMQTT_BROKER_AUTH
 #ifdef WOLFMQTT_STATIC_MEMORY
+    BROKER_FORCE_ZERO(bc->username, BROKER_MAX_USERNAME_LEN);
     BROKER_FORCE_ZERO(bc->password, BROKER_MAX_PASSWORD_LEN);
 #else
+    if (bc->username != NULL) {
+        BROKER_FORCE_ZERO(bc->username, XSTRLEN(bc->username) + 1);
+    }
     if (bc->password != NULL) {
         BROKER_FORCE_ZERO(bc->password, (size_t)bc->password_len + 1);
     }
@@ -5140,6 +5159,12 @@ static int BrokerHandle_Subscribe(BrokerClient* bc, int rx_len,
                 }
             }
 #endif
+        }
+        else {
+            /* The filter length could not be recovered, so no subscription
+             * was registered; report failure instead of the requested QoS so
+             * the SUBACK cannot claim a subscription that was never added. */
+            granted_qos = (MqttQoS)MQTT_SUBSCRIBE_ACK_CODE_FAILURE;
         }
         return_codes[i] = (byte)granted_qos;
     }
@@ -5280,6 +5305,22 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
         WBLOG_ERR(broker, "broker: client PUBLISH carried SUBSCRIPTION_ID "
             "sock=%d", (int)bc->sock);
         (void)BrokerSend_Disconnect(bc, MQTT_REASON_PROTOCOL_ERR);
+        rc = MQTT_CODE_ERROR_MALFORMED_DATA;
+        goto publish_cleanup;
+    }
+
+    /* The broker does not implement Topic Aliases (it advertises a Topic Alias
+     * Maximum of 0), so any inbound Topic Alias property is a Protocol Error -
+     * whether it accompanies an empty Topic Name (an alias-only PUBLISH that
+     * cannot be resolved to a topic) or a full one (which would otherwise be
+     * forwarded, alias property included, to subscribers). Reject it rather
+     * than silently dropping the message while acknowledging SUCCESS. */
+    if (bc->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+            pub.props != NULL &&
+            BrokerProps_Find(pub.props, MQTT_PROP_TOPIC_ALIAS) != NULL) {
+        WBLOG_ERR(broker, "broker: client PUBLISH used unsupported Topic Alias "
+            "sock=%d", (int)bc->sock);
+        (void)BrokerSend_Disconnect(bc, MQTT_REASON_TOPIC_ALIAS_INVALID);
         rc = MQTT_CODE_ERROR_MALFORMED_DATA;
         goto publish_cleanup;
     }
@@ -6543,7 +6584,7 @@ int MqttBroker_Run(MqttBroker* broker)
             /* Idle - sleep briefly to avoid busy-waiting */
             BROKER_SLEEP_MS(10);
         }
-        else if (rc < 0 && rc != MQTT_CODE_CONTINUE) {
+        else if (rc < 0) {
             break;
         }
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1110,6 +1110,13 @@ static int MqttClient_HandlePacket(MqttClient* client,
             rc = MqttClient_DecodePacket(client, client->rx_buf,
                 client->packet.buf_len, packet_obj, &packet_type, &packet_qos,
                 &packet_id, 1);
+            /* The decoded AUTH properties (including AUTH_DATA) were pointers
+             * into rx_buf and have now been delivered to the callback and
+             * freed. Scrub rx_buf so the enhanced-authentication material does
+             * not linger until the next read, matching MqttClient_Auth and the
+             * v5 CONNACK path. This runs under lockRecv (held by MqttReadStart
+             * in MqttClient_WaitType), so no additional locking is needed. */
+            CLIENT_FORCE_ZERO(client->rx_buf, client->rx_buf_len);
         #else
             rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PACKET_TYPE);
         #endif
@@ -1205,33 +1212,50 @@ static void MqttClient_PacketReset(MqttPacketType packet_type, void* packet_obj)
 {
     size_t objSz = 0;
     size_t offset = sizeof(MqttMsgStat);
-#ifdef WOLFMQTT_MULTITHREAD
-    offset += sizeof(MqttPendResp);
-#endif
+    /* The MqttPendResp offset is added only for the types whose struct embeds
+     * a pendResp member (right after MqttMsgStat). Ack-only types (CONNECT_ACK,
+     * SUBSCRIBE_ACK, UNSUBSCRIBE_ACK, DISCONNECT) have no pendResp, so adding
+     * it there would skip live fields - matching the per-type handling in
+     * MqttSNClient_PacketReset. */
     switch (packet_type) {
         case MQTT_PACKET_TYPE_CONNECT:
             objSz = sizeof(MqttConnect);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_CONNECT_ACK:
             objSz = sizeof(MqttConnectAck);
             break;
         case MQTT_PACKET_TYPE_PUBLISH:
             objSz = sizeof(MqttPublish);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_PUBLISH_ACK:
         case MQTT_PACKET_TYPE_PUBLISH_REC:
         case MQTT_PACKET_TYPE_PUBLISH_REL:
         case MQTT_PACKET_TYPE_PUBLISH_COMP:
             objSz = sizeof(MqttPublishResp);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_SUBSCRIBE:
             objSz = sizeof(MqttSubscribe);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_SUBSCRIBE_ACK:
             objSz = sizeof(MqttSubscribeAck);
             break;
         case MQTT_PACKET_TYPE_UNSUBSCRIBE:
             objSz = sizeof(MqttUnsubscribe);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_UNSUBSCRIBE_ACK:
             objSz = sizeof(MqttUnsubscribeAck);
@@ -1239,10 +1263,16 @@ static void MqttClient_PacketReset(MqttPacketType packet_type, void* packet_obj)
         case MQTT_PACKET_TYPE_PING_REQ:
         case MQTT_PACKET_TYPE_PING_RESP:
             objSz = sizeof(MqttPing);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case MQTT_PACKET_TYPE_AUTH:
         #ifdef WOLFMQTT_V5
             objSz = sizeof(MqttAuth);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
         #endif
             break;
         case MQTT_PACKET_TYPE_DISCONNECT:

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2810,8 +2810,11 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
     }
 
     if (unsubscribe->ack.props != NULL) {
-        /* Release the allocated properties */
+        /* Release the allocated properties and clear the caller-visible
+         * pointer so a stale reference cannot be observed, reused, or freed
+         * again after this API returns. */
         MqttClient_PropsFree(unsubscribe->ack.props);
+        unsubscribe->ack.props = NULL;
     }
 #endif
 

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -690,15 +690,17 @@ int MqttDecode_String(byte *buf, const char **pstr, word16 *pstr_len, word32 buf
    If buf is NULL, return number of bytes that would be encoded. */
 int MqttEncode_String(byte *buf, const char *str)
 {
-    int str_len = (int)XSTRLEN(str);
+    size_t str_len = XSTRLEN(str);
     int len;
 
     /* MQTT UTF-8 strings are limited to 65535 bytes [MQTT-1.5.3]. Callers
      * validate UTF-8 well-formedness in their length-computation pass (where
      * the error propagates), mirroring the wildcard/length checks; the
      * CONNECT Password is Binary Data [MQTT-3.1.3.5] and uses MqttEncode_Data
-     * so it is deliberately excluded from that check. */
-    if (str_len > (int)0xFFFF) {
+     * so it is deliberately excluded from that check. Keep the length in
+     * size_t and reject oversize values before narrowing so a very large
+     * string cannot truncate to a small or negative int and reach XMEMCPY. */
+    if (str_len > (size_t)0xFFFF) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
     len = MqttEncode_Num(buf, (word16)str_len);
@@ -707,7 +709,7 @@ int MqttEncode_String(byte *buf, const char *str)
         buf += len;
         XMEMCPY(buf, str, str_len);
     }
-    return len + str_len;
+    return len + (int)str_len;
 }
 
 /* Returns number of buffer bytes encoded

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2305,6 +2305,13 @@ int MqttDecode_Publish(byte *rx_buf, int rx_buf_len, MqttPublish *publish)
 
     /* Decode Payload */
     if (variable_len > remain_len) {
+    #ifdef WOLFMQTT_V5
+        /* Free any v5 properties decoded above so this late error return does
+         * not leak the property list; the caller only frees props on the
+         * success path. */
+        MqttProps_Free(publish->props);
+        publish->props = NULL;
+    #endif
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
     }
     payload_len = remain_len - variable_len;
@@ -2925,9 +2932,21 @@ int MqttDecode_SubscribeAck(byte* rx_buf, int rx_buf_len,
             byte level = 0;
             int i;
             if (payload_len < 0 || buf_remain < 0) {
+            #ifdef WOLFMQTT_V5
+                if (subscribe_ack->props != NULL) {
+                    (void)MqttProps_Free(subscribe_ack->props);
+                    subscribe_ack->props = NULL;
+                }
+            #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
             }
             if (payload_len > buf_remain) {
+            #ifdef WOLFMQTT_V5
+                if (subscribe_ack->props != NULL) {
+                    (void)MqttProps_Free(subscribe_ack->props);
+                    subscribe_ack->props = NULL;
+                }
+            #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
             }
             subscribe_ack->return_code_count =
@@ -4091,10 +4110,10 @@ int MqttPacket_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
                 client->packet.header_len += len;
             }
 
-            if (i == MQTT_PACKET_MAX_LEN_BYTES) {
-                return MqttPacket_HandleNetError(client,
-                        MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA));
-            }
+            /* No post-loop over-length check is needed: the in-loop guard above
+             * (i == MQTT_PACKET_MAX_LEN_BYTES - 1) is the sole exit for a VBI
+             * whose last allowed byte still sets the continuation bit, so i can
+             * never reach MQTT_PACKET_MAX_LEN_BYTES at this point. */
 
             /* Try and decode remaining length */
             if (rx_buf_len < (client->packet.header_len - (i + 1))) {

--- a/src/mqtt_sn_client.c
+++ b/src/mqtt_sn_client.c
@@ -563,6 +563,9 @@ static void MqttSNClient_PacketReset(SN_MsgType packet_type, void* packet_obj)
             break;
         case SN_MSG_TYPE_DISCONNECT:
             objSz = sizeof(SN_Disconnect);
+        #ifdef WOLFMQTT_MULTITHREAD
+            offset += sizeof(MqttPendResp);
+        #endif
             break;
         case SN_MSG_TYPE_WILLTOPICUPD:
         case SN_MSG_TYPE_WILLTOPICRESP:
@@ -998,7 +1001,7 @@ static int SN_WillTopic(MqttClient *client, SN_Will *will)
         case MQTT_MSG_WAIT:
         {
             /* Wait for Will Topic Request packet */
-            rc = SN_Client_WaitType(client, will,
+            rc = SN_Client_WaitType(client, &will->resp.topicResp,
                     SN_MSG_TYPE_WILLTOPICREQ, 0, client->cmd_timeout_ms);
         #ifdef WOLFMQTT_NONBLOCK
             if (rc == MQTT_CODE_CONTINUE) {

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -1449,6 +1449,24 @@ TEST(decode_publish_v5_duplicate_singleton_prop_rejected)
     ASSERT_EQ(MQTT_CODE_ERROR_PROPERTY, rc);
     ASSERT_NULL(pub.props);
 }
+
+/* A late OUT_OF_BUFFER return (variable_len > remain_len) reached after the v5
+ * property block was already decoded must release and NULL publish->props so a
+ * caller cannot leak the property list. Wire: PUBLISH QoS 0 with remain_len=4
+ * but topic "t" plus a PAYLOAD_FORMAT_INDICATOR property make variable_len=6;
+ * the over-length buffer lets decoding reach the length-consistency check. */
+TEST(decode_publish_v5_props_freed_on_short_remain_len)
+{
+    byte buf[] = { 0x30, 0x04, 0x00, 0x01, 't', 0x02, 0x01, 0x00 };
+    MqttPublish pub;
+    int rc;
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    pub.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttDecode_Publish(buf, (int)sizeof(buf), &pub);
+    ASSERT_EQ(MQTT_CODE_ERROR_OUT_OF_BUFFER, rc);
+    ASSERT_NULL(pub.props);
+}
 #endif /* WOLFMQTT_V5 */
 
 /* [MQTT-2.3.1-1] PUBLISH with QoS > 0 must carry a non-zero Packet
@@ -4126,6 +4144,25 @@ TEST(decode_suback_v5_not_authorized_accepted)
     ASSERT_EQ(0x87, ack.return_codes[0]);
 }
 
+/* A late OUT_OF_BUFFER return in the return-code payload block (payload_len >
+ * buf_remain) reached after the v5 property block was already decoded must
+ * release and NULL subscribe_ack->props. Wire: SUBACK remain_len=12 (claims a
+ * 2-byte return-code payload) but the buffer ends right after a USER_PROPERTY,
+ * so the declared payload overruns the supplied buffer. */
+TEST(decode_suback_v5_props_freed_on_payload_overrun)
+{
+    byte buf[] = { 0x90, 0x0C, 0x00, 0x01, 0x07,
+                   0x26, 0x00, 0x01, 'k', 0x00, 0x01, 'v' };
+    MqttSubscribeAck ack;
+    int rc;
+
+    XMEMSET(&ack, 0, sizeof(ack));
+    ack.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttDecode_SubscribeAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(MQTT_CODE_ERROR_OUT_OF_BUFFER, rc);
+    ASSERT_NULL(ack.props);
+}
+
 /* Pin v5's broadened set via the helper. */
 TEST(suback_return_code_v5_allowed_set)
 {
@@ -5347,6 +5384,7 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(encode_publish_v5_response_topic_wildcard_rejected);
     RUN_TEST(decode_publish_v5_property_count_capped);
     RUN_TEST(decode_publish_v5_duplicate_singleton_prop_rejected);
+    RUN_TEST(decode_publish_v5_props_freed_on_short_remain_len);
 #endif
     RUN_TEST(decode_publish_qos1_packet_id_zero_rejected);
     RUN_TEST(decode_publish_qos2_packet_id_zero_rejected);
@@ -5502,6 +5540,7 @@ void run_mqtt_packet_tests(void)
 #ifdef WOLFMQTT_V5
     RUN_TEST(decode_suback_v5_not_authorized_accepted);
     RUN_TEST(suback_return_code_v5_allowed_set);
+    RUN_TEST(decode_suback_v5_props_freed_on_payload_overrun);
 #endif
 
     /* MqttDecode_PublishResp */


### PR DESCRIPTION
  ## Fixed findings

  ### Medium
  - f-7172: WebSocket Origin allowlist fails open when the Origin header exceeds the 256-byte scratch buffer

  ### Low
  - f-7173: Broker sends PUBACK/PUBREC SUCCESS for a v5 PUBLISH it silently discards (unsupported Topic Alias)
  - f-7176: WebSocket outbound staging buffer `ws->tx_pending` freed without zeroization
  - f-7177: Broker retains plaintext CONNECT username for the whole session while the password is scrubbed
  - f-7178: MQTT v5 AUTH received through MqttClient_WaitMessage leaves AUTH_DATA in client rx_buf
  - f-7158: MqttSNClient_PacketReset omits the MqttPendResp offset for SN_MSG_TYPE_DISCONNECT
  - f-7159: MqttClient_PacketReset applies the MqttPendResp offset to ack-only types that have no pendResp member
  - f-7161: SN_WillTopic waits with a different packet_obj than the one registered in its pending-response entry
  - f-7174: Decoded MQTT v5 property list leaked on late error returns in MqttDecode_Publish and MqttDecode_SubscribeAck
  - f-7160: Unreachable VBI-overflow check in MqttPacket_Read after the in-loop  4-byte guard

  ### Info
  - f-7162: BrokerHandle_Subscribe reports the requested QoS as granted when the filter-length decode is skipped
  - f-7163: Redundant MQTT_CODE_CONTINUE test in MqttBroker_Run's else-if
  - f-7175: Dangling else spanning #ifdef boundaries in BrokerClient_Free
