### PR TITLE
Fenrir fixes

### DIFF
--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -6856,7 +6856,7 @@ int wolfmqtt_broker(int argc, char** argv)
     MqttBrokerNet net;
     int i;
 #ifdef WOLFMQTT_BROKER_AUTH
-    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN] = {0};
 #endif
 #ifdef WOLFMQTT_BROKER_PERSIST
     MqttBrokerPersistHooks persist_hooks;

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -136,6 +136,10 @@ static const char* BrokerLog_Sanitize(const char* src)
     char* dst = pool[pool_idx];
     word32 di = 0;
 
+    /* Clear the slot before reuse so no residue from a previous longer
+     * sanitized string survives past this call's NUL terminator. */
+    BROKER_FORCE_ZERO(dst, BROKER_LOG_SAN_SZ);
+
     pool_idx = (pool_idx + 1) % BROKER_LOG_SAN_POOL;
 
     if (src == NULL) {
@@ -1816,6 +1820,9 @@ static void BrokerClient_DrainOutQueue(BrokerClient* bc)
             WBLOG_ERR(bc->broker,
                 "broker: drain encode failed sock=%d topic=%s rc=%d",
                 (int)bc->sock, BrokerLog_Sanitize(cur->topic), enc_rc);
+            /* Encode length is unknown on failure, so scrub the whole buffer
+             * in case a partial payload was written. */
+            BROKER_FORCE_ZERO(bc->tx_buf, BROKER_CLIENT_TX_SZ(bc));
             /* Drop just this entry and continue. Encoding failure for
              * a single message is not fatal to the connection. */
             if (prev == NULL) {
@@ -1850,6 +1857,14 @@ static void BrokerClient_DrainOutQueue(BrokerClient* bc)
         {
             int wr_rc;
             wr_rc = MqttPacket_Write(&bc->client, bc->tx_buf, enc_rc);
+            /* Scrub the forwarded PUBLISH (which may carry a replayed will or
+             * an application payload) once the buffer is idle. Skip only the
+             * MQTT_CODE_CONTINUE case, where a non-blocking or TLS-async send
+             * still references bc->tx_buf. */
+            if (wr_rc == enc_rc ||
+                    (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
+                BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+            }
             if (wr_rc < 0) {
                 /* Socket dropped (EPIPE/ECONNRESET/etc). Leave this
                  * entry in QUEUED state, do not advance, do not bump
@@ -2395,6 +2410,7 @@ WOLFMQTT_LOCAL void BrokerOrphan_DropFull(MqttBroker* broker,
                     broker->subs = next;
                 }
                 if (sp->filter) {
+                    BROKER_FORCE_ZERO(sp->filter, XSTRLEN(sp->filter) + 1);
                     WOLFMQTT_FREE(sp->filter);
                 }
                 if (sp->client_id) {
@@ -2783,6 +2799,7 @@ static void BrokerSubs_RemoveClient(MqttBroker* broker, BrokerClient* bc)
                 broker->subs = next;
             }
             if (cur->filter) {
+                BROKER_FORCE_ZERO(cur->filter, XSTRLEN(cur->filter) + 1);
                 WOLFMQTT_FREE(cur->filter);
             }
             if (cur->client_id) {
@@ -2974,6 +2991,7 @@ static void BrokerSubs_Remove(MqttBroker* broker, BrokerClient* bc,
             }
             WBLOG_INFO(broker, "broker: sub remove sock=%d filter=%s",
                 (int)bc->sock, BrokerLog_Sanitize(cur->filter));
+            BROKER_FORCE_ZERO(cur->filter, XSTRLEN(cur->filter) + 1);
             WOLFMQTT_FREE(cur->filter);
             if (cur->client_id) {
                 WOLFMQTT_FREE(cur->client_id);
@@ -3097,6 +3115,7 @@ static void BrokerSubs_RemoveByClientId(MqttBroker* broker,
                 broker->subs = next;
             }
             if (cur->filter) {
+                BROKER_FORCE_ZERO(cur->filter, XSTRLEN(cur->filter) + 1);
                 WOLFMQTT_FREE(cur->filter);
             }
             if (cur->client_id) {
@@ -5550,11 +5569,12 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                         wr = MqttPacket_Write(&sub->client->client,
                             sub->client->tx_buf, sub_rc);
                         /* Static fan-out has no per-subscriber resume queue, so
-                         * a partial write leaves this subscriber's stream
-                         * desynced and unrecoverable. Tear down its socket and
-                         * clear connected; the main loop reaps it on the next
-                         * read error, and the match guard above then skips this
-                         * client's other matching subscriptions. */
+                         * anything short of a complete write leaves this
+                         * subscriber's stream desynced and unrecoverable. Tear
+                         * down its socket and clear connected; the main loop
+                         * reaps it on the next read error, and the match guard
+                         * above then skips this client's other matching
+                         * subscriptions. */
                         if (wr != sub_rc &&
                             sub->client->sock != BROKER_SOCKET_INVALID) {
                             broker->net.close(broker->net.ctx,
@@ -5562,6 +5582,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                             sub->client->sock = BROKER_SOCKET_INVALID;
                             sub->client->connected = 0;
                         }
+                        /* Scrub the forwarded payload from the reusable tx_buf.
+                         * On a complete write the send is done; on any other
+                         * outcome the send is abandoned above (no resume queue),
+                         * so nothing references the buffer either way. */
+                        BROKER_FORCE_ZERO(sub->client->tx_buf, sub_rc);
                     }
                     else {
                         WBLOG_ERR(broker,
@@ -6422,8 +6447,14 @@ int MqttBroker_Start(MqttBroker* broker)
 #ifdef WOLFMQTT_BROKER_PERSIST
     /* Restore persisted state (orphan subs, retained messages) before
      * opening the listen sockets so reconnecting clients see the
-     * resumed session immediately. No-op when no hooks are installed. */
-    (void)BrokerPersist_Restore(broker);
+     * resumed session immediately. No-op when no hooks are installed.
+     * A nonzero result means the backing store is unhealthy, so refuse to
+     * start rather than come up with silently incomplete state. */
+    rc = BrokerPersist_Restore(broker);
+    if (rc != MQTT_CODE_SUCCESS) {
+        WBLOG_ERR(broker, "broker: persistence restore failed rc=%d", rc);
+        return rc;
+    }
 #endif
 
 #ifdef ENABLE_MQTT_TLS
@@ -6589,7 +6620,11 @@ int MqttBroker_Run(MqttBroker* broker)
         }
     }
 
-    return MQTT_CODE_SUCCESS;
+    /* Propagate a fatal step error; a clean stop leaves rc idle or success. */
+    if (rc == MQTT_CODE_CONTINUE || rc > 0) {
+        rc = MQTT_CODE_SUCCESS;
+    }
+    return rc;
 }
 
 int MqttBroker_Stop(MqttBroker* broker)
@@ -6627,6 +6662,8 @@ int MqttBroker_Free(MqttBroker* broker)
     while (broker->subs) {
         BrokerSub* next = broker->subs->next;
         if (broker->subs->filter) {
+            BROKER_FORCE_ZERO(broker->subs->filter,
+                XSTRLEN(broker->subs->filter) + 1);
             WOLFMQTT_FREE(broker->subs->filter);
         }
         if (broker->subs->client_id) {
@@ -6801,12 +6838,26 @@ static int wolfmqtt_broker_dev_derive_key(void* ctx, byte* out_key,
 }
 #endif
 
+#ifdef WOLFMQTT_BROKER_AUTH
+/* Wipe the stack copy of the CLI password on every exit path (including the
+ * early error returns) so the plaintext does not outlive the call. Matters for
+ * NO_MAIN_DRIVER builds that reuse the stack frame across invocations. No-op
+ * when broker auth is disabled. */
+#define BROKER_WIPE_AUTH_PASS() \
+    BROKER_FORCE_ZERO(auth_pass_buf, sizeof(auth_pass_buf))
+#else
+#define BROKER_WIPE_AUTH_PASS() do {} while (0)
+#endif
+
 int wolfmqtt_broker(int argc, char** argv)
 {
     int rc;
     MqttBroker broker;
     MqttBrokerNet net;
     int i;
+#ifdef WOLFMQTT_BROKER_AUTH
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+#endif
 #ifdef WOLFMQTT_BROKER_PERSIST
     MqttBrokerPersistHooks persist_hooks;
     const char* persist_dir = NULL;
@@ -6860,7 +6911,21 @@ int wolfmqtt_broker(int argc, char** argv)
             broker.auth_user = argv[++i];
         }
         else if (XSTRCMP(argv[i], "-P") == 0 && i + 1 < argc) {
-            broker.auth_pass = argv[++i];
+            char* pass_arg = argv[++i];
+            word32 pass_len = (word32)XSTRLEN(pass_arg);
+            /* Copy the password into broker-owned storage and wipe the argv
+             * slot so the plaintext does not linger in /proc/<pid>/cmdline
+             * for the life of the process. */
+            if (pass_len >= (word32)sizeof(auth_pass_buf)) {
+                PRINTF("broker: -P password too long (max %d)",
+                    (int)sizeof(auth_pass_buf) - 1);
+                BROKER_FORCE_ZERO(pass_arg, pass_len);
+                return MQTT_CODE_ERROR_BAD_ARG;
+            }
+            XMEMCPY(auth_pass_buf, pass_arg, pass_len);
+            auth_pass_buf[pass_len] = '\0';
+            broker.auth_pass = auth_pass_buf;
+            BROKER_FORCE_ZERO(pass_arg, pass_len);
         }
 #endif
 #ifdef ENABLE_MQTT_TLS
@@ -6909,10 +6974,12 @@ int wolfmqtt_broker(int argc, char** argv)
 #endif
         else if (XSTRCMP(argv[i], "-h") == 0) {
             BrokerUsage(argv[0]);
+            BROKER_WIPE_AUTH_PASS();
             return 0;
         }
         else {
             BrokerUsage(argv[0]);
+            BROKER_WIPE_AUTH_PASS();
             return MQTT_CODE_ERROR_BAD_ARG;
         }
     }
@@ -6934,11 +7001,13 @@ int wolfmqtt_broker(int argc, char** argv)
             PRINTF("broker: ERROR persist+encrypt build needs -E <source> "
                 "(only \"dev\" is recognized; production deployments "
                 "must install MqttBrokerPersistHooks.derive_key)");
+            BROKER_WIPE_AUTH_PASS();
             return MQTT_CODE_ERROR_BAD_ARG;
         }
         if (XSTRCMP(encrypt_key_source, "dev") != 0) {
             PRINTF("broker: ERROR unknown -E source \"%s\" "
                 "(only \"dev\" is recognized)", encrypt_key_source);
+            BROKER_WIPE_AUTH_PASS();
             return MQTT_CODE_ERROR_BAD_ARG;
         }
         #else
@@ -6948,6 +7017,7 @@ int wolfmqtt_broker(int argc, char** argv)
         PRINTF("broker: ERROR persist+encrypt build has no built-in key "
             "source (rebuild with --enable-broker-persist-encrypt-dev-key "
             "for testing, or install MqttBrokerPersistHooks.derive_key)");
+        BROKER_WIPE_AUTH_PASS();
         return MQTT_CODE_ERROR_BAD_ARG;
         #endif
     #endif
@@ -6955,6 +7025,7 @@ int wolfmqtt_broker(int argc, char** argv)
         if (rc != 0) {
             PRINTF("broker: persist init failed dir=%s rc=%d",
                 persist_dir, rc);
+            BROKER_WIPE_AUTH_PASS();
             return rc;
         }
         persist_initialized = 1;
@@ -7018,6 +7089,9 @@ int wolfmqtt_broker(int argc, char** argv)
 
     MqttBroker_Free(&broker);
 
+    /* Erase the broker-owned password copy before returning. */
+    BROKER_WIPE_AUTH_PASS();
+
 #ifdef WOLFMQTT_BROKER_PERSIST
     if (persist_initialized) {
         MqttBrokerNet_PersistPosix_Free(&persist_hooks);
@@ -7026,6 +7100,7 @@ int wolfmqtt_broker(int argc, char** argv)
 
     return rc;
 }
+#undef BROKER_WIPE_AUTH_PASS
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char** argv)

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -1861,8 +1861,7 @@ static void BrokerClient_DrainOutQueue(BrokerClient* bc)
              * an application payload) once the buffer is idle. Skip only the
              * MQTT_CODE_CONTINUE case, where a non-blocking or TLS-async send
              * still references bc->tx_buf. */
-            if (wr_rc == enc_rc ||
-                    (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
+            if (wr_rc != MQTT_CODE_CONTINUE) {
                 BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
             }
             if (wr_rc < 0) {
@@ -3920,8 +3919,7 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                  * MQTT_CODE_CONTINUE with the send still referencing bc->tx_buf,
                  * so zeroing then would corrupt it (that residue is cleared by
                  * the next full write or by BrokerClient_Free). */
-                if (wr_rc == enc_rc ||
-                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
+                if (wr_rc != MQTT_CODE_CONTINUE) {
                     /* Scrub the retained (possibly retained-will) payload from
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
@@ -4001,8 +3999,7 @@ static void BrokerRetained_DeliverToClient(MqttBroker* broker,
                  * MQTT_CODE_CONTINUE with the send still referencing bc->tx_buf,
                  * so zeroing then would corrupt it (that residue is cleared by
                  * the next full write or by BrokerClient_Free). */
-                if (wr_rc == enc_rc ||
-                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
+                if (wr_rc != MQTT_CODE_CONTINUE) {
                     /* Scrub the retained (possibly retained-will) payload from
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
@@ -4167,8 +4164,7 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                  * MQTT_CODE_CONTINUE with the send still referencing tx_buf, so
                  * zeroing then would corrupt it. Scrubbing on the error path
                  * keeps the will payload from lingering after a failed send. */
-                if (wr_rc == enc_rc ||
-                        (wr_rc < 0 && wr_rc != MQTT_CODE_CONTINUE)) {
+                if (wr_rc != MQTT_CODE_CONTINUE) {
                     BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);
                 }
             }
@@ -6839,6 +6835,36 @@ static int wolfmqtt_broker_dev_derive_key(void* ctx, byte* out_key,
 #endif
 
 #ifdef WOLFMQTT_BROKER_AUTH
+/* Copy a CLI -P password into broker-owned storage and wipe the source argv
+ * slot so the plaintext leaves /proc/<pid>/cmdline. The destination is cleared
+ * first so no residue from a previous -P (or a rejected too-long value)
+ * survives. Exposed as WOLFMQTT_LOCAL for unit tests. */
+WOLFMQTT_LOCAL int wolfmqtt_broker_set_auth_pass(MqttBroker* broker,
+    char* pass_arg, char* auth_pass_buf, word32 auth_pass_buf_sz)
+{
+    word32 pass_len;
+
+    if (broker == NULL || pass_arg == NULL || auth_pass_buf == NULL) {
+        return MQTT_CODE_ERROR_BAD_ARG;
+    }
+    pass_len = (word32)XSTRLEN(pass_arg);
+
+    /* Clear any residue from a previous -P before copying or rejecting. */
+    BROKER_FORCE_ZERO(auth_pass_buf, auth_pass_buf_sz);
+
+    if (pass_len >= auth_pass_buf_sz) {
+        PRINTF("broker: -P password too long (max %d)",
+            (int)auth_pass_buf_sz - 1);
+        BROKER_FORCE_ZERO(pass_arg, pass_len);
+        return MQTT_CODE_ERROR_BAD_ARG;
+    }
+    XMEMCPY(auth_pass_buf, pass_arg, pass_len);
+    auth_pass_buf[pass_len] = '\0';
+    broker->auth_pass = auth_pass_buf;
+    BROKER_FORCE_ZERO(pass_arg, pass_len);
+    return MQTT_CODE_SUCCESS;
+}
+
 /* Wipe the stack copy of the CLI password on every exit path (including the
  * early error returns) so the plaintext does not outlive the call. Matters for
  * NO_MAIN_DRIVER builds that reuse the stack frame across invocations. No-op
@@ -6911,21 +6937,11 @@ int wolfmqtt_broker(int argc, char** argv)
             broker.auth_user = argv[++i];
         }
         else if (XSTRCMP(argv[i], "-P") == 0 && i + 1 < argc) {
-            char* pass_arg = argv[++i];
-            word32 pass_len = (word32)XSTRLEN(pass_arg);
-            /* Copy the password into broker-owned storage and wipe the argv
-             * slot so the plaintext does not linger in /proc/<pid>/cmdline
-             * for the life of the process. */
-            if (pass_len >= (word32)sizeof(auth_pass_buf)) {
-                PRINTF("broker: -P password too long (max %d)",
-                    (int)sizeof(auth_pass_buf) - 1);
-                BROKER_FORCE_ZERO(pass_arg, pass_len);
-                return MQTT_CODE_ERROR_BAD_ARG;
+            rc = wolfmqtt_broker_set_auth_pass(&broker, argv[++i],
+                auth_pass_buf, (word32)sizeof(auth_pass_buf));
+            if (rc != MQTT_CODE_SUCCESS) {
+                return rc;
             }
-            XMEMCPY(auth_pass_buf, pass_arg, pass_len);
-            auth_pass_buf[pass_len] = '\0';
-            broker.auth_pass = auth_pass_buf;
-            BROKER_FORCE_ZERO(pass_arg, pass_len);
         }
 #endif
 #ifdef ENABLE_MQTT_TLS

--- a/src/mqtt_broker_persist_posix.c
+++ b/src/mqtt_broker_persist_posix.c
@@ -70,6 +70,18 @@ static int wmqb_posix_iter(void* ctx, byte ns, MqttBrokerPersist_IterCb cb,
     void* cb_ctx);
 static int wmqb_posix_sync(void* ctx);
 
+/* Secure zeroing via a volatile pointer so the compiler cannot elide the
+ * stores. Kept file-local because MqttClient_ForceZero has hidden linkage
+ * and is not reachable from the standalone broker program. */
+static void wmqb_posix_force_zero(void* mem, word32 len)
+{
+    volatile byte* p = (volatile byte*)mem;
+    word32 i;
+    for (i = 0; i < len; i++) {
+        p[i] = 0;
+    }
+}
+
 /* hex encode key bytes into out (must be 2*key_len+1). Lowercase. */
 static void wmqb_hex_encode(char* out, const byte* in, word16 in_len)
 {
@@ -439,10 +451,16 @@ static int wmqb_posix_iter(void* ctx, byte ns, MqttBrokerPersist_IterCb cb,
         }
         (void)close(fd);
         if (read_total != blob_cap) {
+            /* Scrub the record before releasing the heap buffer. In
+             * encrypt-at-rest builds the blob is ciphertext, so the wipe is
+             * harmless; in plaintext builds it clears session and payload
+             * data from a buffer that would otherwise linger in the heap. */
+            wmqb_posix_force_zero(blob, blob_cap);
             WOLFMQTT_FREE(blob);
             continue;
         }
         stop = cb(key_buf, (word16)kn, blob, blob_cap, cb_ctx);
+        wmqb_posix_force_zero(blob, blob_cap);
         WOLFMQTT_FREE(blob);
         if (stop != 0) {
             break;

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -3837,21 +3837,11 @@ int MqttDecode_Auth(byte *rx_buf, int rx_buf_len, MqttAuth *auth)
                         return tmp;
                     rx_payload += tmp;
                 }
-                else if (auth->reason_code != MQTT_REASON_SUCCESS) {
-                    /* The Reason Code and Property Length can be omitted if
-                       the Reason Code is 0x00 (Success) and there are no
-                       Properties. In this case the AUTH has a Remaining
-                       Length of 0. */
-                    return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
-                }
-                if (auth->props != NULL) {
-                    /* Must have Authentication Method */
-
-                    /* Must have Authentication Data */
-
-                    /* May have zero or more User Property pairs */
-                }
-                else {
+                if (auth->props == NULL) {
+                    /* An AUTH that carries a reason code must also carry
+                       properties (at minimum the Authentication Method). The
+                       short form (reason 0x00 Success, no properties) has a
+                       Remaining Length of 0 and never reaches this branch. */
                     return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
                 }
             }

--- a/src/mqtt_sn_packet.c
+++ b/src/mqtt_sn_packet.c
@@ -558,8 +558,11 @@ int SN_Encode_WillMsg(byte *tx_buf, int tx_buf_len, SN_Will *willMsg)
     int total_len;
     byte *tx_payload;
 
-    /* Validate required arguments */
-    if ((tx_buf == NULL) || (willMsg == NULL)) {
+    /* Validate required arguments. A non-NULL will struct that declares a
+     * non-zero message length must also provide the buffer, mirroring the
+     * WillTopic encoders, so the XMEMCPY below cannot read from NULL. */
+    if ((tx_buf == NULL) || (willMsg == NULL) ||
+            ((willMsg->willMsgLen > 0) && (willMsg->willMsg == NULL))) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
@@ -594,8 +597,10 @@ int SN_Encode_WillMsg(byte *tx_buf, int tx_buf_len, SN_Will *willMsg)
     *tx_payload++ = SN_MSG_TYPE_WILLMSG;
 
     /* Encode Will Message */
-    XMEMCPY(tx_payload, willMsg->willMsg, willMsg->willMsgLen);
-    tx_payload += willMsg->willMsgLen;
+    if (willMsg->willMsgLen > 0) {
+        XMEMCPY(tx_payload, willMsg->willMsg, willMsg->willMsgLen);
+        tx_payload += willMsg->willMsgLen;
+    }
     (void)tx_payload;
 
     return total_len;
@@ -708,8 +713,11 @@ int SN_Encode_WillMsgUpdate(byte *tx_buf, int tx_buf_len, SN_Will *willMsg)
     int total_len;
     byte *tx_payload;
 
-    /* Validate required arguments */
-    if ((tx_buf == NULL) || (willMsg == NULL)) {
+    /* Validate required arguments. A non-NULL will struct that declares a
+     * non-zero message length must also provide the buffer, mirroring the
+     * WillTopic encoders, so the XMEMCPY below cannot read from NULL. */
+    if ((tx_buf == NULL) || (willMsg == NULL) ||
+            ((willMsg->willMsgLen > 0) && (willMsg->willMsg == NULL))) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
@@ -744,8 +752,10 @@ int SN_Encode_WillMsgUpdate(byte *tx_buf, int tx_buf_len, SN_Will *willMsg)
     *tx_payload++ = SN_MSG_TYPE_WILLMSGUPD;
 
     /* Encode Will Message */
-    XMEMCPY(tx_payload, willMsg->willMsg, willMsg->willMsgLen);
-    tx_payload += willMsg->willMsgLen;
+    if (willMsg->willMsgLen > 0) {
+        XMEMCPY(tx_payload, willMsg->willMsg, willMsg->willMsgLen);
+        tx_payload += willMsg->willMsgLen;
+    }
     (void)tx_payload;
 
     return total_len;
@@ -1279,7 +1289,8 @@ int SN_Decode_Publish(byte *rx_buf, int rx_buf_len, SN_Publish *publish)
     byte flags = 0, type;
 
     /* Validate required arguments */
-    if (rx_buf == NULL || publish == NULL) {
+    if (rx_buf == NULL || rx_buf_len < MQTT_PACKET_HEADER_MIN_SIZE ||
+            publish == NULL) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
@@ -1783,27 +1794,33 @@ int SN_Packet_Read(MqttClient *client, byte* rx_buf, int rx_buf_len,
         {
             client->packet.stat = MQTT_PK_READ_HEAD;
 
-            if (total_len > len) {
-                client->packet.remain_len = total_len - len;
-            }
-            else if ((total_len == 2) || (total_len == 4)) {
-                /* Handle peek */
-                if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_DTLS) {
+            if (MqttClient_Flags(client,0,0) & MQTT_CLIENT_FLAG_IS_DTLS) {
+                /* DTLS reads (not peeks) the header, so those bytes are
+                 * already consumed and only the remainder is read at offset
+                 * header_len. */
+                if (total_len > len) {
                     client->packet.remain_len = total_len - len;
                 }
                 else {
-                    client->packet.remain_len = total_len;
+                    client->packet.remain_len = 0;
+                }
+
+                /* Make sure it does not overflow rx_buf */
+                if (client->packet.remain_len >
+                    (rx_buf_len - client->packet.header_len)) {
+                    client->packet.remain_len = rx_buf_len -
+                                                client->packet.header_len;
                 }
             }
             else {
-                client->packet.remain_len = 0;
-            }
+                /* Non-DTLS peeks the header without consuming it, so the whole
+                 * datagram must be re-read from offset 0. */
+                client->packet.remain_len = total_len;
 
-            /* Make sure it does not overflow rx_buf */
-            if (client->packet.remain_len >
-                (rx_buf_len - client->packet.header_len)) {
-                client->packet.remain_len = rx_buf_len -
-                                            client->packet.header_len;
+                /* Make sure it does not overflow rx_buf */
+                if (client->packet.remain_len > rx_buf_len) {
+                    client->packet.remain_len = rx_buf_len;
+                }
             }
         }
         FALL_THROUGH;

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -24,22 +24,6 @@
     #include <config.h>
 #endif
 
-#ifdef WOLFMQTT_NONBLOCK
-    /* need EWOULDBLOCK and EAGAIN */
-    #if defined(WOLFMQTT_WOLFIP)
-        #include "wolfip.h"
-        #define EWOULDBLOCK WOLFIP_EAGAIN
-        #define EAGAIN WOLFIP_EAGAIN
-    #elif defined(MICROCHIP_MPLAB_HARMONY) && \
-        ((__XC32_VERSION < 4000) || (__XC32_VERSION == 243739000))
-        /* xc32 versions >= v4.0 no longer have sys/errno.h */
-        #include <sys/errno.h>
-        #include <errno.h>
-    #else
-        #include <errno.h>
-    #endif
-#endif
-
 #ifdef ENABLE_MQTT_CURL
     #include <curl/curl.h>
 #endif
@@ -215,9 +199,6 @@ int MqttSocket_Write(MqttClient *client, const byte* buf, int buf_len,
             rc = MQTT_CODE_CONTINUE;
         }
     }
-    else if (rc == EWOULDBLOCK || rc == EAGAIN) {
-        rc = MQTT_CODE_CONTINUE;
-    }
 
 #else
     do {
@@ -329,9 +310,6 @@ int MqttSocket_Read(MqttClient *client, byte* buf, int buf_len, int timeout_ms)
         if (client->read.pos < buf_len) {
             rc = MQTT_CODE_CONTINUE;
         }
-    }
-    else if (rc == EWOULDBLOCK || rc == EAGAIN) {
-        rc = MQTT_CODE_CONTINUE;
     }
 
 #else

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -827,6 +827,129 @@ TEST(connect_auth_partial_pass_only_fails_closed)
     MqttBroker_Stop(&broker);
     MqttBroker_Free(&broker);
 }
+
+/* ---------------------------------------------------------------------------
+ * wolfmqtt_broker_set_auth_pass: the CLI -P copy/length/scrub logic. The
+ * argument loop in wolfmqtt_broker is unreachable in the CUSTOM_NET test build
+ * (it returns before parsing), so the helper is exercised directly.
+ * ------------------------------------------------------------------------- */
+
+TEST(broker_set_auth_pass_valid)
+{
+    MqttBroker broker;
+    char pass_arg[BROKER_MAX_PASSWORD_LEN];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+
+    XMEMSET(&broker, 0, sizeof(broker));
+    /* Non-zero fill proves the helper clears the destination before copying. */
+    XMEMSET(auth_pass_buf, 0xAA, sizeof(auth_pass_buf));
+    XMEMSET(pass_arg, 0, sizeof(pass_arg));
+    XMEMCPY(pass_arg, "secretpw", 8);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, wolfmqtt_broker_set_auth_pass(&broker,
+        pass_arg, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    ASSERT_TRUE(broker.auth_pass == auth_pass_buf);
+    ASSERT_EQ(0, XSTRCMP(auth_pass_buf, "secretpw"));
+    /* Source argv slot scrubbed. */
+    ASSERT_EQ('\0', pass_arg[0]);
+}
+
+TEST(broker_set_auth_pass_max_len_valid)
+{
+    MqttBroker broker;
+    char pass_arg[BROKER_MAX_PASSWORD_LEN + 1];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+    int i;
+
+    XMEMSET(&broker, 0, sizeof(broker));
+    XMEMSET(auth_pass_buf, 0, sizeof(auth_pass_buf));
+    XMEMSET(pass_arg, 0, sizeof(pass_arg));
+    /* BROKER_MAX_PASSWORD_LEN-1 characters is the longest accepted. */
+    for (i = 0; i < BROKER_MAX_PASSWORD_LEN - 1; i++) {
+        pass_arg[i] = 'a';
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, wolfmqtt_broker_set_auth_pass(&broker,
+        pass_arg, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    ASSERT_EQ(BROKER_MAX_PASSWORD_LEN - 1, (int)XSTRLEN(auth_pass_buf));
+}
+
+TEST(broker_set_auth_pass_too_long_rejected)
+{
+    MqttBroker broker;
+    char pass_arg[BROKER_MAX_PASSWORD_LEN + 8];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+    int i;
+
+    XMEMSET(&broker, 0, sizeof(broker));
+    XMEMSET(auth_pass_buf, 0, sizeof(auth_pass_buf));
+    XMEMSET(pass_arg, 0, sizeof(pass_arg));
+    /* BROKER_MAX_PASSWORD_LEN characters is one too many. */
+    for (i = 0; i < BROKER_MAX_PASSWORD_LEN; i++) {
+        pass_arg[i] = 'a';
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, wolfmqtt_broker_set_auth_pass(&broker,
+        pass_arg, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    /* The over-long argv slot is still scrubbed. */
+    ASSERT_EQ('\0', pass_arg[0]);
+}
+
+TEST(broker_set_auth_pass_too_long_wipes_prior)
+{
+    /* Repeated -P: a valid password followed by a too-long one must not leave
+     * the first password resident in the broker-owned buffer. */
+    MqttBroker broker;
+    char first[BROKER_MAX_PASSWORD_LEN];
+    char second[BROKER_MAX_PASSWORD_LEN + 8];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+    char zero[BROKER_MAX_PASSWORD_LEN];
+    int i;
+
+    XMEMSET(&broker, 0, sizeof(broker));
+    XMEMSET(auth_pass_buf, 0, sizeof(auth_pass_buf));
+    XMEMSET(zero, 0, sizeof(zero));
+    XMEMSET(first, 0, sizeof(first));
+    XMEMSET(second, 0, sizeof(second));
+    XMEMCPY(first, "firstpw", 7);
+    for (i = 0; i < BROKER_MAX_PASSWORD_LEN; i++) {
+        second[i] = 'b';
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, wolfmqtt_broker_set_auth_pass(&broker,
+        first, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, wolfmqtt_broker_set_auth_pass(&broker,
+        second, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    /* No residue of "firstpw" survives the rejected second argument. */
+    ASSERT_EQ(0, XMEMCMP(auth_pass_buf, zero, sizeof(auth_pass_buf)));
+}
+
+TEST(broker_set_auth_pass_shorter_second_no_residue)
+{
+    /* A shorter second -P must not leave the first password's tail past the
+     * new NUL terminator. */
+    MqttBroker broker;
+    char first[BROKER_MAX_PASSWORD_LEN];
+    char second[BROKER_MAX_PASSWORD_LEN];
+    char auth_pass_buf[BROKER_MAX_PASSWORD_LEN];
+    char zero[BROKER_MAX_PASSWORD_LEN];
+
+    XMEMSET(&broker, 0, sizeof(broker));
+    XMEMSET(auth_pass_buf, 0, sizeof(auth_pass_buf));
+    XMEMSET(zero, 0, sizeof(zero));
+    XMEMSET(first, 0, sizeof(first));
+    XMEMSET(second, 0, sizeof(second));
+    XMEMCPY(first, "longpassword", 12);
+    XMEMCPY(second, "x", 1);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, wolfmqtt_broker_set_auth_pass(&broker,
+        first, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, wolfmqtt_broker_set_auth_pass(&broker,
+        second, auth_pass_buf, (word32)sizeof(auth_pass_buf)));
+    ASSERT_EQ(0, XSTRCMP(auth_pass_buf, "x"));
+    /* Everything after "x\0" is zero - no "longpassword" tail. */
+    ASSERT_EQ(0, XMEMCMP(auth_pass_buf + 1, zero, sizeof(auth_pass_buf) - 1));
+}
 #endif /* WOLFMQTT_BROKER_AUTH */
 
 #ifdef WOLFMQTT_V5
@@ -3490,6 +3613,11 @@ int main(int argc, char** argv)
     RUN_TEST(connect_auth_pass_only_start_rejected);
     RUN_TEST(connect_auth_partial_config_fails_closed);
     RUN_TEST(connect_auth_partial_pass_only_fails_closed);
+    RUN_TEST(broker_set_auth_pass_valid);
+    RUN_TEST(broker_set_auth_pass_max_len_valid);
+    RUN_TEST(broker_set_auth_pass_too_long_rejected);
+    RUN_TEST(broker_set_auth_pass_too_long_wipes_prior);
+    RUN_TEST(broker_set_auth_pass_shorter_second_no_residue);
 #ifndef WOLFMQTT_STATIC_MEMORY
     RUN_TEST(connect_credentials_scrubbed_after_accept);
 #endif

--- a/tests/test_mqtt_sn.c
+++ b/tests/test_mqtt_sn.c
@@ -1222,6 +1222,20 @@ TEST(sn_decode_publish_null_args_rejected)
     ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
 }
 
+TEST(sn_decode_publish_short_buffer_rejected)
+{
+    /* rx_buf_len below the minimum SN header size must be rejected before the
+     * length byte is read out of the caller's buffer. */
+    byte buf[7] = { 0x07, 0x0C, 0x00, 0x00, 0x01, 0x00, 0x00 };
+    SN_Publish publish;
+    int rc;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+
+    rc = SN_Decode_Publish(buf, 1, &publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+}
+
 /* ----------------------------------------------------------------------------
  * MsgId=0 guard for QoS > 0 (report 4248)
  *
@@ -1673,6 +1687,45 @@ TEST(sn_encode_willtopicupd_topic_valid)
 }
 
 /* ============================================================================
+ * SN_Encode_WillMsg / SN_Encode_WillMsgUpdate
+ *
+ * Unlike the WillTopic encoders these size the payload from an explicit
+ * willMsgLen field rather than XSTRLEN, so a caller that sets a non-zero
+ * length but leaves the willMsg buffer NULL would XMEMCPY from NULL. The
+ * encoders must reject that with BAD_ARG, mirroring the WillTopic guard.
+ * ============================================================================ */
+
+TEST(sn_encode_willmsg_null_msg_buffer_rejected)
+{
+    /* Non-zero willMsgLen with a NULL willMsg buffer must be rejected rather
+     * than copied from NULL. */
+    byte tx_buf[32];
+    SN_Will will;
+    int rc;
+
+    XMEMSET(&will, 0, sizeof(will));
+    will.willMsgLen = 4;
+    /* will.willMsg buffer left NULL by the memset */
+
+    rc = SN_Encode_WillMsg(tx_buf, (int)sizeof(tx_buf), &will);
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+}
+
+TEST(sn_encode_willmsgupd_null_msg_buffer_rejected)
+{
+    byte tx_buf[32];
+    SN_Will will;
+    int rc;
+
+    XMEMSET(&will, 0, sizeof(will));
+    will.willMsgLen = 4;
+    /* will.willMsg buffer left NULL by the memset */
+
+    rc = SN_Encode_WillMsgUpdate(tx_buf, (int)sizeof(tx_buf), &will);
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+}
+
+/* ============================================================================
  * SN_Encode_Register
  *
  * topicName is dereferenced unconditionally - XSTRLEN for length sizing and
@@ -1836,6 +1889,7 @@ int main(int argc, char** argv)
     RUN_TEST(sn_decode_publish_predef_topic_type_valid);
     RUN_TEST(sn_decode_publish_short_topic_type_valid);
     RUN_TEST(sn_decode_publish_null_args_rejected);
+    RUN_TEST(sn_decode_publish_short_buffer_rejected);
     RUN_TEST(sn_decode_publish_qos1_zero_packet_id_rejected);
     RUN_TEST(sn_decode_publish_qos2_zero_packet_id_rejected);
     RUN_TEST(sn_decode_publish_qos0_zero_packet_id_valid);
@@ -1867,6 +1921,9 @@ int main(int argc, char** argv)
     RUN_TEST(sn_encode_willtopicupd_null_buf_rejected);
     RUN_TEST(sn_encode_willtopicupd_empty_will_valid);
     RUN_TEST(sn_encode_willtopicupd_topic_valid);
+
+    RUN_TEST(sn_encode_willmsg_null_msg_buffer_rejected);
+    RUN_TEST(sn_encode_willmsgupd_null_msg_buffer_rejected);
 
     RUN_TEST(sn_encode_register_null_topic_string_rejected);
     RUN_TEST(sn_encode_register_null_args_rejected);

--- a/tests/test_mqtt_sn_client.c
+++ b/tests/test_mqtt_sn_client.c
@@ -1462,6 +1462,41 @@ TEST(sn_ping_nonblock_pendresp_lifecycle)
 
 #endif /* WOLFMQTT_NONBLOCK */
 
+/* Regression: on the non-DTLS transport SN_Packet_Read peeks the 2-byte header
+ * without consuming it, so it must re-read the whole datagram from offset 0. It
+ * previously subtracted the peeked header and short-read every frame longer
+ * than two bytes: a 3-byte CONNACK came back as one byte and failed to decode.
+ * Drive the peek path with a 3-byte CONNACK and an 8-byte SUBACK and assert the
+ * full frame length is returned. Runs in blocking and non-blocking builds. */
+static void test_sn_nondtls_reads_full_frames(void)
+{
+    SN_Connect mc;
+    SN_Subscribe sub;
+    int rc, iters;
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, sn_client_init(0));
+    /* Clear the datagram flag so the reader takes the non-DTLS peek path. */
+    (void)MqttClient_Flags(&g_client, MQTT_CLIENT_FLAG_IS_DTLS, 0);
+
+    /* Connect and read a 3-byte CONNACK. Before the fix the peek path
+     * short-read it to a single byte and SN_Decode_Header rejected it, so the
+     * connect failed instead of succeeding. */
+    XMEMSET(&mc, 0, sizeof(mc));
+    mc.client_id = "wolfMQTT-sn-test";
+    mc.protocol_level = SN_PROTOCOL_ID;
+    mc.enable_lwt = 0;
+    mock_net_push(&g_mock, CONNACK_FRAME, (int)sizeof(CONNACK_FRAME));
+    rc = sn_connect_pump(&mc, &iters);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(SN_RC_ACCEPTED, mc.ack.return_code);
+
+    /* Subscribe and read an 8-byte SUBACK through the same non-DTLS path. */
+    sn_subscribe_setup(&sub);
+    mock_net_push(&g_mock, SUBACK_FRAME, (int)sizeof(SUBACK_FRAME));
+    rc = sn_subscribe_pump(&sub, &iters);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
 #endif /* WOLFMQTT_SN */
 
 /* ============================================================================
@@ -1493,6 +1528,7 @@ int main(int argc, char** argv)
     RUN_TEST(sn_publish_incoming_null_msg_cb_errors_no_ack);
     RUN_TEST(sn_ping_no_continue);
     RUN_TEST(sn_ping_null_no_continue);
+    RUN_TEST(sn_nondtls_reads_full_frames);
 
     /* The non-blocking retry regression only exists under WOLFMQTT_NONBLOCK. */
 #ifdef WOLFMQTT_NONBLOCK

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -758,6 +758,15 @@ WOLFMQTT_API int MqttBroker_Free(MqttBroker* broker);
  * For embedded systems that use a cooperative main loop with Step(). */
 WOLFMQTT_API int MqttBroker_Start(MqttBroker* broker);
 
+#ifdef WOLFMQTT_BROKER_AUTH
+/* Internal: copy a CLI -P password into broker-owned storage, clearing any
+ * prior residue and wiping the source argv slot. Returns
+ * MQTT_CODE_ERROR_BAD_ARG if the password does not fit. WOLFMQTT_LOCAL keeps
+ * it out of the public ABI; exposed for unit tests. */
+WOLFMQTT_LOCAL int wolfmqtt_broker_set_auth_pass(MqttBroker* broker,
+    char* pass_arg, char* auth_pass_buf, word32 auth_pass_buf_sz);
+#endif
+
 /* wolfIP backend initializer.
  * wolfIP_stack is a (struct wolfIP*) pointer to the wolfIP stack instance. */
 #ifdef WOLFMQTT_WOLFIP


### PR DESCRIPTION
* f-7478: check and return the BrokerPersist_Restore error in MqttBroker_Start instead of discarding it
* f-7479: re-read the full datagram from offset 0 on the non-DTLS MQTT-SN peek path instead of short-reading the header
* f-7485: copy the -P broker password into private storage and scrub the argv slot so it leaves /proc/<pid>/cmdline
* f-7476: same -P argv password exposure as f-7485, resolved by the same copy and scrub
* f-7480: remove the unreachable EWOULDBLOCK/EAGAIN branch in MqttSocket_Read and MqttSocket_Write
* f-7481: reject a non-zero willMsgLen with a NULL willMsg buffer in SN_Encode_WillMsg and SN_Encode_WillMsgUpdate
* f-7482: propagate a fatal MqttBroker_Step error from MqttBroker_Run instead of always returning success
* f-7486: zeroize the subscriber tx_buf after forwarding a PUBLISH in the drain and static fan-out paths
* f-7487: clear the BrokerLog_Sanitize pool slot before reuse so no credential residue survives past a rotation
* f-7488: zeroize restored persist records before freeing them in the POSIX backend
* f-7477: zeroize subscription topic filters before freeing them
* f-7483: drop the redundant reason-code guard in MqttDecode_Auth
* f-7484: validate rx_buf_len in SN_Decode_Publish before reading the length byte
