### PR TITLE
Fenrir fixes: MQTT v5 client and broker

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,25 @@
       `mqttclient` example now relies on the automatic ping, keeping its
       previous manual keep-alive loop under `WOLFMQTT_NO_TIME` (#501)
 
+* API / Behavior Changes
+    - A v5 `CONNECT` now advertises `Receive Maximum` set to
+      `MQTT_MAX_RECV_QOS2` (16 by default) unless the application supplied its
+      own `MQTT_PROP_RECEIVE_MAX`. This bounds the QoS 1 and QoS 2 PUBLISH
+      packets a conforming server may have in flight toward the client
+      [MQTT-3.3.4], keeping inbound QoS 2 within the client's de-duplication
+      table so a retransmitted PUBLISH cannot be delivered twice
+      [MQTT-4.3.3-10]. Override `MQTT_MAX_RECV_QOS2` in `user_settings.h` to
+      trade memory for a larger window, or set the property explicitly to keep
+      full control.
+    - In `WOLFMQTT_MULTITHREAD` builds, a QoS 2 PUBREC rejection processed by
+      the reading thread now also completes the originating
+      `MqttClient_Publish_WriteOnly` pending response with
+      `MQTT_CODE_ERROR_PUBLISH_REJECTED`, so the publisher's next poll returns
+      that error instead of spinning on `MQTT_CODE_CONTINUE` until
+      `cmd_timeout_ms`. This is the only v5 rejection surfaced on the write-only
+      path; a QoS 1 PUBACK or QoS 2 PUBCOMP reason code >= 0x80 is still not
+      detected there. Supersedes the v2.1.0 note below.
+
 ### v2.1.0 (07/02/2026)
 Release 2.1.0 has been developed according to wolfSSL's development and QA
 process (see link below) and successfully passed the quality criteria.

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -44,6 +44,14 @@
     #define NUM_PUB_PER_TASK 2
 #endif
 
+/* How many cmd_timeout_ms intervals a write-only publish may spend waiting for
+   the reader thread to complete its acknowledgement before the timeout is
+   treated as terminal. Bounds the poll loop in publish_task against a broker
+   that never acknowledges. */
+#ifndef PUBLISH_ACK_MAX_TIMEOUTS
+    #define PUBLISH_ACK_MAX_TIMEOUTS 3
+#endif
+
 /* Maximum size for network read/write callbacks. There is also a v5 define that
    describes the max MQTT control packet size, DEFAULT_MAX_PKT_SZ. */
 #ifndef MAX_BUFFER_SIZE
@@ -655,6 +663,7 @@ static void *publish_task(void *param)
     MQTTCtx *mqttCtx = (MQTTCtx*)param;
     MqttPublish publish[NUM_PUB_PER_TASK];
     word32 startSec[NUM_PUB_PER_TASK];
+    int acktimeouts[NUM_PUB_PER_TASK];
 
     /* Build publish */
     for (i=0; i<NUM_PUB_PER_TASK; i++) {
@@ -670,6 +679,7 @@ static void *publish_task(void *param)
 
         rc[i] = MQTT_CODE_CONTINUE;
         startSec[i] = 0;
+        acktimeouts[i] = 0;
     }
 
     /* Send until complete. A write-only publish returns MQTT_CODE_CONTINUE
@@ -686,8 +696,14 @@ static void *publish_task(void *param)
                 MQTT_PACKET_TYPE_PUBLISH, mqttCtx->cmd_timeout_ms);
         #ifndef WOLFMQTT_TEST_CANCEL
             /* A benign poll timeout is not a failure for an in-flight write-only
-             * publish; keep waiting for the reader thread to finish its ack. */
-            if (rc[i] == MQTT_CODE_ERROR_TIMEOUT) {
+             * publish; keep waiting for the reader thread to finish its ack.
+             * Bounded, though: mqtt_check_timeout restarts its interval every
+             * time it reports a timeout, so converting every one back to
+             * MQTT_CODE_CONTINUE would poll forever against a broker that never
+             * acknowledges, and this thread would never join. After
+             * PUBLISH_ACK_MAX_TIMEOUTS intervals the timeout stays terminal. */
+            if (rc[i] == MQTT_CODE_ERROR_TIMEOUT &&
+                    ++acktimeouts[i] < PUBLISH_ACK_MAX_TIMEOUTS) {
                 rc[i] = MQTT_CODE_CONTINUE;
             }
         #endif

--- a/examples/multithread/multithread.c
+++ b/examples/multithread/multithread.c
@@ -672,19 +672,34 @@ static void *publish_task(void *param)
         startSec[i] = 0;
     }
 
-    /* Send until != continue */
+    /* Send until complete. A write-only publish returns MQTT_CODE_CONTINUE
+     * while its acknowledgement is still outstanding; the reader thread
+     * completes that ack, so keep polling until it reports success rather than
+     * abandoning an in-flight publish. Cancelling one whose PUBLISH already
+     * reached the wire cannot reclaim its Receive Maximum unit until reconnect,
+     * since the server keeps counting it [MQTT-4.9]. */
     for (i=0; i<NUM_PUB_PER_TASK; i++) {
         while (rc[i] == MQTT_CODE_CONTINUE) {
             rc[i] = MqttClient_Publish_WriteOnly(&mqttCtx->client, &publish[i],
                 NULL);
             rc[i] = check_response(mqttCtx, rc[i], &startSec[i],
                 MQTT_PACKET_TYPE_PUBLISH, mqttCtx->cmd_timeout_ms);
+        #ifndef WOLFMQTT_TEST_CANCEL
+            /* A benign poll timeout is not a failure for an in-flight write-only
+             * publish; keep waiting for the reader thread to finish its ack. */
+            if (rc[i] == MQTT_CODE_ERROR_TIMEOUT) {
+                rc[i] = MQTT_CODE_CONTINUE;
+            }
+        #endif
         }
     }
 
     /* Report result */
     for (i=0; i<NUM_PUB_PER_TASK; i++) {
-        if (rc[i] != MQTT_CODE_SUCCESS) {
+        /* Only cancel on a genuine terminal error, never a publish still in
+         * flight (MQTT_CODE_CONTINUE): cancelling one whose PUBLISH is already
+         * on the wire forfeits its reserved Receive Maximum unit [MQTT-4.9]. */
+        if (rc[i] != MQTT_CODE_SUCCESS && rc[i] != MQTT_CODE_CONTINUE) {
             MqttClient_CancelMessage(&mqttCtx->client, (MqttObject*)&publish[i]);
         }
 

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -1044,6 +1044,7 @@ static BrokerClient* BrokerClient_AddWs(MqttBroker* broker, struct lws *wsi)
 #ifndef WOLFMQTT_STATIC_MEMORY
         bc->next = broker->clients;
         broker->clients = bc;
+        broker->clients_gen++;
 #endif
         WBLOG_INFO(broker, "broker: ws client added (wsi=%p)", (void*)wsi);
     }
@@ -2453,6 +2454,7 @@ static BrokerClient* BrokerClient_Add(MqttBroker* broker,
         /* Prepend to linked list */
         bc->next = broker->clients;
         broker->clients = bc;
+        broker->clients_gen++;
 #endif
     }
     else if (bc != NULL) {
@@ -2495,6 +2497,7 @@ static void BrokerClient_Remove(MqttBroker* broker, BrokerClient* bc)
      * (e.g. WebSocket LWS_CALLBACK_CLOSED during a takeover fan-out) can have
      * already removed and freed bc; freeing again here would double-free. */
     if (found) {
+        broker->clients_gen++;
         BrokerClient_Free(bc);
     }
 #else
@@ -3951,24 +3954,99 @@ static void BrokerSubs_EndClientSession(MqttBroker* broker, BrokerClient* bc)
 }
 
 #ifndef WOLFMQTT_STATIC_MEMORY
-/* Confirm a fan-out loop's snapshotted successor is still linked in
- * broker->subs. A peer-initiated WS LWS_CALLBACK_CLOSED delivered during a
- * fan-out write runs BrokerSubs_RemoveClient, which frees every BrokerSub owned
- * by the closing subscriber. That set can include the node a loop saved as
- * next_sub, so the snapshot guards only against sub->next moving, not against
- * next_sub itself being freed. Re-check it before the next dereference,
- * mirroring the client-list revalidation in MqttBroker_Step. */
-static int BrokerSubs_StillLinked(const MqttBroker* broker,
-    const BrokerSub* node)
+/* Confirm a snapshotted fan-out destination is still a live client. Writing to
+ * one subscriber can drive an lws_service spin whose LWS_CALLBACK_CLOSED fires
+ * for a *different* subscriber; only the client whose own write is spinning has
+ * ws->processing set and gets deferred removal, so that peer's BrokerClient is
+ * unlinked and freed immediately. A destination collected before the write must
+ * therefore be re-checked against broker->clients before it is used. Gated on
+ * clients_gen so the common (nothing removed) case stays O(1). */
+static int BrokerClients_StillLinked(const MqttBroker* broker,
+    const BrokerClient* bc)
 {
-    const BrokerSub* cur = broker->subs;
+    const BrokerClient* cur = broker->clients;
     while (cur != NULL) {
-        if (cur == node) {
+        if (cur == bc) {
             return 1;
         }
         cur = cur->next;
     }
     return 0;
+}
+
+/* One resolved fan-out destination. Collected in a pass that performs no
+ * writes, so the walk of broker->subs cannot be disturbed part way through and
+ * the BrokerSub nodes are never dereferenced again once delivery starts. */
+typedef struct BrokerFanoutTarget {
+    BrokerClient* client;
+    MqttQoS       qos;      /* already narrowed against the subscription */
+} BrokerFanoutTarget;
+
+/* Destinations a fan-out can hold without allocating. Sized for the common
+ * handful of subscribers on a topic; beyond it the list moves to the heap. */
+#ifndef BROKER_FANOUT_STACK_TARGETS
+    #define BROKER_FANOUT_STACK_TARGETS 16
+#endif
+
+/* Growable destination list backed by a caller-supplied stack array. `heap` is
+ * non-NULL once it has outgrown that array, and `truncated` records that an
+ * allocation failed so the caller can report the dropped deliveries rather than
+ * silently fanning out to a subset. */
+typedef struct BrokerFanoutList {
+    BrokerFanoutTarget* items;
+    BrokerFanoutTarget* heap;
+    int count;
+    int cap;
+    int truncated;
+} BrokerFanoutList;
+
+static void BrokerFanout_Init(BrokerFanoutList* fl, BrokerFanoutTarget* stack,
+    int cap)
+{
+    fl->items = stack;
+    fl->heap = NULL;
+    fl->count = 0;
+    fl->cap = cap;
+    fl->truncated = 0;
+}
+
+static void BrokerFanout_Add(BrokerFanoutList* fl, BrokerClient* client,
+    MqttQoS qos)
+{
+    if (fl->truncated) {
+        return;
+    }
+    if (fl->count == fl->cap) {
+        int new_cap = fl->cap * 2;
+        BrokerFanoutTarget* grown = (BrokerFanoutTarget*)WOLFMQTT_MALLOC(
+            (size_t)new_cap * sizeof(BrokerFanoutTarget));
+        if (grown == NULL) {
+            fl->truncated = 1;
+            return;
+        }
+        XMEMCPY(grown, fl->items,
+            (size_t)fl->count * sizeof(BrokerFanoutTarget));
+        if (fl->heap != NULL) {
+            WOLFMQTT_FREE(fl->heap);
+        }
+        fl->heap = grown;
+        fl->items = grown;
+        fl->cap = new_cap;
+    }
+    fl->items[fl->count].client = client;
+    fl->items[fl->count].qos = qos;
+    fl->count++;
+}
+
+static void BrokerFanout_Free(BrokerFanoutList* fl)
+{
+    if (fl->heap != NULL) {
+        WOLFMQTT_FREE(fl->heap);
+        fl->heap = NULL;
+    }
+    fl->items = NULL;
+    fl->count = 0;
+    fl->cap = 0;
 }
 #endif
 
@@ -5402,8 +5480,10 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
     int i;
 #else
     BrokerSub* sub;
-    BrokerSub* next_sub = NULL;
-    word32 subs_gen_snapshot = 0;
+    BrokerFanoutTarget stack_targets[BROKER_FANOUT_STACK_TARGETS];
+    BrokerFanoutList targets;
+    word32 clients_gen_snapshot;
+    int t;
 #endif
 
     if (broker == NULL || topic == NULL) {
@@ -5430,25 +5510,11 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
     for (i = 0; i < BROKER_MAX_SUBS; i++) {
         BrokerSub* sub = &broker->subs[i];
         if (!sub->in_use) continue;
-#else
-    sub = broker->subs;
-    while (sub) {
-        /* Snapshot the successor before any MqttPacket_Write: a WS fan-out
-         * write can drive an lws_service spin whose re-entrant CLOSED frees
-         * this client's BrokerSub nodes, so reading sub->next afterwards
-         * would dereference a freed node. Also snapshot the subs generation so
-         * next_sub is only re-validated when a free actually happened. */
-        next_sub = sub->next;
-        subs_gen_snapshot = broker->subs_gen;
-#endif
         if (sub->client != NULL && sub->client->protocol_level != 0 &&
-#ifdef WOLFMQTT_STATIC_MEMORY
             sub->client->connected &&
-#endif
             BROKER_STR_VALID(sub->filter) &&
             BrokerTopicMatch(sub->filter, topic)) {
             MqttQoS eff_qos = (qos < sub->qos) ? qos : sub->qos;
-#ifdef WOLFMQTT_STATIC_MEMORY
             if (eff_qos >= MQTT_QOS_1) {
                 BrokerStaticOrphanSession* orphan =
                     BrokerStaticOrphan_Find(broker,
@@ -5486,72 +5552,9 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                     continue;
                 }
             }
-#else
-            if (eff_qos >= MQTT_QOS_1) {
-                /* Route QoS 1/2 through out_q so it survives reconnect. A full
-                 * queue must not silently drop an accepted Will: disconnect the
-                 * slow subscriber with Quota Exceeded, matching the live PUBLISH
-                 * fan-out policy. Gate on connected (not sock) so a WebSocket
-                 * client - which uses ws_ctx with sock == INVALID - is still
-                 * torn down, and a client with several matching subscriptions is
-                 * not disconnected twice. Clearing connected lets the reaper
-                 * close the transport (BrokerClient_Remove -> ws disconnect). */
-                if (sub->client->out_q_count >=
-                        BROKER_MAX_QUEUED_MSGS_PER_SUB) {
-                    BrokerClient* c = sub->client;
-                    if (c->connected) {
-                        WBLOG_ERR(broker,
-                            "broker: will out_q full (%d) -> disconnect sock=%d",
-                            c->out_q_count, (int)c->sock);
-                    #ifdef WOLFMQTT_V5
-                        (void)BrokerSend_Disconnect(c,
-                            MQTT_REASON_QUOTA_EXCEEDED);
-                    #endif
-                        if (c->sock != BROKER_SOCKET_INVALID) {
-                            broker->net.close(broker->net.ctx, c->sock);
-                            c->sock = BROKER_SOCKET_INVALID;
-                        }
-                        c->connected = 0;
-                    }
-                }
-                else {
-                    BrokerOutPub* e = BrokerOutPub_Alloc(topic,
-                        (payload_len > 0) ? payload : NULL, payload_len
-                    #ifdef WOLFMQTT_V5
-                        , NULL
-                    #endif
-                        );
-                    if (e == NULL) {
-                        WBLOG_ERR(broker,
-                            "broker: will alloc failed sock=%d",
-                            (int)sub->client->sock);
-                    }
-                    else {
-                        e->qos = eff_qos;
-                        e->packet_id = BrokerNextPacketId(broker);
-                        e->retain = 0;
-                        e->state = BROKER_OUTQ_QUEUED;
-                    #ifdef WOLFMQTT_V5
-                        e->protocol_level = sub->client->protocol_level;
-                    #endif
-                        BrokerClient_EnqueueOutPub(sub->client, e);
-                        BrokerClient_DrainOutQueue(sub->client);
-                    }
-                }
-            }
-            /* QoS 0 is best effort; skip while tx_buf holds an in-flight
-             * CONNACK. */
-            else if (sub->client->connack_pending_len == 0)
-#endif
             {
                 MqttPublish out_pub;
                 int enc_rc, wr_rc;
-                /* Cache the client before the write: MqttPacket_Write can drive
-                 * a re-entrant WS close that frees this subscriber's BrokerSub
-                 * nodes (this `sub`), while the BrokerClient itself survives via
-                 * deferred removal. Reaching it through the freed `sub` after
-                 * the write would be a use-after-free; go through wc instead,
-                 * mirroring BrokerHandle_Publish. */
                 BrokerClient* wc = sub->client;
                 XMEMSET(&out_pub, 0, sizeof(out_pub));
                 out_pub.topic_name = (char*)topic;
@@ -5578,7 +5581,6 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                 }
             }
         }
-#ifdef WOLFMQTT_STATIC_MEMORY
         else if ((sub->client == NULL || !sub->client->connected) &&
                 BROKER_STR_VALID(sub->client_id) &&
                 BROKER_STR_VALID(sub->filter) &&
@@ -5603,18 +5605,123 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                 }
             }
         }
-#endif
-#ifndef WOLFMQTT_STATIC_MEMORY
-        /* The write above can drive a re-entrant WS close that frees next_sub.
-         * Only re-validate it when a subscription was actually removed during
-         * the write (generation changed), so the common case stays O(1). */
-        if (next_sub != NULL && broker->subs_gen != subs_gen_snapshot &&
-                !BrokerSubs_StillLinked(broker, next_sub)) {
-            break;
-        }
-        sub = next_sub;
-#endif
     }
+#else
+    /* Two phases. The collect pass performs no writes, so broker->subs cannot
+     * be mutated part way through it; delivery then works only from the
+     * collected BrokerClient pointers and never dereferences a BrokerSub again.
+     * Walking and writing in one pass is not safe: a write can drive an
+     * lws_service spin whose re-entrant LWS_CALLBACK_CLOSED frees the closing
+     * subscriber's BrokerSub nodes, including the node this loop would advance
+     * to next, and abandoning the walk there would silently drop every
+     * still-connected subscriber after it. */
+    BrokerFanout_Init(&targets, stack_targets, BROKER_FANOUT_STACK_TARGETS);
+    for (sub = broker->subs; sub != NULL; sub = sub->next) {
+        if (sub->client != NULL && sub->client->protocol_level != 0 &&
+            BROKER_STR_VALID(sub->filter) &&
+            BrokerTopicMatch(sub->filter, topic)) {
+            BrokerFanout_Add(&targets, sub->client,
+                (qos < sub->qos) ? qos : sub->qos);
+        }
+    }
+    if (targets.truncated) {
+        WBLOG_ERR(broker,
+            "broker: will fan-out list alloc failed after %d destination(s), "
+            "remaining subscribers not served topic=%s",
+            targets.count, BrokerLog_Sanitize(topic));
+    }
+
+    clients_gen_snapshot = broker->clients_gen;
+    for (t = 0; t < targets.count; t++) {
+        BrokerClient* wc = targets.items[t].client;
+        MqttQoS eff_qos = targets.items[t].qos;
+
+        /* An earlier delivery in this fan-out can have closed this peer, and a
+         * peer that is not the one being written to is freed outright rather
+         * than deferred. Only rescan when the client list actually changed. */
+        if (broker->clients_gen != clients_gen_snapshot &&
+                !BrokerClients_StillLinked(broker, wc)) {
+            continue;
+        }
+
+        if (eff_qos >= MQTT_QOS_1) {
+            /* Route QoS 1/2 through out_q so it survives reconnect. A full
+             * queue must not silently drop an accepted Will: disconnect the
+             * slow subscriber with Quota Exceeded, matching the live PUBLISH
+             * fan-out policy. Gate on connected (not sock) so a WebSocket
+             * client - which uses ws_ctx with sock == INVALID - is still
+             * torn down, and a client with several matching subscriptions is
+             * not disconnected twice. Clearing connected lets the reaper
+             * close the transport (BrokerClient_Remove -> ws disconnect). */
+            if (wc->out_q_count >= BROKER_MAX_QUEUED_MSGS_PER_SUB) {
+                if (wc->connected) {
+                    WBLOG_ERR(broker,
+                        "broker: will out_q full (%d) -> disconnect sock=%d",
+                        wc->out_q_count, (int)wc->sock);
+                #ifdef WOLFMQTT_V5
+                    (void)BrokerSend_Disconnect(wc,
+                        MQTT_REASON_QUOTA_EXCEEDED);
+                #endif
+                    if (wc->sock != BROKER_SOCKET_INVALID) {
+                        broker->net.close(broker->net.ctx, wc->sock);
+                        wc->sock = BROKER_SOCKET_INVALID;
+                    }
+                    wc->connected = 0;
+                }
+            }
+            else {
+                BrokerOutPub* e = BrokerOutPub_Alloc(topic,
+                    (payload_len > 0) ? payload : NULL, payload_len
+                #ifdef WOLFMQTT_V5
+                    , NULL
+                #endif
+                    );
+                if (e == NULL) {
+                    WBLOG_ERR(broker,
+                        "broker: will alloc failed sock=%d", (int)wc->sock);
+                }
+                else {
+                    e->qos = eff_qos;
+                    e->packet_id = BrokerNextPacketId(broker);
+                    e->retain = 0;
+                    e->state = BROKER_OUTQ_QUEUED;
+                #ifdef WOLFMQTT_V5
+                    e->protocol_level = wc->protocol_level;
+                #endif
+                    BrokerClient_EnqueueOutPub(wc, e);
+                    BrokerClient_DrainOutQueue(wc);
+                }
+            }
+        }
+        /* QoS 0 is best effort; skip while tx_buf holds an in-flight
+         * CONNACK. */
+        else if (wc->connack_pending_len == 0) {
+            MqttPublish out_pub;
+            int enc_rc, wr_rc;
+
+            XMEMSET(&out_pub, 0, sizeof(out_pub));
+            out_pub.topic_name = (char*)topic;
+            out_pub.qos = eff_qos;
+            out_pub.retain = 0;
+            out_pub.duplicate = 0;
+            out_pub.buffer = (payload_len > 0) ? (byte*)payload : NULL;
+            out_pub.total_len = payload_len;
+        #ifdef WOLFMQTT_V5
+            out_pub.protocol_level = wc->protocol_level;
+        #endif
+            enc_rc = MqttEncode_Publish(wc->tx_buf,
+                BROKER_CLIENT_TX_SZ(wc), &out_pub, 0);
+            if (enc_rc > 0) {
+                wr_rc = MqttPacket_Write(&wc->client, wc->tx_buf, enc_rc);
+                /* Scrub tx_buf unless still in-progress (CONTINUE). */
+                if (wr_rc != MQTT_CODE_CONTINUE) {
+                    BROKER_FORCE_ZERO(wc->tx_buf, enc_rc);
+                }
+            }
+        }
+    }
+    BrokerFanout_Free(&targets);
+#endif
 }
 #endif /* WOLFMQTT_BROKER_WILL */
 
@@ -7196,33 +7303,23 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
     #endif
         topic != NULL && (payload != NULL || pub.total_len == 0)) {
 #ifndef WOLFMQTT_STATIC_MEMORY
-        BrokerSub* sub = broker->subs;
-        BrokerSub* next_sub = NULL;
-        word32 subs_gen_snapshot = 0;
+        BrokerSub* sub;
+        BrokerFanoutTarget stack_targets[BROKER_FANOUT_STACK_TARGETS];
+        BrokerFanoutList targets;
+        word32 clients_gen_snapshot;
+        int t;
 #endif
         /* Fan out to matching subscribers */
 #ifdef WOLFMQTT_STATIC_MEMORY
         for (i = 0; i < BROKER_MAX_SUBS; i++) {
             sub = &broker->subs[i];
             if (!sub->in_use) continue;
-#else
-        while (sub) {
-            /* Snapshot the successor before any MqttPacket_Write: a fan-out
-             * write can drive an lws_service spin that frees this client's
-             * BrokerSub nodes re-entrantly (LWS_CALLBACK_CLOSED), so reading
-             * sub->next afterwards would dereference a freed node. Also snapshot
-             * the subs generation so next_sub is only re-validated when a free
-             * actually happened. */
-            next_sub = sub->next;
-            subs_gen_snapshot = broker->subs_gen;
-#endif
             if (sub->client != NULL &&
                 sub->client->protocol_level != 0 &&
                 sub->client->connected &&
                 BROKER_STR_VALID(sub->filter) &&
                 BrokerTopicMatch(sub->filter, topic)) {
                 eff_qos = (pub.qos < sub->qos) ? pub.qos : sub->qos;
-#ifdef WOLFMQTT_STATIC_MEMORY
                 queued_session = BrokerStaticOrphan_Find(broker,
                     sub->client->client_id);
                 if (eff_qos > MQTT_QOS_0 && queued_session != NULL) {
@@ -7298,91 +7395,7 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                         "sock=%d -> sock=%d rc=%d",
                         (int)bc->sock, (int)sub->client->sock, sub_rc);
                 }
-#else
-                /* Dynamic mode: enqueue a heap-owned copy on the
-                 * subscriber's out_q, then drain. The queue gives us
-                 * the inflight cap (#7 ordered delivery) and is the
-                 * substrate for the offline queue in PR2. Invariant:
-                 * MqttDecode_Publish above has populated pub.buffer
-                 * with at least pub.total_len contiguous bytes (full
-                 * PUBLISH is fully received and decoded before we
-                 * reach the fan-out); BrokerOutPub_Alloc deep-copies
-                 * pub.total_len from that buffer. */
-                if (sub->client->out_q_count >=
-                        BROKER_MAX_QUEUED_MSGS_PER_SUB) {
-                    /* DoS guard: bound the connected subscriber's outbound
-                     * queue depth. The inflight cap above only limits bytes on
-                     * the wire; a subscriber that stops acking lets QUEUED
-                     * entries accumulate one heap-copied PUBLISH at a time
-                     * until the broker exhausts memory. Disconnect the slow /
-                     * abusive subscriber rather than growing out_q or silently
-                     * dropping accepted QoS 1/2 messages. A persistent session
-                     * is reclaimable on reconnect via the (capped) offline
-                     * queue. Mirrors the static partial-write teardown: tear
-                     * the socket down and clear connected so the match guard
-                     * above skips this client's remaining subscriptions; the
-                     * main loop reaps it on the next read error. */
-                    /* Cache the client before BrokerSend_Disconnect below: that
-                     * write can drive an lws_service spin whose
-                     * LWS_CALLBACK_CLOSED frees this subscriber's BrokerSub
-                     * nodes re-entrantly (the same hazard the next_sub snapshot
-                     * guards against), leaving `sub` dangling. The BrokerClient
-                     * itself survives the write - its free is deferred while the
-                     * WS context is marked processing - so the post-write socket
-                     * teardown must reach it through this cached pointer, never
-                     * through the freed sub node. */
-                    BrokerClient* c = sub->client;
-                    WBLOG_ERR(broker,
-                        "broker: out_q full (%d) -> disconnect sock=%d "
-                        "(from sock=%d)", c->out_q_count,
-                        (int)c->sock, (int)bc->sock);
-                #ifdef WOLFMQTT_V5
-                    (void)BrokerSend_Disconnect(c,
-                        MQTT_REASON_QUOTA_EXCEEDED);
-                #endif
-                    if (c->sock != BROKER_SOCKET_INVALID) {
-                        broker->net.close(broker->net.ctx,
-                            c->sock);
-                        c->sock = BROKER_SOCKET_INVALID;
-                    }
-                    c->connected = 0;
-                }
-                else {
-                    BrokerOutPub* e = BrokerOutPub_Alloc(topic, payload,
-                                          pub.total_len
-                    #ifdef WOLFMQTT_V5
-                                          , pub.props
-                    #endif
-                                          );
-                    if (e == NULL) {
-                        WBLOG_ERR(broker,
-                            "broker: PUBLISH fwd alloc failed sock=%d "
-                            "-> sock=%d", (int)bc->sock,
-                            (int)sub->client->sock);
-                    }
-                    else {
-                        e->qos = eff_qos;
-                        if (eff_qos >= MQTT_QOS_1) {
-                            e->packet_id = BrokerNextPacketId(broker);
-                        }
-                        e->retain = 0;
-                        e->state = BROKER_OUTQ_QUEUED;
-                    #ifdef WOLFMQTT_V5
-                        e->protocol_level = sub->client->protocol_level;
-                    #endif
-                        BrokerClient_EnqueueOutPub(sub->client, e);
-                        WBLOG_DBG(broker,
-                            "broker: PUBLISH enq sock=%d -> sock=%d "
-                            "topic=%s qos=%d len=%u",
-                            (int)bc->sock, (int)sub->client->sock,
-                            BrokerLog_Sanitize(topic), eff_qos,
-                            (unsigned)pub.total_len);
-                        BrokerClient_DrainOutQueue(sub->client);
-                    }
-                }
-#endif
             }
-#ifdef WOLFMQTT_STATIC_MEMORY
             else if ((sub->client == NULL || !sub->client->connected) &&
                      BROKER_STR_VALID(sub->client_id) &&
                      BROKER_STR_VALID(sub->filter) &&
@@ -7419,19 +7432,35 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                     }
                 }
             }
+        }
 #else
-            /* Note on iteration model: static-mode walks the BrokerSub
-             * array via for (i=0; i<BROKER_MAX_SUBS; i++) and gets its
-             * advance from i++. Dynamic-mode walks the linked list and
-             * needs an explicit sub = sub->next below. The orphan
-             * branch (sub->client == NULL) only exists in dynamic mode -
-             * static-mode orphan handling lives in the restore path. */
+        /* Two phases. The collect pass performs no writes - the orphan queueing
+         * below never touches the wire - so broker->subs cannot be mutated part
+         * way through it, and delivery then works only from the collected
+         * BrokerClient pointers. Walking and writing in one pass is not safe: a
+         * write can drive an lws_service spin whose re-entrant
+         * LWS_CALLBACK_CLOSED frees the closing subscriber's BrokerSub nodes,
+         * including the node this loop would advance to next, and abandoning
+         * the walk there would silently drop every still-connected subscriber
+         * after it. */
+        BrokerFanout_Init(&targets, stack_targets,
+            BROKER_FANOUT_STACK_TARGETS);
+        for (sub = broker->subs; sub != NULL; sub = sub->next) {
+            if (sub->client != NULL &&
+                sub->client->protocol_level != 0 &&
+                sub->client->connected &&
+                BROKER_STR_VALID(sub->filter) &&
+                BrokerTopicMatch(sub->filter, topic)) {
+                BrokerFanout_Add(&targets, sub->client,
+                    (pub.qos < sub->qos) ? pub.qos : sub->qos);
+            }
+            /* Orphaned persistent session: subscriber is currently
+             * disconnected. Queue QoS 1/2 messages on the orphan slot for
+             * delivery on reconnect. Pure bookkeeping, so it stays in this
+             * pass. */
             else if (sub->client == NULL && sub->client_id != NULL &&
                      BROKER_STR_VALID(sub->filter) &&
                      BrokerTopicMatch(sub->filter, topic)) {
-                /* Orphaned persistent session: subscriber is currently
-                 * disconnected. Queue QoS 1/2 messages on the orphan
-                 * slot for delivery on reconnect. */
                 eff_qos = (pub.qos < sub->qos) ? pub.qos : sub->qos;
                 if (eff_qos > MQTT_QOS_0) {
                     BrokerOrphanSession* o =
@@ -7446,17 +7475,105 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                     }
                 }
             }
-            /* The write above can drive a re-entrant WS close that frees
-             * next_sub. Only re-validate it when a subscription was actually
-             * removed during the write (generation changed), so the common
-             * case stays O(1). */
-            if (next_sub != NULL && broker->subs_gen != subs_gen_snapshot &&
-                    !BrokerSubs_StillLinked(broker, next_sub)) {
-                break;
-            }
-            sub = next_sub;
-#endif
         }
+        if (targets.truncated) {
+            WBLOG_ERR(broker,
+                "broker: fan-out list alloc failed after %d destination(s), "
+                "remaining subscribers not served sock=%d topic=%s",
+                targets.count, (int)bc->sock, BrokerLog_Sanitize(topic));
+        }
+
+        clients_gen_snapshot = broker->clients_gen;
+        for (t = 0; t < targets.count; t++) {
+            BrokerClient* wc = targets.items[t].client;
+
+            eff_qos = targets.items[t].qos;
+
+            /* An earlier delivery in this fan-out can have closed this peer,
+             * and a peer that is not the one being written to is freed
+             * outright rather than deferred. Only rescan when the client list
+             * actually changed. */
+            if (broker->clients_gen != clients_gen_snapshot &&
+                    !BrokerClients_StillLinked(broker, wc)) {
+                continue;
+            }
+            /* A quota disconnect earlier in this fan-out clears connected;
+             * skip its remaining subscriptions, as the single-pass match
+             * guard used to. */
+            if (!wc->connected) {
+                continue;
+            }
+
+            /* Dynamic mode: enqueue a heap-owned copy on the
+             * subscriber's out_q, then drain. The queue gives us
+             * the inflight cap (#7 ordered delivery) and is the
+             * substrate for the offline queue in PR2. Invariant:
+             * MqttDecode_Publish above has populated pub.buffer
+             * with at least pub.total_len contiguous bytes (full
+             * PUBLISH is fully received and decoded before we
+             * reach the fan-out); BrokerOutPub_Alloc deep-copies
+             * pub.total_len from that buffer. */
+            if (wc->out_q_count >= BROKER_MAX_QUEUED_MSGS_PER_SUB) {
+                /* DoS guard: bound the connected subscriber's outbound
+                 * queue depth. The inflight cap above only limits bytes on
+                 * the wire; a subscriber that stops acking lets QUEUED
+                 * entries accumulate one heap-copied PUBLISH at a time
+                 * until the broker exhausts memory. Disconnect the slow /
+                 * abusive subscriber rather than growing out_q or silently
+                 * dropping accepted QoS 1/2 messages. A persistent session
+                 * is reclaimable on reconnect via the (capped) offline
+                 * queue. Mirrors the static partial-write teardown: tear
+                 * the socket down and clear connected so the guard above
+                 * skips this client's remaining subscriptions; the main
+                 * loop reaps it on the next read error. */
+                WBLOG_ERR(broker,
+                    "broker: out_q full (%d) -> disconnect sock=%d "
+                    "(from sock=%d)", wc->out_q_count,
+                    (int)wc->sock, (int)bc->sock);
+            #ifdef WOLFMQTT_V5
+                (void)BrokerSend_Disconnect(wc, MQTT_REASON_QUOTA_EXCEEDED);
+            #endif
+                if (wc->sock != BROKER_SOCKET_INVALID) {
+                    broker->net.close(broker->net.ctx, wc->sock);
+                    wc->sock = BROKER_SOCKET_INVALID;
+                }
+                wc->connected = 0;
+            }
+            else {
+                BrokerOutPub* e = BrokerOutPub_Alloc(topic, payload,
+                                      pub.total_len
+                #ifdef WOLFMQTT_V5
+                                      , pub.props
+                #endif
+                                      );
+                if (e == NULL) {
+                    WBLOG_ERR(broker,
+                        "broker: PUBLISH fwd alloc failed sock=%d "
+                        "-> sock=%d", (int)bc->sock, (int)wc->sock);
+                }
+                else {
+                    e->qos = eff_qos;
+                    if (eff_qos >= MQTT_QOS_1) {
+                        e->packet_id = BrokerNextPacketId(broker);
+                    }
+                    e->retain = 0;
+                    e->state = BROKER_OUTQ_QUEUED;
+                #ifdef WOLFMQTT_V5
+                    e->protocol_level = wc->protocol_level;
+                #endif
+                    BrokerClient_EnqueueOutPub(wc, e);
+                    WBLOG_DBG(broker,
+                        "broker: PUBLISH enq sock=%d -> sock=%d "
+                        "topic=%s qos=%d len=%u",
+                        (int)bc->sock, (int)wc->sock,
+                        BrokerLog_Sanitize(topic), eff_qos,
+                        (unsigned)pub.total_len);
+                    BrokerClient_DrainOutQueue(wc);
+                }
+            }
+        }
+        BrokerFanout_Free(&targets);
+#endif
     }
 
     if (pub.qos == MQTT_QOS_1 || pub.qos == MQTT_QOS_2) {

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -3417,6 +3417,7 @@ WOLFMQTT_LOCAL void BrokerOrphan_DropFull(MqttBroker* broker,
                     WOLFMQTT_FREE(sp->client_id);
                 }
                 WOLFMQTT_FREE(sp);
+                broker->subs_gen++;
             }
             else {
                 prev = sp;
@@ -3902,6 +3903,7 @@ static void BrokerSubs_RemoveClient(MqttBroker* broker, BrokerClient* bc)
                 WOLFMQTT_FREE(cur->client_id);
             }
             WOLFMQTT_FREE(cur);
+            broker->subs_gen++;
         }
         else {
             prev = cur;
@@ -4053,6 +4055,11 @@ static int BrokerSubs_Add(MqttBroker* broker, BrokerClient* bc,
         sub->filter[filter_len] = '\0';
         sub->next = broker->subs;
         broker->subs = sub;
+        /* Bump on add too so subs_gen reflects every structural change to the
+         * list, not only removals. Also narrows the ABA window where a free and
+         * a same-address add in one fan-out iteration could otherwise pass the
+         * successor-still-linked check. */
+        broker->subs_gen++;
     }
     else if (sub != NULL) {
         WOLFMQTT_FREE(sub);
@@ -4138,6 +4145,7 @@ static void BrokerSubs_Remove(MqttBroker* broker, BrokerClient* bc,
                 WOLFMQTT_FREE(cur->client_id);
             }
             WOLFMQTT_FREE(cur);
+            broker->subs_gen++;
             if (bc->sub_count > 0) {
                 bc->sub_count--;
             }
@@ -4263,6 +4271,7 @@ static void BrokerSubs_RemoveByClientId(MqttBroker* broker,
                 WOLFMQTT_FREE(cur->client_id);
             }
             WOLFMQTT_FREE(cur);
+            broker->subs_gen++;
         }
         else {
             prev = cur;
@@ -5394,6 +5403,7 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
 #else
     BrokerSub* sub;
     BrokerSub* next_sub = NULL;
+    word32 subs_gen_snapshot = 0;
 #endif
 
     if (broker == NULL || topic == NULL) {
@@ -5426,8 +5436,10 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
         /* Snapshot the successor before any MqttPacket_Write: a WS fan-out
          * write can drive an lws_service spin whose re-entrant CLOSED frees
          * this client's BrokerSub nodes, so reading sub->next afterwards
-         * would dereference a freed node. */
+         * would dereference a freed node. Also snapshot the subs generation so
+         * next_sub is only re-validated when a free actually happened. */
         next_sub = sub->next;
+        subs_gen_snapshot = broker->subs_gen;
 #endif
         if (sub->client != NULL && sub->client->protocol_level != 0 &&
 #ifdef WOLFMQTT_STATIC_MEMORY
@@ -5534,6 +5546,13 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
             {
                 MqttPublish out_pub;
                 int enc_rc, wr_rc;
+                /* Cache the client before the write: MqttPacket_Write can drive
+                 * a re-entrant WS close that frees this subscriber's BrokerSub
+                 * nodes (this `sub`), while the BrokerClient itself survives via
+                 * deferred removal. Reaching it through the freed `sub` after
+                 * the write would be a use-after-free; go through wc instead,
+                 * mirroring BrokerHandle_Publish. */
+                BrokerClient* wc = sub->client;
                 XMEMSET(&out_pub, 0, sizeof(out_pub));
                 out_pub.topic_name = (char*)topic;
                 out_pub.qos = eff_qos;
@@ -5545,16 +5564,16 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                     out_pub.packet_id = BrokerNextPacketId(broker);
                 }
 #ifdef WOLFMQTT_V5
-                out_pub.protocol_level = sub->client->protocol_level;
+                out_pub.protocol_level = wc->protocol_level;
 #endif
-                enc_rc = MqttEncode_Publish(sub->client->tx_buf,
-                    BROKER_CLIENT_TX_SZ(sub->client), &out_pub, 0);
+                enc_rc = MqttEncode_Publish(wc->tx_buf,
+                    BROKER_CLIENT_TX_SZ(wc), &out_pub, 0);
                 if (enc_rc > 0) {
-                    wr_rc = MqttPacket_Write(&sub->client->client,
-                            sub->client->tx_buf, enc_rc);
+                    wr_rc = MqttPacket_Write(&wc->client,
+                            wc->tx_buf, enc_rc);
                     /* Scrub tx_buf unless still in-progress (CONTINUE). */
                     if (wr_rc != MQTT_CODE_CONTINUE) {
-                        BROKER_FORCE_ZERO(sub->client->tx_buf, enc_rc);
+                        BROKER_FORCE_ZERO(wc->tx_buf, enc_rc);
                     }
                 }
             }
@@ -5586,9 +5605,11 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
         }
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
-        /* The write above can drive a re-entrant WS close that frees next_sub;
-         * stop the walk if that snapshot is no longer linked. */
-        if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+        /* The write above can drive a re-entrant WS close that frees next_sub.
+         * Only re-validate it when a subscription was actually removed during
+         * the write (generation changed), so the common case stays O(1). */
+        if (next_sub != NULL && broker->subs_gen != subs_gen_snapshot &&
+                !BrokerSubs_StillLinked(broker, next_sub)) {
             break;
         }
         sub = next_sub;
@@ -7177,6 +7198,7 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
 #ifndef WOLFMQTT_STATIC_MEMORY
         BrokerSub* sub = broker->subs;
         BrokerSub* next_sub = NULL;
+        word32 subs_gen_snapshot = 0;
 #endif
         /* Fan out to matching subscribers */
 #ifdef WOLFMQTT_STATIC_MEMORY
@@ -7188,8 +7210,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
             /* Snapshot the successor before any MqttPacket_Write: a fan-out
              * write can drive an lws_service spin that frees this client's
              * BrokerSub nodes re-entrantly (LWS_CALLBACK_CLOSED), so reading
-             * sub->next afterwards would dereference a freed node. */
+             * sub->next afterwards would dereference a freed node. Also snapshot
+             * the subs generation so next_sub is only re-validated when a free
+             * actually happened. */
             next_sub = sub->next;
+            subs_gen_snapshot = broker->subs_gen;
 #endif
             if (sub->client != NULL &&
                 sub->client->protocol_level != 0 &&
@@ -7422,8 +7447,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                 }
             }
             /* The write above can drive a re-entrant WS close that frees
-             * next_sub; stop the walk if that snapshot is no longer linked. */
-            if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+             * next_sub. Only re-validate it when a subscription was actually
+             * removed during the write (generation changed), so the common
+             * case stays O(1). */
+            if (next_sub != NULL && broker->subs_gen != subs_gen_snapshot &&
+                    !BrokerSubs_StillLinked(broker, next_sub)) {
                 break;
             }
             sub = next_sub;
@@ -8564,6 +8592,7 @@ static void BrokerSubs_FreeAll(MqttBroker* broker)
             WOLFMQTT_FREE(broker->subs->client_id);
         }
         WOLFMQTT_FREE(broker->subs);
+        broker->subs_gen++;
         broker->subs = next;
     }
 #endif

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -6235,6 +6235,20 @@ static int BrokerHandle_Connect(BrokerClient* bc, int rx_len,
             ack.return_code = MQTT_CONNECT_ACK_CODE_REFUSED_UNAVAIL;
             goto send_connack;
         }
+#ifdef WOLFMQTT_V5
+        /* [MQTT-3.2.2-11] A v5 Server that caps Maximum QoS below the requested
+         * Will QoS must refuse the connection, not silently downgrade the Will
+         * delivery QoS. v3.1.1 has no Maximum QoS advertisement, so it is still
+         * downgraded when the Will is stored below. */
+        if (mc.protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+                mc.lwt_msg->qos > WOLFMQTT_MAX_QOS) {
+            WBLOG_ERR(broker,
+                "broker: LWT QoS %d exceeds max %d sock=%d",
+                (int)mc.lwt_msg->qos, WOLFMQTT_MAX_QOS, (int)bc->sock);
+            ack.return_code = MQTT_REASON_QOS_NOT_SUPPORTED;
+            goto send_connack;
+        }
+#endif
     }
 #endif
 
@@ -6447,10 +6461,9 @@ static int BrokerHandle_Connect(BrokerClient* bc, int rx_len,
 #endif
             bc->will_payload_len = wp_len;
         }
-        /* Clamp will QoS to this build's Maximum QoS. A v5 client that
-         * sent Will QoS > advertised Max QoS would already be in
-         * Protocol Error territory, but for v3.1.1 (no advertisement)
-         * we silently downgrade rather than rejecting CONNECT. */
+        /* Clamp will QoS to this build's Maximum QoS. A v5 Will over the cap
+         * was already refused above, so this only downgrades v3.1.1, which has
+         * no Maximum QoS advertisement to reject against. */
         bc->will_qos = (mc.lwt_msg->qos > WOLFMQTT_MAX_QOS) ?
             (MqttQoS)WOLFMQTT_MAX_QOS : mc.lwt_msg->qos;
         bc->will_retain = mc.lwt_msg->retain;

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -3948,6 +3948,28 @@ static void BrokerSubs_EndClientSession(MqttBroker* broker, BrokerClient* bc)
     }
 }
 
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* Confirm a fan-out loop's snapshotted successor is still linked in
+ * broker->subs. A peer-initiated WS LWS_CALLBACK_CLOSED delivered during a
+ * fan-out write runs BrokerSubs_RemoveClient, which frees every BrokerSub owned
+ * by the closing subscriber. That set can include the node a loop saved as
+ * next_sub, so the snapshot guards only against sub->next moving, not against
+ * next_sub itself being freed. Re-check it before the next dereference,
+ * mirroring the client-list revalidation in MqttBroker_Step. */
+static int BrokerSubs_StillLinked(const MqttBroker* broker,
+    const BrokerSub* node)
+{
+    const BrokerSub* cur = broker->subs;
+    while (cur != NULL) {
+        if (cur == node) {
+            return 1;
+        }
+        cur = cur->next;
+    }
+    return 0;
+}
+#endif
+
 static int BrokerSubs_Add(MqttBroker* broker, BrokerClient* bc,
     const char* filter, word16 filter_len, MqttQoS qos)
 {
@@ -5564,6 +5586,11 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
         }
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
+        /* The write above can drive a re-entrant WS close that frees next_sub;
+         * stop the walk if that snapshot is no longer linked. */
+        if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+            break;
+        }
         sub = next_sub;
 #endif
     }
@@ -7368,6 +7395,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                             );
                     }
                 }
+            }
+            /* The write above can drive a re-entrant WS close that frees
+             * next_sub; stop the walk if that snapshot is no longer linked. */
+            if (next_sub != NULL && !BrokerSubs_StillLinked(broker, next_sub)) {
+                break;
             }
             sub = next_sub;
 #endif

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -6248,6 +6248,18 @@ static int BrokerHandle_Connect(BrokerClient* bc, int rx_len,
             ack.return_code = MQTT_REASON_QOS_NOT_SUPPORTED;
             goto send_connack;
         }
+#ifndef WOLFMQTT_BROKER_RETAINED
+        /* A v5 Server that does not support retained messages must refuse a
+         * CONNECT whose Will Retain is set, not accept it while advertising
+         * Retain Available = 0 in the same CONNACK. */
+        if (mc.protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+                mc.lwt_msg->retain != 0) {
+            WBLOG_ERR(broker,
+                "broker: LWT retain unsupported sock=%d", (int)bc->sock);
+            ack.return_code = MQTT_REASON_RETAIN_NOT_SUPPORTED;
+            goto send_connack;
+        }
+#endif
 #endif
     }
 #endif

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1175,8 +1175,18 @@ static int MqttClient_HandlePacket(MqttClient* client,
             /* Record this QoS 2 packet id as delivered and awaiting PUBREL so a
              * retransmit is acknowledged again without a second delivery
              * [MQTT-4.3.3-10]. A no-op for the retransmit, which is already
-             * tracked. */
-            if (packet_qos == MQTT_QOS_2) {
+             * tracked. Skipped when the callback rejected the message and the
+             * PUBREC carries a reason code >= 0x80: that ends the exchange
+             * [MQTT-4.3.3], so no PUBREL will arrive to clear the entry and the
+             * sender is free to reuse the packet id - a tracked id would both
+             * hold a slot forever and suppress the next PUBLISH that reuses
+             * it. */
+            if (packet_qos == MQTT_QOS_2
+            #ifdef WOLFMQTT_V5
+                && (client->protocol_level < MQTT_CONNECT_PROTOCOL_LEVEL_5 ||
+                    (resp->reason_code & 0x80) == 0)
+            #endif
+                ) {
                 MqttClient_RecvQos2_Add(client, packet_id);
             }
         #endif
@@ -1221,11 +1231,13 @@ static int MqttClient_HandlePacket(MqttClient* client,
              * the broker will never send. The QoS 1 PUBACK and the QoS 2
              * PUBCOMP reason codes are checked by the caller after the wait.
              * Note (WOLFMQTT_MULTITHREAD): when a separate thread drives reads
-             * and processes this PUBREC, it receives this error directly and
-             * the publishing thread's PUBCOMP pending response is not marked
-             * done, so that publish blocks until cmd_timeout_ms. This matches
-             * the pre-existing behavior (which left the publisher waiting on a
-             * PUBCOMP after an illegal PUBREL) and is not made worse here. */
+             * and processes this PUBREC, that thread receives this error
+             * directly, and the publishing thread's PUBCOMP pending response is
+             * completed with it below, so its next poll returns
+             * MQTT_CODE_ERROR_PUBLISH_REJECTED rather than spinning on
+             * MQTT_CODE_CONTINUE until cmd_timeout_ms. This is the one
+             * rejection MqttClient_Publish_WriteOnly does surface; see its
+             * documentation in mqtt_client.h. */
             if (packet_type == MQTT_PACKET_TYPE_PUBLISH_REC &&
                 client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 (((MqttPublishResp*)packet_obj)->reason_code & 0x80)) {
@@ -2941,10 +2953,13 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
             /* if failure or no data was written yet */
             if (rc != xfer) {
                 MqttWriteStop(client, &publish->stat);
-                MqttClient_CancelMessage(client, (MqttObject*)publish);
             #ifdef WOLFMQTT_V5
+                /* Credit the unit before the cancel: nothing reached the wire,
+                 * so it is genuinely reclaimable, and the cancel drops this
+                 * message's ownership of it either way. */
                 MqttClient_RestoreRecvQuota(client, publish);
             #endif
+                MqttClient_CancelMessage(client, (MqttObject*)publish);
                 return rc;
             }
 
@@ -2967,10 +2982,12 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         #endif
             MqttWriteStop(client, &publish->stat);
             if (rc < 0) {
-                MqttClient_CancelMessage(client, (MqttObject*)publish);
             #ifdef WOLFMQTT_V5
+                /* Credit before the cancel; see the header-write failure path
+                 * above. */
                 MqttClient_RestoreRecvQuota(client, publish);
             #endif
+                MqttClient_CancelMessage(client, (MqttObject*)publish);
                 break;
             }
 
@@ -3929,7 +3946,18 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
      * unit while the connection stays open - the server still counts it against
      * Receive Maximum [MQTT-4.9], and crediting it would let the client exceed
      * the quota. The genuinely-unsent write-failure paths release explicitly via
-     * MqttClient_RestoreRecvQuota, so no quota leaks there. */
+     * MqttClient_RestoreRecvQuota, which they call before cancelling so the
+     * credit is not swallowed by the ownership reset below. */
+#ifdef WOLFMQTT_V5
+    /* The unit stays charged to the connection, but ownership of it must not
+     * stay on this message object: cancel resets the object for reuse, and a
+     * leftover recvQuotaHeld would make MqttClient_RecvQuotaReserve treat the
+     * next publish through it as already reserved and skip the decrement,
+     * putting one more PUBLISH in flight than Receive Maximum allows
+     * [MQTT-4.9]. Clear the flag without crediting server_recv_max; the unit is
+     * recovered when the next connect resets the quota. */
+    mms_stat->recvQuotaHeld = 0;
+#endif
 
 #ifdef WOLFMQTT_MULTITHREAD
     /* Remove any pending responses expected */
@@ -4071,7 +4099,16 @@ int MqttClient_NetDisconnect(MqttClient *client)
         #endif
             /* Reserved Receive Maximum units are not credited on disconnect
              * (the PUBLISH may be on the wire); the next connect resets
-             * server_recv_max to the newly negotiated value. */
+             * server_recv_max to the newly negotiated value. Ownership must
+             * still be dropped from the message object, though: the quota
+             * belonged to the connection being torn down, and a leftover
+             * recvQuotaHeld would let a reused publish object skip the
+             * decrement on the next connection [MQTT-4.9]. */
+        #ifdef WOLFMQTT_V5
+            if (tmpResp->recvQuotaStat != NULL) {
+                tmpResp->recvQuotaStat->recvQuotaHeld = 0;
+            }
+        #endif
             MqttClient_RespList_Remove(client, tmpResp);
         }
         wm_SemUnlock(&client->lockClient);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2113,17 +2113,6 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
-    #if WOLFMQTT_MAX_QOS >= 2
-        /* A Clean Start resets the session, so drop any inbound QoS 2 dedup
-         * state from a prior connection; a resumed session (clean_session == 0)
-         * keeps its pending inbound QoS 2 packet ids so a server retransmit
-         * still awaiting PUBREL is not delivered to the app twice
-         * [MQTT-4.3.3-10]. */
-        if (mc_connect->clean_session) {
-            XMEMSET(client->recv_qos2_pending, 0,
-                sizeof(client->recv_qos2_pending));
-        }
-    #endif
     #ifdef WOLFMQTT_V5
         #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);
@@ -2413,6 +2402,21 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             (mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
         rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
     }
+
+#if WOLFMQTT_MAX_QOS >= 2
+    /* The server's Session Present flag, not the client's request, decides
+     * whether inbound QoS 2 dedup state carries over. Keep it only when the
+     * server resumed the session (Session Present = 1); on any fresh session -
+     * a requested Clean Start or a resume the server declined - drop stale
+     * pending packet ids so they cannot suppress a new inbound QoS 2 PUBLISH
+     * that reuses one [MQTT-4.3.3-10]. Packet ids also restart per connection,
+     * so a fresh session must start with an empty table. */
+    if (rc == MQTT_CODE_SUCCESS &&
+            !(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
+        XMEMSET(client->recv_qos2_pending, 0,
+            sizeof(client->recv_qos2_pending));
+    }
+#endif
 
 #ifndef WOLFMQTT_NO_TIME
     if (rc == MQTT_CODE_SUCCESS) {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -454,6 +454,63 @@ static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
 }
 #endif /* WOLFMQTT_V5 */
 
+#if WOLFMQTT_MAX_QOS >= 2
+/* Inbound QoS 2 de-duplication. A subscribing client that has delivered a
+ * QoS 2 PUBLISH to the application and answered with PUBREC records its packet
+ * id until the matching PUBREL arrives, so a retransmitted PUBLISH is
+ * acknowledged again without a second delivery [MQTT-4.3.3-10]. These run on
+ * the receive path (under lockRecv), so no extra locking is required. */
+static int MqttClient_RecvQos2_Contains(const MqttClient* client,
+    word16 packet_id)
+{
+    int i;
+
+    if (client == NULL || packet_id == 0) {
+        return 0;
+    }
+    for (i = 0; i < MQTT_MAX_RECV_QOS2; i++) {
+        if (client->recv_qos2_pending[i] == packet_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void MqttClient_RecvQos2_Add(MqttClient* client, word16 packet_id)
+{
+    int i;
+
+    if (client == NULL || packet_id == 0 ||
+            MqttClient_RecvQos2_Contains(client, packet_id)) {
+        return;
+    }
+    for (i = 0; i < MQTT_MAX_RECV_QOS2; i++) {
+        if (client->recv_qos2_pending[i] == 0) {
+            client->recv_qos2_pending[i] = packet_id;
+            return;
+        }
+    }
+    /* Table full: this id stays untracked, so a later retransmit of it may
+     * still reach the application. Delivery correctness is preserved; only the
+     * duplicate suppression is best effort under a flood of unacked QoS 2. */
+}
+
+static void MqttClient_RecvQos2_Remove(MqttClient* client, word16 packet_id)
+{
+    int i;
+
+    if (client == NULL || packet_id == 0) {
+        return;
+    }
+    for (i = 0; i < MQTT_MAX_RECV_QOS2; i++) {
+        if (client->recv_qos2_pending[i] == packet_id) {
+            client->recv_qos2_pending[i] = 0;
+            return;
+        }
+    }
+}
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
+
 #ifdef WOLFMQTT_MULTITHREAD
 
 /* These RespList functions assume caller has locked client->lockClient mutex */
@@ -1100,6 +1157,15 @@ static int MqttClient_HandlePacket(MqttClient* client,
                 MQTT_PACKET_TYPE_PUBLISH_ACK :
                 MQTT_PACKET_TYPE_PUBLISH_REC;
             resp->packet_id = packet_id;
+        #if WOLFMQTT_MAX_QOS >= 2
+            /* Record this QoS 2 packet id as delivered and awaiting PUBREL so a
+             * retransmit is acknowledged again without a second delivery
+             * [MQTT-4.3.3-10]. A no-op for the retransmit, which is already
+             * tracked. */
+            if (packet_qos == MQTT_QOS_2) {
+                MqttClient_RecvQos2_Add(client, packet_id);
+            }
+        #endif
             break;
         }
         case MQTT_PACKET_TYPE_PUBLISH_ACK:
@@ -1150,6 +1216,14 @@ static int MqttClient_HandlePacket(MqttClient* client,
                 client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 (((MqttPublishResp*)packet_obj)->reason_code & 0x80)) {
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PUBLISH_REJECTED);
+            }
+        #endif
+
+        #if WOLFMQTT_MAX_QOS >= 2
+            /* An incoming PUBREL completes the inbound QoS 2 handshake: drop the
+             * awaiting-PUBREL record so a future PUBLISH may reuse the id. */
+            if (packet_type == MQTT_PACKET_TYPE_PUBLISH_REL) {
+                MqttClient_RecvQos2_Remove(client, packet_id);
             }
         #endif
 
@@ -1969,6 +2043,13 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
+    #if WOLFMQTT_MAX_QOS >= 2
+        /* Packet ids restart per connection, so clear any inbound QoS 2 dedup
+         * state left by a prior connection: a stale entry must not suppress a
+         * new message that reuses its id [MQTT-4.3.3-10]. */
+        XMEMSET(client->recv_qos2_pending, 0,
+            sizeof(client->recv_qos2_pending));
+    #endif
     #ifdef WOLFMQTT_V5
         #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);
@@ -2269,6 +2350,14 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
 {
     int rc = MQTT_CODE_SUCCESS;
     byte msg_done;
+#if WOLFMQTT_MAX_QOS >= 2
+    /* A retransmitted QoS 2 PUBLISH still awaiting its PUBREL must be drained to
+     * keep the stream in sync, but not delivered to the application again
+     * [MQTT-4.3.3-10]. Re-derived from the packet id so it survives non-blocking
+     * re-entry into this function. */
+    int suppress_cb = (publish->qos == MQTT_QOS_2 &&
+        MqttClient_RecvQos2_Contains(client, publish->packet_id));
+#endif
 
     /* Handle packet callback and read remaining payload */
     do {
@@ -2278,7 +2367,11 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
 
         if (publish->buffer_new) {
             /* Issue callback for new message (first time only) */
-            if (client->msg_cb) {
+            if (client->msg_cb
+            #if WOLFMQTT_MAX_QOS >= 2
+                && !suppress_cb
+            #endif
+            ) {
                 /* if using the temp publish message buffer,
                    then populate message context with client context */
                 if (publish->ctx == NULL && &client->msg.publish == publish) {
@@ -2331,7 +2424,11 @@ static int MqttClient_Publish_ReadPayload(MqttClient* client,
                     publish->total_len) ? 1 : 0;
 
                 /* Issue callback for additional publish payload */
-                if (client->msg_cb) {
+                if (client->msg_cb
+                #if WOLFMQTT_MAX_QOS >= 2
+                    && !suppress_cb
+                #endif
+                ) {
                     rc = client->msg_cb(client, publish, publish->buffer_new,
                                         msg_done);
                     if (rc != MQTT_CODE_SUCCESS) {

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2732,6 +2732,24 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
             #endif
                 return rc;
             }
+        #ifdef WOLFMQTT_V5
+            /* [MQTT-3.1.2-24] The whole PUBLISH must fit the Server's Maximum
+             * Packet Size. MqttPacket_Write only sees each tx_buf-sized
+             * fragment, so a streamed or oversized payload can slip past it;
+             * check the full packet once here before any byte is written.
+             * rc is fixed header + variable header + the in-buffer payload
+             * chunk (publish->intBuf_len), so (rc - intBuf_len) is the fixed
+             * plus variable header and the full size adds total_len. The
+             * comparison is ordered to avoid unsigned overflow. */
+            if (client->packet_sz_max > 0 &&
+                ((publish->total_len > client->packet_sz_max) ||
+                 (((word32)rc - publish->intBuf_len) >
+                     (client->packet_sz_max - publish->total_len)))) {
+                MqttWriteStop(client, &publish->stat);
+                MqttClient_RestoreRecvQuota(client, publish);
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
+            }
+        #endif
             client->write.len = rc;
 
         #ifdef WOLFMQTT_MULTITHREAD

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2348,6 +2348,17 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_CONNECT_REFUSED);
     }
 
+    /* [MQTT-3.2.2-1] / [MQTT-3.2.2-4] A Server MUST report Session Present = 0
+     * when the Client requested Clean Session / Clean Start. A successful
+     * CONNACK that reports Session Present = 1 is then a protocol violation:
+     * refuse it rather than proceed on session state the client never had.
+     * Returning an error also leaves keep-alive disarmed below, and the caller
+     * tears the transport down as it does for a refused CONNACK. */
+    if (rc == MQTT_CODE_SUCCESS && mc_connect->clean_session &&
+            (mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
+        rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
+    }
+
 #ifndef WOLFMQTT_NO_TIME
     if (rc == MQTT_CODE_SUCCESS) {
         /* Connection accepted: arm auto keep-alive. A v5 Server Keep Alive

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2033,6 +2033,25 @@ int MqttClient_SetPropertyCallback(MqttClient *client, MqttPropertyCb propCb,
 }
 #endif
 
+#ifdef WOLFMQTT_V5
+/* Return 1 if the CONNECT carries an Authentication Method property, i.e. the
+ * connection is negotiating enhanced authentication [MQTT-4.12]. */
+static int MqttConnect_HasAuthMethod(const MqttConnect* mc_connect)
+{
+    const MqttProp* prop;
+
+    if (mc_connect == NULL) {
+        return 0;
+    }
+    for (prop = mc_connect->props; prop != NULL; prop = prop->next) {
+        if (prop->type == MQTT_PROP_AUTH_METHOD) {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif
+
 int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
@@ -2068,6 +2087,13 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             return rc;
         }
         XMEMSET(&mc_connect->ack, 0, sizeof(mc_connect->ack));
+
+        /* Record whether this connection negotiates enhanced authentication so
+         * a later MqttClient_Auth can be refused when no Authentication Method
+         * was sent [MQTT-4.12.0-1]. Recomputed each connect, so it also resets
+         * across a reconnect on the same client. */
+        client->auth_method_set =
+            (byte)MqttConnect_HasAuthMethod(mc_connect);
     #endif
         /* Warn if credentials are being sent without TLS */
     #ifdef WOLFMQTT_DEBUG_CLIENT
@@ -3530,7 +3556,13 @@ static int MqttClient_AuthEx(MqttClient *client, MqttAuth* auth,
 
 int MqttClient_Auth(MqttClient *client, MqttAuth* auth)
 {
-    if (auth == NULL) {
+    if (client == NULL || auth == NULL) {
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
+    }
+    /* [MQTT-4.12.0-1] An AUTH may only be sent on a connection whose CONNECT
+     * carried an Authentication Method. Refuse otherwise so a client cannot
+     * emit an AUTH on a connection that never negotiated enhanced auth. */
+    if (client->auth_method_set == 0) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
     return MqttClient_AuthEx(client, auth, &auth->stat,

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2101,11 +2101,35 @@ static int MqttConnect_HasAuthMethod(const MqttConnect* mc_connect)
     }
     return 0;
 }
+
+#if WOLFMQTT_MAX_QOS >= 2
+/* Return 1 if the CONNECT already carries a Receive Maximum property, i.e. the
+ * application picked its own inbound flow-control window. */
+static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
+{
+    const MqttProp* prop;
+
+    if (mc_connect == NULL) {
+        return 0;
+    }
+    for (prop = mc_connect->props; prop != NULL; prop = prop->next) {
+        if (prop->type == MQTT_PROP_RECEIVE_MAX) {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
 #endif
 
 int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
+#if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
+    MqttProp recv_max_prop;
+    MqttProp* app_props = NULL;
+    int recv_max_added = 0;
+#endif
 
     /* Validate required arguments */
     if (client == NULL || mc_connect == NULL) {
@@ -2189,8 +2213,39 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         client->topic_alias_max = 0;
     #endif
 
+    #if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
+        /* [MQTT-3.3.4] Receive Maximum bounds the QoS 1 and QoS 2 PUBLISH
+         * packets the server may have in flight toward this client. The inbound
+         * QoS 2 de-duplication table tracks MQTT_MAX_RECV_QOS2 packet ids
+         * awaiting PUBREL; with no advertised limit a server may exceed it, and
+         * an id that no longer fits goes untracked, so a retransmit of it would
+         * reach the application a second time [MQTT-4.3.3-10]. Advertising the
+         * table size keeps a conforming server inside it. An application that
+         * supplied its own Receive Maximum keeps it - that is an explicit
+         * choice, and above MQTT_MAX_RECV_QOS2 the dedup is best effort again.
+         * The property lives on this stack frame and is linked only across the
+         * encode below, so the caller's list is unchanged on return. */
+        if (mc_connect->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+                !MqttConnect_HasRecvMax(mc_connect)) {
+            XMEMSET(&recv_max_prop, 0, sizeof(recv_max_prop));
+            recv_max_prop.type = MQTT_PROP_RECEIVE_MAX;
+            recv_max_prop.data_short = (word16)MQTT_MAX_RECV_QOS2;
+            recv_max_prop.next = mc_connect->props;
+            app_props = mc_connect->props;
+            mc_connect->props = &recv_max_prop;
+            recv_max_added = 1;
+        }
+    #endif
+
         /* Encode the connect packet */
         rc = MqttEncode_Connect(client->tx_buf, client->tx_buf_len, mc_connect);
+    #if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
+        /* Unlink the stack-local property before anything else walks or frees
+         * the caller's list. */
+        if (recv_max_added) {
+            mc_connect->props = app_props;
+        }
+    #endif
     #ifdef WOLFMQTT_DEBUG_CLIENT
         PRINTF("MqttClient_EncodePacket: Len %d, Type %s (%d), ID %d, QoS %d",
             rc, MqttPacket_TypeDesc(MQTT_PACKET_TYPE_CONNECT),

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2641,7 +2641,9 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
     }
 
-    /* [MQTT-3.3.2.3.4]: reject a Topic Alias over CONNACK's maximum. */
+    /* [MQTT-3.3.2.3.4]: reject a Topic Alias over CONNACK's maximum.
+     * [MQTT-3.3.4-6]: a Client-to-Server PUBLISH MUST NOT carry a
+     * Subscription Identifier. */
     if (client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
         MqttProp* prop;
         for (prop = publish->props; prop != NULL; prop = prop->next) {
@@ -2650,7 +2652,11 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     (prop->data_short > client->topic_alias_max)) {
                     return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
                 }
-                break;
+            }
+            /* The Subscription Identifier is only valid on a Server-to-Client
+             * PUBLISH the broker generates; reject a caller-supplied one. */
+            else if (prop->type == MQTT_PROP_SUBSCRIPTION_ID) {
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
             }
         }
     }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -610,6 +610,11 @@ void MqttClient_RespList_Remove(MqttClient *client, MqttPendResp *rmResp)
         }
     }
     if (tmpResp) {
+    #ifdef WOLFMQTT_V5
+        /* Drop the reserved-quota back-reference so a recycled publish object
+         * cannot carry a stale pointer into a future pending response. */
+        tmpResp->recvQuotaStat = NULL;
+    #endif
         /* Fix up the first and last pointers */
         if (client->firstPendResp == tmpResp) {
             client->firstPendResp = tmpResp->next;
@@ -2916,7 +2921,14 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                         publish->packet_id);
                 #ifndef WOLFMQTT_NONBLOCK
                     if (rc == MQTT_CODE_CONTINUE) {
-                        /* mark success, let other thread handle response */
+                        /* No non-blocking re-entry will complete this ack, so
+                         * report success now. Release the reserved quota since
+                         * the ack will no longer be tracked, and the pending
+                         * response is unlinked below so no reference to the
+                         * caller's publish object remains. */
+                    #ifdef WOLFMQTT_V5
+                        MqttClient_RestoreRecvQuota(client, publish);
+                    #endif
                         rc = MQTT_CODE_SUCCESS;
                     }
                 #endif
@@ -2968,13 +2980,13 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     break;
             #endif
             #ifdef WOLFMQTT_MULTITHREAD
-                /* Leave a write-only publish's pending response in the list: a
-                 * build without WOLFMQTT_NONBLOCK reports success here without
-                 * the ack, and unlinking it now would prevent the reading thread
-                 * from completing it and releasing the reserved Receive Maximum
-                 * unit, leaking quota. The reader removes it when the ack
-                 * arrives. */
-                if (!writeOnly && wm_SemLock(&client->lockClient) == 0) {
+                /* Remove the pending response before returning: a caller told
+                 * SUCCESS may free its publish object, so no reference to it may
+                 * remain in the list. A write-only publish under
+                 * WOLFMQTT_NONBLOCK returned CONTINUE above and broke out before
+                 * here, leaving its entry for the reading thread to complete and
+                 * remove. */
+                if (wm_SemLock(&client->lockClient) == 0) {
                     MqttClient_RespList_Remove(client, &publish->pendResp);
                     wm_SemUnlock(&client->lockClient);
                 }
@@ -3868,6 +3880,15 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
         #endif
+        #ifdef WOLFMQTT_V5
+            /* Release any Receive Maximum unit this response reserved so
+             * cancelling a QoS>0 (e.g. write-only) publish does not leak it.
+             * lockClient is held; idempotent via recvQuotaHeld. */
+            if (tmpResp->recvQuotaStat != NULL) {
+                MqttClient_RecvQuotaRelease_Locked(client,
+                    tmpResp->recvQuotaStat);
+            }
+        #endif
             MqttClient_RespList_Remove(client, tmpResp);
             break;
         }
@@ -3972,6 +3993,15 @@ int MqttClient_NetDisconnect(MqttClient *client)
                 MqttPacket_TypeDesc(tmpResp->packet_type),
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
+        #endif
+        #ifdef WOLFMQTT_V5
+            /* Release any reserved Receive Maximum unit as the list is purged
+             * on disconnect, so it is not left held. Idempotent via
+             * recvQuotaHeld; lockClient is held. */
+            if (tmpResp->recvQuotaStat != NULL) {
+                MqttClient_RecvQuotaRelease_Locked(client,
+                    tmpResp->recvQuotaStat);
+            }
         #endif
             MqttClient_RespList_Remove(client, tmpResp);
         }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1224,6 +1224,24 @@ static int MqttClient_HandlePacket(MqttClient* client,
             if (packet_type == MQTT_PACKET_TYPE_PUBLISH_REC &&
                 client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 (((MqttPublishResp*)packet_obj)->reason_code & 0x80)) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                /* The QoS 2 exchange ends here with no PUBCOMP [MQTT-4.9], so
+                 * the reserved Receive Maximum unit for this packet id would be
+                 * leaked. Release it via the PUBCOMP pending response (the only
+                 * way a write-only publisher, whose thread never returns, can be
+                 * credited). Idempotent, so an ordinary waiting publisher is
+                 * unaffected. */
+                MqttPendResp* qpr = NULL;
+                if (wm_SemLock(&client->lockClient) == 0) {
+                    if (MqttClient_RespList_Find(client,
+                            MQTT_PACKET_TYPE_PUBLISH_COMP, packet_id, &qpr) &&
+                            qpr != NULL && qpr->recvQuotaStat != NULL) {
+                        MqttClient_RecvQuotaRelease_Locked(client,
+                            qpr->recvQuotaStat);
+                    }
+                    wm_SemUnlock(&client->lockClient);
+                }
+            #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PUBLISH_REJECTED);
             }
         #endif
@@ -1703,10 +1721,10 @@ wait_again:
                      * but does not wait for its own ack; release it here as this
                      * reading thread completes the terminal PUBACK / PUBCOMP,
                      * via the reserving stat recorded on the pending response.
-                     * Idempotent, so an ordinary publish that also releases in
-                     * its waiting thread is unaffected. */
-                    if (rc == MQTT_CODE_SUCCESS &&
-                            pendResp->recvQuotaStat != NULL) {
+                     * Only reached on a completed (non-error) response, so no
+                     * result gate is needed. Idempotent, so an ordinary publish
+                     * that also releases in its waiting thread is unaffected. */
+                    if (pendResp->recvQuotaStat != NULL) {
                         MqttClient_RecvQuotaRelease_Locked(client,
                             pendResp->recvQuotaStat);
                     }
@@ -2950,7 +2968,13 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     break;
             #endif
             #ifdef WOLFMQTT_MULTITHREAD
-                if (wm_SemLock(&client->lockClient) == 0) {
+                /* Leave a write-only publish's pending response in the list: a
+                 * build without WOLFMQTT_NONBLOCK reports success here without
+                 * the ack, and unlinking it now would prevent the reading thread
+                 * from completing it and releasing the reserved Receive Maximum
+                 * unit, leaking quota. The reader removes it when the ack
+                 * arrives. */
+                if (!writeOnly && wm_SemLock(&client->lockClient) == 0) {
                     MqttClient_RespList_Remove(client, &publish->pendResp);
                     wm_SemUnlock(&client->lockClient);
                 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1230,19 +1230,25 @@ static int MqttClient_HandlePacket(MqttClient* client,
                 client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 (((MqttPublishResp*)packet_obj)->reason_code & 0x80)) {
             #ifdef WOLFMQTT_MULTITHREAD
-                /* The QoS 2 exchange ends here with no PUBCOMP [MQTT-4.9], so
-                 * the reserved Receive Maximum unit for this packet id would be
-                 * leaked. Release it via the PUBCOMP pending response (the only
-                 * way a write-only publisher, whose thread never returns, can be
-                 * credited). Idempotent, so an ordinary waiting publisher is
-                 * unaffected. */
+                /* The QoS 2 exchange ends here with no PUBCOMP [MQTT-4.9].
+                 * Complete the PUBCOMP pending response with the rejection so a
+                 * write-only publisher polling for it observes the failure
+                 * instead of spinning on CONTINUE, release the reserved unit,
+                 * and clear the back-reference so a later cancel/disconnect
+                 * cannot touch it. Idempotent for an ordinary waiting
+                 * publisher, whose own wait also surfaces the rejection. */
                 MqttPendResp* qpr = NULL;
                 if (wm_SemLock(&client->lockClient) == 0) {
                     if (MqttClient_RespList_Find(client,
                             MQTT_PACKET_TYPE_PUBLISH_COMP, packet_id, &qpr) &&
-                            qpr != NULL && qpr->recvQuotaStat != NULL) {
-                        MqttClient_RecvQuotaRelease_Locked(client,
-                            qpr->recvQuotaStat);
+                            qpr != NULL) {
+                        if (qpr->recvQuotaStat != NULL) {
+                            MqttClient_RecvQuotaRelease_Locked(client,
+                                qpr->recvQuotaStat);
+                            qpr->recvQuotaStat = NULL;
+                        }
+                        qpr->packet_ret = MQTT_CODE_ERROR_PUBLISH_REJECTED;
+                        qpr->packetDone = 1;
                     }
                     wm_SemUnlock(&client->lockClient);
                 }
@@ -2108,11 +2114,15 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
     #if WOLFMQTT_MAX_QOS >= 2
-        /* Packet ids restart per connection, so clear any inbound QoS 2 dedup
-         * state left by a prior connection: a stale entry must not suppress a
-         * new message that reuses its id [MQTT-4.3.3-10]. */
-        XMEMSET(client->recv_qos2_pending, 0,
-            sizeof(client->recv_qos2_pending));
+        /* A Clean Start resets the session, so drop any inbound QoS 2 dedup
+         * state from a prior connection; a resumed session (clean_session == 0)
+         * keeps its pending inbound QoS 2 packet ids so a server retransmit
+         * still awaiting PUBREL is not delivered to the app twice
+         * [MQTT-4.3.3-10]. */
+        if (mc_connect->clean_session) {
+            XMEMSET(client->recv_qos2_pending, 0,
+                sizeof(client->recv_qos2_pending));
+        }
     #endif
     #ifdef WOLFMQTT_V5
         #ifdef WOLFMQTT_MULTITHREAD
@@ -2757,12 +2767,21 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         #ifdef WOLFMQTT_V5
             /* [MQTT-3.1.2.11.3]: atomically reserve one flow-control unit,
              * refusing once the quota is exhausted. Only reached in
-             * MQTT_MSG_BEGIN, so once per logical publish. A write-only publish
-             * is included: it reserves here and the reading thread that
-             * completes its terminal PUBACK / PUBCOMP releases the unit (see
-             * MqttClient_WaitType), so the quota is enforced on that API too. */
+             * MQTT_MSG_BEGIN, so once per logical publish. The unit is released
+             * only on the acknowledgement, so a publish is reserved only when
+             * that ack can be tracked to completion. A write-only publish in a
+             * WOLFMQTT_MULTITHREAD build without WOLFMQTT_NONBLOCK returns
+             * success immediately, abandoning ack tracking (and the caller may
+             * free the object), so it is left unreserved there - the alternative
+             * would either over-credit an on-wire PUBLISH [MQTT-4.9] or dangle.
+             * A blocking (non-multithread) write-only still waits, and a
+             * non-blocking one keeps its pending response for the reader, so
+             * both reserve. */
             if (client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 publish->qos > MQTT_QOS_0 &&
+            #if defined(WOLFMQTT_MULTITHREAD) && !defined(WOLFMQTT_NONBLOCK)
+                !writeOnly &&
+            #endif
                 !MqttClient_RecvQuotaReserve(client, publish))
             {
                 MqttWriteStop(client, &publish->stat);
@@ -2922,13 +2941,11 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 #ifndef WOLFMQTT_NONBLOCK
                     if (rc == MQTT_CODE_CONTINUE) {
                         /* No non-blocking re-entry will complete this ack, so
-                         * report success now. Release the reserved quota since
-                         * the ack will no longer be tracked, and the pending
-                         * response is unlinked below so no reference to the
-                         * caller's publish object remains. */
-                    #ifdef WOLFMQTT_V5
-                        MqttClient_RestoreRecvQuota(client, publish);
-                    #endif
+                         * report success. This build does not reserve quota for
+                         * a write-only publish (see the reserve gate above), and
+                         * the pending response is unlinked below, so nothing is
+                         * leaked and no reference to the caller's object
+                         * remains. */
                         rc = MQTT_CODE_SUCCESS;
                     }
                 #endif
@@ -2943,15 +2960,18 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                         publish->packet_id, client->cmd_timeout_ms, NULL);
 
                 #ifdef WOLFMQTT_V5
-                    /* Replenish the reserved quota unit only on a real
-                     * acknowledgement. rc is still SUCCESS here for both a clean
-                     * PUBACK/PUBCOMP and a rejecting reason code (reclassified to
-                     * PUBLISH_REJECTED just below), which both free the unit
-                     * [MQTT-4.9]. A timeout leaves the PUBLISH unacknowledged on
-                     * a still-open connection - the server keeps counting it
-                     * against Receive Maximum - so crediting here would let the
-                     * client exceed the negotiated quota. */
-                    if (rc == MQTT_CODE_SUCCESS) {
+                    /* Replenish the reserved quota unit on any real end to the
+                     * exchange, all of which free the server's unit [MQTT-4.9]:
+                     * a clean PUBACK/PUBCOMP (rc SUCCESS), a rejecting
+                     * PUBACK/PUBCOMP reason code (still SUCCESS here,
+                     * reclassified below), and a PUBREC rejection (surfaced
+                     * directly as PUBLISH_REJECTED, which without this credit
+                     * would leak a unit in a non-multithread build). A timeout
+                     * leaves the PUBLISH unacknowledged on a still-open
+                     * connection - the server keeps counting it - so it is
+                     * excluded. */
+                    if (rc == MQTT_CODE_SUCCESS ||
+                            rc == MQTT_CODE_ERROR_PUBLISH_REJECTED) {
                         MqttClient_RestoreRecvQuota(client, publish);
                     }
 
@@ -3880,15 +3900,11 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
         #endif
-        #ifdef WOLFMQTT_V5
-            /* Release any Receive Maximum unit this response reserved so
-             * cancelling a QoS>0 (e.g. write-only) publish does not leak it.
-             * lockClient is held; idempotent via recvQuotaHeld. */
-            if (tmpResp->recvQuotaStat != NULL) {
-                MqttClient_RecvQuotaRelease_Locked(client,
-                    tmpResp->recvQuotaStat);
-            }
-        #endif
+            /* Do not credit any reserved Receive Maximum unit here: the PUBLISH
+             * may already be on the wire, where the server keeps counting it
+             * [MQTT-4.9], so crediting it on a local cancel could exceed the
+             * negotiated quota. The unit is released on the acknowledgement, or
+             * recovered when the connection resets server_recv_max. */
             MqttClient_RespList_Remove(client, tmpResp);
             break;
         }
@@ -3994,15 +4010,9 @@ int MqttClient_NetDisconnect(MqttClient *client)
                 tmpResp->packet_type, tmpResp->packet_id,
                 tmpResp->packetProcessing, tmpResp->packetDone);
         #endif
-        #ifdef WOLFMQTT_V5
-            /* Release any reserved Receive Maximum unit as the list is purged
-             * on disconnect, so it is not left held. Idempotent via
-             * recvQuotaHeld; lockClient is held. */
-            if (tmpResp->recvQuotaStat != NULL) {
-                MqttClient_RecvQuotaRelease_Locked(client,
-                    tmpResp->recvQuotaStat);
-            }
-        #endif
+            /* Reserved Receive Maximum units are not credited on disconnect
+             * (the PUBLISH may be on the wire); the next connect resets
+             * server_recv_max to the newly negotiated value. */
             MqttClient_RespList_Remove(client, tmpResp);
         }
         wm_SemUnlock(&client->lockClient);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -435,6 +435,20 @@ static int MqttClient_RecvQuotaReserve(MqttClient* client,
     return reserved;
 }
 
+/* Credit one Receive Maximum unit back for this message. The caller must hold
+ * lockClient (where applicable). Idempotent via recvQuotaHeld, so a second
+ * release for the same message is a no-op. */
+static void MqttClient_RecvQuotaRelease_Locked(MqttClient* client,
+    MqttMsgStat* stat)
+{
+    if (stat->recvQuotaHeld) {
+        if (client->server_recv_max < client->server_recv_max_negotiated) {
+            client->server_recv_max++;
+        }
+        stat->recvQuotaHeld = 0;
+    }
+}
+
 static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
 {
 #ifdef WOLFMQTT_MULTITHREAD
@@ -442,12 +456,7 @@ static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
         return;
     }
 #endif
-    if (stat->recvQuotaHeld) {
-        if (client->server_recv_max < client->server_recv_max_negotiated) {
-            client->server_recv_max++;
-        }
-        stat->recvQuotaHeld = 0;
-    }
+    MqttClient_RecvQuotaRelease_Locked(client, stat);
 #ifdef WOLFMQTT_MULTITHREAD
     wm_SemUnlock(&client->lockClient);
 #endif
@@ -1689,6 +1698,19 @@ wait_again:
                 if (wm_SemLock(&client->lockClient) == 0) {
                     pendResp->packetDone = 1;
                     pendResp->packet_ret = rc;
+                #ifdef WOLFMQTT_V5
+                    /* A write-only QoS>0 publish reserves a Receive Maximum unit
+                     * but does not wait for its own ack; release it here as this
+                     * reading thread completes the terminal PUBACK / PUBCOMP,
+                     * via the reserving stat recorded on the pending response.
+                     * Idempotent, so an ordinary publish that also releases in
+                     * its waiting thread is unaffected. */
+                    if (rc == MQTT_CODE_SUCCESS &&
+                            pendResp->recvQuotaStat != NULL) {
+                        MqttClient_RecvQuotaRelease_Locked(client,
+                            pendResp->recvQuotaStat);
+                    }
+                #endif
                 #ifdef WOLFMQTT_DEBUG_CLIENT
                     PRINTF("PendResp Done %p", pendResp);
                 #endif
@@ -2711,13 +2733,12 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
 
         #ifdef WOLFMQTT_V5
             /* [MQTT-3.1.2.11.3]: atomically reserve one flow-control unit,
-             * refusing once the quota is exhausted. Released when the publish
-             * terminates. Only reached in MQTT_MSG_BEGIN, so once per logical
-             * publish. Write-only publishes are excluded: a reader thread owns
-             * their ack, so a per-object reservation cannot be released
-             * reliably across that hand-off. */
-            if (!writeOnly &&
-                client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
+             * refusing once the quota is exhausted. Only reached in
+             * MQTT_MSG_BEGIN, so once per logical publish. A write-only publish
+             * is included: it reserves here and the reading thread that
+             * completes its terminal PUBACK / PUBCOMP releases the unit (see
+             * MqttClient_WaitType), so the quota is enforced on that API too. */
+            if (client->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 &&
                 publish->qos > MQTT_QOS_0 &&
                 !MqttClient_RecvQuotaReserve(client, publish))
             {
@@ -2774,6 +2795,14 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     /* inform other threads of expected response */
                     rc = MqttClient_RespList_Add(client, resp_type,
                         publish->packet_id, &publish->pendResp, &publish->resp);
+                #ifdef WOLFMQTT_V5
+                    /* Let the thread that completes this ack release any
+                     * reserved Receive Maximum unit, needed for a write-only
+                     * publish that does not wait for its own ack. */
+                    if (rc == 0 && publish->stat.recvQuotaHeld) {
+                        publish->pendResp.recvQuotaStat = &publish->stat;
+                    }
+                #endif
                     wm_SemUnlock(&client->lockClient);
                 }
                 if (rc != 0) {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -313,13 +313,41 @@ static int MqttPacket_PublishRespReasonCodeValid(byte type, byte code)
  * it must be treated as malformed. The length is decoded by the caller
  * via MqttDecode_String so this helper takes (filter, len) rather than
  * a NUL-terminated string. */
-int MqttPacket_TopicFilterValid(const char* filter, word16 len)
+int MqttPacket_TopicFilterValid_ex(const char* filter, word16 len,
+    byte protocol_level)
 {
     word16 i;
+    word16 start = 0;
+
     if (filter == NULL || len == 0) {
         return 0;
     }
-    for (i = 0; i < len; i++) {
+
+#ifdef WOLFMQTT_V5
+    /* MQTT v5 shared subscription: $share/{ShareName}/{filter} [MQTT-4.8.2].
+     * The ShareName must be present and free of '/', '+' and '#', and a
+     * non-empty filter must follow. The trailing filter is then validated by
+     * the generic wildcard rules below. */
+    if (protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5 && len >= 7 &&
+            XMEMCMP(filter, "$share/", 7) == 0) {
+        word16 name_end = 7;
+        while (name_end < len && filter[name_end] != '/') {
+            if (filter[name_end] == '+' || filter[name_end] == '#') {
+                return 0;
+            }
+            name_end++;
+        }
+        /* Reject an empty ShareName, a missing separator, or an empty filter. */
+        if (name_end == 7 || name_end >= (word16)(len - 1)) {
+            return 0;
+        }
+        start = (word16)(name_end + 1);
+    }
+#else
+    (void)protocol_level;
+#endif
+
+    for (i = start; i < len; i++) {
         char c = filter[i];
         if (c == '#') {
             if (i != 0 && filter[i - 1] != '/') {
@@ -339,6 +367,14 @@ int MqttPacket_TopicFilterValid(const char* filter, word16 len)
         }
     }
     return 1;
+}
+
+int MqttPacket_TopicFilterValid(const char* filter, word16 len)
+{
+    /* Default to v3.1.1 semantics, where '$share/...' is an ordinary filter
+     * with no shared-subscription constraints. */
+    return MqttPacket_TopicFilterValid_ex(filter, len,
+        MQTT_CONNECT_PROTOCOL_LEVEL_4);
 }
 
 /* Validate an MQTT PUBLISH Topic Name against [MQTT-3.3.2-2] /
@@ -2678,8 +2714,13 @@ int MqttEncode_Subscribe(byte *tx_buf, int tx_buf_len,
             }
             /* Reject filters the decoder would treat as malformed so the
              * encoder cannot emit an undecodable SUBSCRIBE [MQTT-4.7]. */
+        #ifdef WOLFMQTT_V5
+            if (!MqttPacket_TopicFilterValid_ex(topic->topic_filter,
+                    (word16)str_len, subscribe->protocol_level)) {
+        #else
             if (!MqttPacket_TopicFilterValid(topic->topic_filter,
                     (word16)str_len)) {
+        #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
             }
         #ifndef WOLFMQTT_NO_UTF8_VALIDATION
@@ -2876,8 +2917,14 @@ int MqttDecode_Subscribe(byte *rx_buf, int rx_buf_len, MqttSubscribe *subscribe)
             }
             /* [MQTT-4.7.3-1] / [MQTT-4.7.1-2] / [MQTT-4.7.1-3] Reject
              * empty filters and malformed wildcard placement. */
+        #ifdef WOLFMQTT_V5
+            if (!MqttPacket_TopicFilterValid_ex(topic->topic_filter,
+                                             filter_len,
+                                             subscribe->protocol_level)) {
+        #else
             if (!MqttPacket_TopicFilterValid(topic->topic_filter,
                                              filter_len)) {
+        #endif
                 tmp = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
                 break;
             }
@@ -3116,8 +3163,13 @@ int MqttEncode_Unsubscribe(byte *tx_buf, int tx_buf_len,
             }
             /* Reject filters the decoder would treat as malformed so the
              * encoder cannot emit an undecodable UNSUBSCRIBE [MQTT-4.7]. */
+        #ifdef WOLFMQTT_V5
+            if (!MqttPacket_TopicFilterValid_ex(topic->topic_filter,
+                    (word16)str_len, unsubscribe->protocol_level)) {
+        #else
             if (!MqttPacket_TopicFilterValid(topic->topic_filter,
                     (word16)str_len)) {
+        #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
             }
         #ifndef WOLFMQTT_NO_UTF8_VALIDATION
@@ -3290,8 +3342,14 @@ int MqttDecode_Unsubscribe(byte *rx_buf, int rx_buf_len, MqttUnsubscribe *unsubs
             /* [MQTT-4.7.3-1] / [MQTT-4.7.1-2] / [MQTT-4.7.1-3]: an
              * UNSUBSCRIBE Topic Filter must obey the same syntax rules
              * as a SUBSCRIBE Topic Filter. */
+        #ifdef WOLFMQTT_V5
+            if (!MqttPacket_TopicFilterValid_ex(topic->topic_filter,
+                                             filter_len,
+                                             unsubscribe->protocol_level)) {
+        #else
             if (!MqttPacket_TopicFilterValid(topic->topic_filter,
                                              filter_len)) {
+        #endif
                 tmp = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
                 break;
             }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -377,6 +377,17 @@ int MqttPacket_TopicFilterValid(const char* filter, word16 len)
         MQTT_CONNECT_PROTOCOL_LEVEL_4);
 }
 
+#ifdef WOLFMQTT_V5
+/* Return 1 if the Topic Filter is an MQTT v5 shared subscription, i.e. it
+ * begins with the "$share/" prefix [MQTT-4.8.2]. Full ShareName validity is
+ * enforced by MqttPacket_TopicFilterValid_ex; this only detects the form. */
+static int MqttPacket_TopicFilterIsShared(const char* filter, word16 len)
+{
+    return (filter != NULL && len >= 7 &&
+        XMEMCMP(filter, "$share/", 7) == 0);
+}
+#endif
+
 /* Validate an MQTT PUBLISH Topic Name against [MQTT-3.3.2-2] /
  * [MQTT-4.7.1-1] (Topic Names MUST NOT contain wildcard characters '#'
  * or '+'; applies to both v3.1.1 and v5) and [MQTT-4.7.3-1] (minimum
@@ -2809,6 +2820,13 @@ int MqttEncode_Subscribe(byte *tx_buf, int tx_buf_len,
                 ((topic->sub_options >> 4) & 0x03) == 0x03) {
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
             }
+            /* [MQTT-3.8.3-4] No Local MUST NOT be set on a Shared
+             * Subscription. */
+            if ((topic->sub_options & MQTT_SUBSCRIBE_NO_LOCAL) != 0 &&
+                    MqttPacket_TopicFilterIsShared(topic->topic_filter,
+                        (word16)XSTRLEN(topic->topic_filter))) {
+                return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+            }
             options |= (byte)(topic->sub_options & MQTT_SUBSCRIBE_OPTIONS_MASK);
         }
     #endif
@@ -2948,6 +2966,14 @@ int MqttDecode_Subscribe(byte *rx_buf, int rx_buf_len, MqttSubscribe *subscribe)
                 if ((options & 0xC0) != 0 ||
                     (options & 0x03) > MQTT_QOS_2 ||
                     ((options >> 4) & 0x03) == 0x03) {
+                    tmp = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+                    break;
+                }
+                /* [MQTT-3.8.3-4] No Local MUST NOT be set on a Shared
+                 * Subscription; treat as a Protocol Error. */
+                if ((options & MQTT_SUBSCRIBE_NO_LOCAL) != 0 &&
+                        MqttPacket_TopicFilterIsShared(topic->topic_filter,
+                            filter_len)) {
                     tmp = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
                     break;
                 }

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -138,6 +138,13 @@ static int mock_read(void* ctx, BROKER_SOCKET_T sock,
     return buf_len;
 }
 
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* One-shot hook run from inside the first PUBLISH the broker writes. The mock
+ * network has no lws_service, so this is how a test reproduces the mutation a
+ * re-entrant WebSocket close performs part way through a fan-out. */
+static void (*g_write_publish_hook)(void);
+#endif
+
 static int mock_write(void* ctx, BROKER_SOCKET_T sock,
     const byte* buf, int buf_len, int timeout_ms)
 {
@@ -156,6 +163,14 @@ static int mock_write(void* ctx, BROKER_SOCKET_T sock,
      * scrub target was actually written) before checking it was scrubbed. */
     XMEMCPY(mc->out_buf + mc->out_len, buf, (size_t)buf_len);
     mc->out_len += (size_t)buf_len;
+#ifndef WOLFMQTT_STATIC_MEMORY
+    if (g_write_publish_hook != NULL && buf_len > 0 &&
+            ((buf[0] & 0xF0) >> 4) == MQTT_PACKET_TYPE_PUBLISH) {
+        void (*hook)(void) = g_write_publish_hook;
+        g_write_publish_hook = NULL; /* one shot */
+        hook();
+    }
+#endif
     if (mc->write_err) {
         return MQTT_CODE_ERROR_NETWORK; /* simulate a hard write failure */
     }
@@ -184,6 +199,9 @@ static void reset_mock_clients(int n_clients)
     }
     g_clients_active = n_clients;
     g_accept_count = 0;
+#ifndef WOLFMQTT_STATIC_MEMORY
+    g_write_publish_hook = NULL;
+#endif
 }
 
 /* Append bytes to a client's input queue (i.e., what it appears to send to
@@ -1305,6 +1323,196 @@ TEST(fanout_subs_generation_bumped_on_unsubscribe)
     MqttBroker_Stop(&broker);
     MqttBroker_Free(&broker);
 }
+
+/* Broker under test for the re-entrant fan-out hooks below. */
+static MqttBroker* g_fanout_broker;
+
+/* Unlink and free the second subscription in broker->subs, mirroring what
+ * BrokerSubs_RemoveClient does to a peer whose WebSocket closes part way
+ * through another subscriber's fan-out write. The second node is exactly the
+ * successor a single-pass walk would have snapshotted before that write. */
+static void fanout_drop_second_sub(void)
+{
+    BrokerSub* first;
+    BrokerSub* victim;
+
+    if (g_fanout_broker == NULL) {
+        return;
+    }
+    first = g_fanout_broker->subs;
+    if (first == NULL || first->next == NULL) {
+        return;
+    }
+    victim = first->next;
+    first->next = victim->next;
+    if (victim->filter != NULL) {
+        WOLFMQTT_FREE(victim->filter);
+    }
+    if (victim->client_id != NULL) {
+        WOLFMQTT_FREE(victim->client_id);
+    }
+    WOLFMQTT_FREE(victim);
+    g_fanout_broker->subs_gen++;
+}
+
+/* A fan-out write can re-entrantly free BrokerSub nodes, including the one a
+ * single-pass walk saved as its successor. Abandoning the walk there is not
+ * safe either: every still-connected subscriber further down the list silently
+ * loses the message while the publisher is acknowledged as though delivery
+ * completed. Three subscribers share topic "x"; the subscription behind the
+ * first one written to is freed from inside that write, and all three must
+ * still receive exactly one PUBLISH. */
+TEST(fanout_survives_reentrant_sub_free)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    /* CONNECT for subscribers "A", "B", "C" and publisher "P". */
+    static const byte connect_a[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'A'
+    };
+    static const byte connect_b[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'B'
+    };
+    static const byte connect_c[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'C'
+    };
+    static const byte connect_p[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* SUBSCRIBE packet_id=1, filter "x", QoS 0. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06, 0x00, 0x01, 0x00, 0x01, 'x', 0x00
+    };
+    /* PUBLISH QoS 0, topic "x", payload "hi". */
+    static const byte publish_x[] = {
+        0x30, 0x05, 0x00, 0x01, 'x', 'h', 'i'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(4);
+    mock_client_input_append(0, connect_a, sizeof(connect_a));
+    mock_client_input_append(0, subscribe_x, sizeof(subscribe_x));
+    mock_client_input_append(1, connect_b, sizeof(connect_b));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    mock_client_input_append(2, connect_c, sizeof(connect_c));
+    mock_client_input_append(2, subscribe_x, sizeof(subscribe_x));
+    mock_client_input_append(3, connect_p, sizeof(connect_p));
+    for (i = 0; i < 48; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* All three subscriptions are in place before the publish. */
+    ASSERT_NOT_NULL(broker.subs);
+    ASSERT_NOT_NULL(broker.subs->next);
+    ASSERT_NOT_NULL(broker.subs->next->next);
+
+    g_fanout_broker = &broker;
+    g_write_publish_hook = fanout_drop_second_sub;
+
+    mock_client_input_append(3, publish_x, sizeof(publish_x));
+    for (i = 0; i < 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* The hook fired, so the fan-out really did run over a mutated list. */
+    ASSERT_NULL(g_write_publish_hook);
+
+    /* Every subscriber collected before the write is served. Pre-fix the walk
+     * stopped at the freed successor and the trailing subscribers got 0. */
+    for (i = 0; i < 3; i++) {
+        ASSERT_EQ(1, count_packets_of_type(g_clients[i].out_buf,
+            g_clients[i].out_len, MQTT_PACKET_TYPE_PUBLISH));
+    }
+
+    g_fanout_broker = NULL;
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+#ifdef WOLFMQTT_BROKER_WILL
+/* Same hazard on the Will fan-out, which runs its own subscription walk. The
+ * publisher's socket drops, the broker fans its Will out to three subscribers,
+ * and a subscription is freed from inside the first delivery write. */
+TEST(will_fanout_survives_reentrant_sub_free)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    static const byte connect_a[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'A'
+    };
+    static const byte connect_b[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'B'
+    };
+    static const byte connect_c[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'C'
+    };
+    /* Publisher "P" with LWT: flags 0x06 (will | clean), will_topic "lwt",
+     * will_payload "bye". */
+    static const byte connect_p_will[] = {
+        0x10, 0x17, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x06, 0x00, 0x3C,
+        0x00, 0x01, 'P',
+        0x00, 0x03, 'l', 'w', 't',
+        0x00, 0x03, 'b', 'y', 'e'
+    };
+    /* SUBSCRIBE packet_id=1, filter "lwt", QoS 0. */
+    static const byte subscribe_lwt[] = {
+        0x82, 0x08, 0x00, 0x01, 0x00, 0x03, 'l', 'w', 't', 0x00
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(4);
+    mock_client_input_append(0, connect_a, sizeof(connect_a));
+    mock_client_input_append(0, subscribe_lwt, sizeof(subscribe_lwt));
+    mock_client_input_append(1, connect_b, sizeof(connect_b));
+    mock_client_input_append(1, subscribe_lwt, sizeof(subscribe_lwt));
+    mock_client_input_append(2, connect_c, sizeof(connect_c));
+    mock_client_input_append(2, subscribe_lwt, sizeof(subscribe_lwt));
+    mock_client_input_append(3, connect_p_will, sizeof(connect_p_will));
+    for (i = 0; i < 48; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    ASSERT_NOT_NULL(broker.subs);
+    ASSERT_NOT_NULL(broker.subs->next);
+    ASSERT_NOT_NULL(broker.subs->next->next);
+
+    g_fanout_broker = &broker;
+    g_write_publish_hook = fanout_drop_second_sub;
+
+    /* Drop the publisher's socket so its Will fans out. */
+    g_clients[3].read_err = 1;
+    for (i = 0; i < 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    ASSERT_NULL(g_write_publish_hook);
+    for (i = 0; i < 3; i++) {
+        ASSERT_EQ(1, count_packets_of_type(g_clients[i].out_buf,
+            g_clients[i].out_len, MQTT_PACKET_TYPE_PUBLISH));
+    }
+
+    g_fanout_broker = NULL;
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_BROKER_WILL */
 #endif /* !WOLFMQTT_STATIC_MEMORY */
 
 TEST(qos2_duplicate_publish_dedup)
@@ -5047,6 +5255,10 @@ int main(int argc, char** argv)
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
     RUN_TEST(fanout_subs_generation_bumped_on_unsubscribe);
+    RUN_TEST(fanout_survives_reentrant_sub_free);
+#ifdef WOLFMQTT_BROKER_WILL
+    RUN_TEST(will_fanout_survives_reentrant_sub_free);
+#endif
 #endif
     RUN_TEST(qos2_duplicate_publish_dedup);
     RUN_TEST(qos2_phantom_dup_publish_is_fresh);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -1239,6 +1239,74 @@ static int first_disconnect_reason(const byte* buf, size_t len)
  *
  * Pre-fix the broker fanned out twice and the subscriber would see two
  * forwarded PUBLISHes, breaking exactly-once delivery. */
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* The fan-out loop re-validates a snapshotted successor only when the broker's
+ * subscription generation changed during the write, keeping the common case
+ * O(1). This pins two things: an ordinary PUBLISH is still delivered to a
+ * matching subscriber, and removing a subscription (UNSUBSCRIBE) bumps the
+ * generation, so a re-entrant free during a later fan-out is still detected. */
+TEST(fanout_subs_generation_bumped_on_unsubscribe)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    int i;
+    int sub_pubs;
+    word32 gen_after_sub;
+    /* CONNECT subscriber "A". */
+    static const byte connect_sub[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'A'
+    };
+    /* CONNECT publisher "B". */
+    static const byte connect_pub[] = {
+        0x10, 0x0D, 0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'B'
+    };
+    /* SUBSCRIBE packet_id=1, filter "x", QoS 0. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06, 0x00, 0x01, 0x00, 0x01, 'x', 0x00
+    };
+    /* PUBLISH QoS 0, topic "x", payload "hi". remain = 2+1+2 = 5. */
+    static const byte publish_x[] = {
+        0x30, 0x05, 0x00, 0x01, 'x', 'h', 'i'
+    };
+    /* UNSUBSCRIBE packet_id=2, filter "x". remain = 2 + (2+1) = 5. */
+    static const byte unsubscribe_x[] = {
+        0xA2, 0x05, 0x00, 0x02, 0x00, 0x01, 'x'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(0, subscribe_x, sizeof(subscribe_x));
+    mock_client_input_append(1, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, publish_x, sizeof(publish_x));
+    for (i = 0; i < 32; i++) {
+        MqttBroker_Step(&broker);
+    }
+
+    /* The common-case fan-out delivered the PUBLISH to the subscriber. */
+    sub_pubs = count_packets_of_type(g_clients[0].out_buf,
+        g_clients[0].out_len, MQTT_PACKET_TYPE_PUBLISH);
+    ASSERT_EQ(1, sub_pubs);
+    gen_after_sub = broker.subs_gen;
+
+    /* UNSUBSCRIBE removes the BrokerSub and must bump the generation. */
+    mock_client_input_append(0, unsubscribe_x, sizeof(unsubscribe_x));
+    for (i = 0; i < 16; i++) {
+        MqttBroker_Step(&broker);
+    }
+    ASSERT_TRUE(broker.subs_gen != gen_after_sub);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* !WOLFMQTT_STATIC_MEMORY */
+
 TEST(qos2_duplicate_publish_dedup)
 {
     MqttBroker broker;
@@ -4976,6 +5044,9 @@ int main(int argc, char** argv)
 #ifdef WOLFMQTT_V5
     RUN_TEST(connect_v5_emptyid_assigned_id_emitted);
     RUN_TEST(connect_v5_emptyid_clean0_accepted);
+#endif
+#ifndef WOLFMQTT_STATIC_MEMORY
+    RUN_TEST(fanout_subs_generation_bumped_on_unsubscribe);
 #endif
     RUN_TEST(qos2_duplicate_publish_dedup);
     RUN_TEST(qos2_phantom_dup_publish_is_fresh);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -4270,6 +4270,51 @@ TEST(connect_v5_will_qos_exceeds_max_refused)
 }
 #endif /* WOLFMQTT_MAX_QOS < 2 */
 
+#ifndef WOLFMQTT_BROKER_RETAINED
+/* A v5 Server that does not support retained messages must refuse a CONNECT
+ * whose Will Retain is set with reason 0x9A (Retain not supported) and close,
+ * rather than accepting it while advertising Retain Available = 0. */
+TEST(connect_v5_will_retain_unsupported_refused)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    /* v5 CONNECT: clean + Will flag + Will Retain (flags 0x26), Will QoS 0,
+     * ClientId "W", empty CONNECT and Will props, Will topic "lwt", Will
+     * payload "bye". remain = 25 (0x19). */
+    static const byte connect_wretain[] = {
+        0x10, 0x19,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x05,
+        0x26,
+        0x00, 0x3C,
+        0x00,
+        0x00, 0x01, 'W',
+        0x00,
+        0x00, 0x03, 'l', 'w', 't',
+        0x00, 0x03, 'b', 'y', 'e'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_state(connect_wretain, sizeof(connect_wretain));
+    run_broker_one_connect(&broker);
+
+    /* v5 CONNACK: 0x20, remain, ack flags, reason. Must be refused with
+     * Retain-not-supported and closed, not accepted. */
+    ASSERT_TRUE(g_out_len >= 4);
+    ASSERT_EQ(0x20, g_out_buf[0]);
+    ASSERT_EQ(0x00, g_out_buf[2]);
+    ASSERT_EQ(MQTT_REASON_RETAIN_NOT_SUPPORTED, g_out_buf[3]);
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_BROKER_RETAINED */
+
 TEST(will_delay_interval_capped)
 {
     MqttBroker broker;
@@ -5055,6 +5100,9 @@ int main(int argc, char** argv)
     RUN_TEST(will_delay_interval_capped);
 #if WOLFMQTT_MAX_QOS < 2
     RUN_TEST(connect_v5_will_qos_exceeds_max_refused);
+#endif
+#ifndef WOLFMQTT_BROKER_RETAINED
+    RUN_TEST(connect_v5_will_retain_unsupported_refused);
 #endif
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -4224,6 +4224,52 @@ TEST(pending_will_publish_time_uses_min_of_delay_and_session_expiry)
 
 /* A Will Delay Interval above BROKER_MAX_WILL_DELAY_SEC is clamped so a
  * client cannot monopolize a deferred-will slot indefinitely. */
+#if WOLFMQTT_MAX_QOS < 2
+/* [MQTT-3.2.2-11] A v5 Server whose Maximum QoS is below the requested Will
+ * QoS must refuse the CONNECT with reason 0x9B (QoS not supported) and close,
+ * rather than silently downgrading the stored Will QoS. Only reachable in a
+ * build whose WOLFMQTT_MAX_QOS is below 2. */
+TEST(connect_v5_will_qos_exceeds_max_refused)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    /* v5 CONNECT: clean + Will flag + Will QoS 2 (flags 0x16), ClientId "W",
+     * empty CONNECT and Will props, Will topic "lwt", Will payload "bye".
+     * remain = 25 (0x19). */
+    static const byte connect_wq2[] = {
+        0x10, 0x19,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x05,
+        0x16,
+        0x00, 0x3C,
+        0x00,
+        0x00, 0x01, 'W',
+        0x00,
+        0x00, 0x03, 'l', 'w', 't',
+        0x00, 0x03, 'b', 'y', 'e'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_state(connect_wq2, sizeof(connect_wq2));
+    run_broker_one_connect(&broker);
+
+    /* v5 CONNACK: 0x20, remain, ack flags, reason. The connection must be
+     * refused with QoS-not-supported and then closed, not accepted. */
+    ASSERT_TRUE(g_out_len >= 4);
+    ASSERT_EQ(0x20, g_out_buf[0]);
+    ASSERT_EQ(0x00, g_out_buf[2]);
+    ASSERT_EQ(MQTT_REASON_QOS_NOT_SUPPORTED, g_out_buf[3]);
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_MAX_QOS < 2 */
+
 TEST(will_delay_interval_capped)
 {
     MqttBroker broker;
@@ -5007,6 +5053,9 @@ int main(int argc, char** argv)
     defined(WOLFMQTT_BROKER_WILL)
     RUN_TEST(pending_will_publish_time_uses_min_of_delay_and_session_expiry);
     RUN_TEST(will_delay_interval_capped);
+#if WOLFMQTT_MAX_QOS < 2
+    RUN_TEST(connect_v5_will_qos_exceeds_max_refused);
+#endif
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
     RUN_TEST(puback_malformed_closes_connection);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -774,9 +774,51 @@ TEST(auth_without_connect_method_rejected)
     MqttClient_PropsFree(auth.props);
 }
 
+/* Run a v5 CONNECT against a canned accepted CONNACK, optionally carrying an
+ * Authentication Method property. Exercises MqttConnect_HasAuthMethod and its
+ * per-connection assignment in MqttClient_Connect rather than poking
+ * client->auth_method_set directly. */
+static int run_connect_v5_with_auth_method(int with_method)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttProp method_prop;
+    /* v5 CONNACK: accepted, Session Present = 0, no properties. */
+    static const byte connack[] = { 0x20, 0x03, 0x00, 0x00, 0x00 };
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+    if (with_method) {
+        XMEMSET(&method_prop, 0, sizeof(method_prop));
+        method_prop.type = MQTT_PROP_AUTH_METHOD;
+        method_prop.data_str.str = (char*)"SCRAM-SHA-256";
+        method_prop.data_str.len = (word16)XSTRLEN("SCRAM-SHA-256");
+        connect.props = &method_prop;
+    }
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    return rc;
+}
+
 /* Positive control: after a CONNECT that did carry an Authentication Method,
  * MqttClient_Auth must not be blocked by the new guard and the AUTH must reach
- * the wire. Guards against the guard over-rejecting legitimate re-auth. */
+ * the wire. Guards against the guard over-rejecting legitimate re-auth. The
+ * flag is set by driving a real CONNECT, so the detection helper and its
+ * assignment are covered too. A second CONNECT without the property must reset
+ * the flag, since enhanced authentication is negotiated per connection
+ * [MQTT-4.12.0-1]. */
 TEST(auth_with_connect_method_allowed)
 {
     int rc;
@@ -786,7 +828,10 @@ TEST(auth_with_connect_method_allowed)
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
-    test_client.auth_method_set = 1; /* CONNECT negotiated a method */
+
+    rc = run_connect_v5_with_auth_method(1);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, (int)test_client.auth_method_set);
 
     XMEMSET(&auth, 0, sizeof(auth));
     auth.reason_code = MQTT_REASON_CONT_AUTH;
@@ -805,6 +850,31 @@ TEST(auth_with_connect_method_allowed)
     /* Not blocked by the new guard, and the AUTH was written to the wire. */
     ASSERT_NE(MQTT_CODE_ERROR_BAD_ARG, rc);
     ASSERT_TRUE(g_frames_written > 0);
+
+    MqttClient_PropsFree(auth.props);
+
+    /* Reconnect without the property: the negotiation does not carry over, so
+     * the same AUTH must now be refused before anything reaches the wire. */
+    XMEMSET(&auth, 0, sizeof(auth));
+    rc = run_connect_v5_with_auth_method(0);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(0, (int)test_client.auth_method_set);
+
+    auth.reason_code = MQTT_REASON_CONT_AUTH;
+    prop = MqttClient_PropsAdd(&auth.props);
+    ASSERT_NOT_NULL(prop);
+    prop->type = MQTT_PROP_AUTH_METHOD;
+    prop->data_str.str = (char*)"SCRAM-SHA-256";
+    prop->data_str.len = (word16)XSTRLEN("SCRAM-SHA-256");
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Auth(&test_client, &auth);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+    ASSERT_EQ(0, g_frames_written);
 
     MqttClient_PropsFree(auth.props);
 }
@@ -1046,9 +1116,57 @@ TEST(cancel_message_retains_recv_quota_on_wire)
 
     rc = MqttClient_CancelMessage(&test_client, (MqttObject*)&publish);
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    /* Retained: the unit is not credited back and stays reserved. */
+    /* Retained: the unit is not credited back and stays charged against the
+     * connection. */
     ASSERT_EQ(4, test_client.server_recv_max);
-    ASSERT_EQ(1, (int)publish.stat.recvQuotaHeld);
+    /* But ownership leaves the message object, which cancel has just reset for
+     * reuse. Keeping the flag would make the next publish through this object
+     * skip its own reservation. */
+    ASSERT_EQ(0, (int)publish.stat.recvQuotaHeld);
+}
+
+/* [MQTT-4.9] Cancel resets the message object for reuse, so the next publish
+ * through it must reserve its own Receive Maximum unit. With a quota of 1 and
+ * one unit already charged to the canceled publish, reusing the object with a
+ * fresh packet id must be refused rather than put a second PUBLISH on the wire
+ * while the server still counts the first. */
+TEST(cancel_message_reuse_does_not_bypass_recv_quota)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max_negotiated = 1;
+    test_client.server_recv_max = 0; /* the one unit is on the wire */
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 1;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+    publish.stat.recvQuotaHeld = 1;
+
+    rc = MqttClient_CancelMessage(&test_client, (MqttObject*)&publish);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* Reuse the canceled object for a different message. */
+    publish.packet_id = 2;
+    publish.buffer_pos = 0;
+
+    g_frames_written = 0;
+    rc = MqttClient_Publish(&test_client, &publish);
+
+    /* Quota exhausted, so nothing may reach the wire. */
+    ASSERT_EQ(MQTT_CODE_ERROR_SERVER_PROP, rc);
+    ASSERT_EQ(0, g_frames_written);
 }
 
 /* Cancelling the same abandoned publish twice is stable: the retained unit is
@@ -2697,6 +2815,15 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
     ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED,
         test_client.firstPendResp->packet_ret);
     ASSERT_NULL(test_client.firstPendResp->recvQuotaStat);
+
+    /* The documented contract, exercised through the public API rather than the
+     * internal node: the publisher's next poll must return the rejection, not
+     * another MQTT_CODE_CONTINUE. */
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
 #endif
 }
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
@@ -2785,6 +2912,68 @@ TEST(publish_writeonly_v5_cancel_holds_receive_max)
      * PUBLISH may be on the wire, so the quota stays held (conservative). */
     ASSERT_EQ(0, test_client.server_recv_max);
     ASSERT_NULL(test_client.firstPendResp);
+
+    /* Ownership of that unit left the message object, so reusing it does not
+     * inherit a reservation it no longer owns. */
+    ASSERT_EQ(0, (int)publish.stat.recvQuotaHeld);
+}
+
+/* [MQTT-4.9] A reserved Receive Maximum unit belongs to the connection that
+ * charged it. MqttClient_NetDisconnect drops the pending responses without
+ * crediting - the next connect re-negotiates the quota - so it must also drop
+ * ownership from the message objects. A publish object reused after a
+ * reconnect that kept its recvQuotaHeld would skip the decrement and put one
+ * more PUBLISH in flight than the new connection allows. */
+TEST(disconnect_clears_recv_quota_ownership)
+{
+    int rc;
+    int i;
+    static MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 30;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
+    ASSERT_EQ(0, test_client.server_recv_max);
+    ASSERT_EQ(1, (int)publish.stat.recvQuotaHeld);
+
+    rc = MqttClient_NetDisconnect(&test_client);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_NULL(test_client.firstPendResp);
+    ASSERT_EQ(0, (int)publish.stat.recvQuotaHeld);
+
+    /* Stand in for the reconnect that re-negotiates the quota, then reuse the
+     * same object: it must reserve again rather than ride the stale flag. */
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+    publish.stat.write = MQTT_MSG_BEGIN;
+    publish.stat.read = MQTT_MSG_BEGIN;
+    publish.packet_id = 31;
+    publish.buffer_pos = 0;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
+    ASSERT_EQ(0, test_client.server_recv_max);
 }
 #endif /* WOLFMQTT_NONBLOCK */
 #endif /* WOLFMQTT_MULTITHREAD */
@@ -3298,6 +3487,73 @@ TEST(wait_message_qos2_duplicate_publish_delivered_once)
     ASSERT_TRUE(g_pubresp_written);
     ASSERT_EQ(1, g_msg_cb_calls);
 }
+
+#ifdef WOLFMQTT_V5
+/* Rejects every delivery with a v5 failure reason, which HandlePacket copies
+ * into the outgoing PUBREC. */
+static int test_reject_message_cb(MqttClient* client, MqttMessage* msg,
+    byte msg_new, byte msg_done)
+{
+    (void)client; (void)msg_new; (void)msg_done;
+    g_msg_cb_calls++;
+    msg->resp.reason_code = MQTT_REASON_NOT_AUTHORIZED;
+    return MQTT_CODE_SUCCESS;
+}
+
+/* [MQTT-4.3.3] A PUBREC carrying a reason code >= 0x80 ends the QoS 2 exchange:
+ * no PUBREL follows, and the sender may reuse the packet id immediately. The
+ * receiver must therefore NOT record that id as awaiting PUBREL - the entry
+ * would never be cleared, holding a dedup slot forever and suppressing the next
+ * PUBLISH that legitimately reuses the id. Two v5 QoS 2 PUBLISHes share packet
+ * id 9; the callback rejects both, so both must reach the application. */
+TEST(wait_message_qos2_rejected_publish_not_deduped)
+{
+    int rc = MQTT_CODE_SUCCESS;
+    int i;
+    /* Two v5 QoS2 PUBLISH frames, both packet_id=9, topic "a", prop_len=0,
+     * payload "hi": type|qos2=0x34, remain=8. */
+    static const byte publish_v5_qos2[] = {
+        0x34, 0x08, 0x00, 0x01, 'a', 0x00, 0x09, 0x00, 'h', 'i',
+        0x34, 0x08, 0x00, 0x01, 'a', 0x00, 0x09, 0x00, 'h', 'i'
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.msg_cb = test_reject_message_cb;
+    g_msg_cb_calls = 0;
+
+    g_pubresp_written = 0;
+    g_last_ack_written = MQTT_PACKET_TYPE_RESERVED;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, publish_v5_qos2, sizeof(publish_v5_qos2));
+    g_canned_len = (int)sizeof(publish_v5_qos2);
+    g_canned_pos = 0;
+
+    for (i = 0; i < 40 && g_canned_pos < g_canned_len; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+        if (rc != MQTT_CODE_SUCCESS && rc != MQTT_CODE_CONTINUE) {
+            break;
+        }
+    }
+
+    /* The rejected id was never tracked, so the second PUBLISH is a fresh
+     * message and must be delivered, not suppressed as a duplicate. */
+    ASSERT_EQ(2, g_msg_cb_calls);
+    ASSERT_EQ(0, test_client.recv_qos2_pending[0]);
+
+    /* Both were answered with a rejecting PUBREC. The second one carries the
+     * reason only because its delivery actually happened; a suppressed
+     * redelivery would leave the reason at success and shorten the frame. */
+    ASSERT_TRUE(g_pubresp_written);
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_REC, g_last_ack_written);
+    ASSERT_EQ(9, g_last_ack_id);
+    /* v5 PUBREC: type, remain, id hi, id lo, reason. */
+    ASSERT_EQ(5, connect_mock_xfer);
+    ASSERT_EQ(MQTT_REASON_NOT_AUTHORIZED, connect_mock_sent[4]);
+}
+#endif /* WOLFMQTT_V5 */
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 
 /* The four PUBLISH-response packet types (PUBACK 4, PUBREC 5, PUBREL 6,
@@ -4077,6 +4333,7 @@ void run_mqtt_client_tests(void)
 #if defined(WOLFMQTT_MULTITHREAD) || defined(WOLFMQTT_NONBLOCK)
     RUN_TEST(cancel_message_retains_recv_quota_on_wire);
     RUN_TEST(cancel_message_retain_is_idempotent);
+    RUN_TEST(cancel_message_reuse_does_not_bypass_recv_quota);
 #endif
     RUN_TEST(publish_qos1_v5_write_failure_restores_recv_quota);
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
@@ -4091,6 +4348,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject);
 #endif
     RUN_TEST(publish_writeonly_v5_cancel_holds_receive_max);
+    RUN_TEST(disconnect_clears_recv_quota_ownership);
 #else
     RUN_TEST(publish_writeonly_v5_no_dangling_pendresp_on_success);
 #endif
@@ -4115,6 +4373,9 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_qos2_publish_acks_pubrec);
 #if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(wait_message_qos2_duplicate_publish_delivered_once);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(wait_message_qos2_rejected_publish_not_deduped);
+#endif
 #endif
     RUN_TEST(wait_message_pubrec_emits_pubrel);
     RUN_TEST(wait_message_pubrel_emits_pubcomp);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -1190,6 +1190,45 @@ TEST(publish_v5_topic_alias_zero_rejected)
     MqttClient_PropsFree(publish.props);
 }
 
+/* [MQTT-3.3.4-6] A PUBLISH sent from a Client to a Server MUST NOT contain a
+ * Subscription Identifier; that property is only valid on a Server-to-Client
+ * PUBLISH the broker generates. The client publish path must reject it before
+ * anything reaches the wire rather than transmitting an illegal packet. */
+TEST(publish_v5_subscription_id_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    MqttProp* prop;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_0;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    prop = MqttClient_PropsAdd(&publish.props);
+    ASSERT_NOT_NULL(prop);
+    prop->type = MQTT_PROP_SUBSCRIPTION_ID;
+    prop->data_int = 1;
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* errors if ever reached */
+
+    rc = MqttClient_Publish(&test_client, &publish);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+    ASSERT_EQ(0, g_frames_written);
+
+    MqttClient_PropsFree(publish.props);
+}
+
 /* MQTT v5 [3.1.2.11.6]: only Max QoS 0 or 1 are legal. A non-conforming or
  * malicious broker that advertises a larger value (2 here) must be clamped to
  * MQTT_QOS_1 before being narrowed against this build's WOLFMQTT_MAX_QOS, so the
@@ -3239,6 +3278,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_v311_ack_not_misread_as_rejected);
     RUN_TEST(publish_v5_topic_alias_zero_rejected);
     RUN_TEST(publish_v5_topic_alias_exceeds_max_rejected);
+    RUN_TEST(publish_v5_subscription_id_rejected);
 #ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes);
 #endif

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2234,7 +2234,9 @@ TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
     /* The publisher's own struct is NOT updated on this path. */
     ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
 }
+#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
 
+#ifdef WOLFMQTT_MULTITHREAD
 /* [MQTT-3.3.4-9] Receive Maximum bounds unacknowledged QoS>0 PUBLISH packets,
  * and MqttClient_Publish_WriteOnly must honor it like any other publish. With
  * the quota exhausted, a write-only QoS 1 publish must be refused before
@@ -2298,9 +2300,13 @@ TEST(publish_writeonly_v5_receive_max_released_on_puback)
     publish.total_len = (word32)(sizeof(payload) - 1);
     publish.buffer_len = publish.total_len;
 
-    rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
-    /* The single unit was reserved and the call returned without waiting. */
-    ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
+    /* Drive the write-only publish to completion. It returns CONTINUE under
+     * WOLFMQTT_NONBLOCK and SUCCESS in a blocking MT build; either way the unit
+     * is reserved and outstanding until the reader processes the ack. */
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
     ASSERT_EQ(0, test_client.server_recv_max);
 
     /* Reading thread processes the PUBACK. */
@@ -2315,7 +2321,55 @@ TEST(publish_writeonly_v5_receive_max_released_on_puback)
     /* The reserved unit was credited back rather than leaked. */
     ASSERT_EQ(1, test_client.server_recv_max);
 }
-#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
+
+/* A write-only QoS 2 publish reserves a unit; a broker rejection at the PUBREC
+ * stage (reason >= 0x80) ends the exchange with no PUBCOMP, so the unit must
+ * still be credited back rather than leaked. */
+TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
+{
+    int rc;
+    int i;
+    static MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBREC: type=0x50, remain=3, packet_id=22 (0x16), reason=0x97. */
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x16, 0x97 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 22;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
+    ASSERT_EQ(0, test_client.server_recv_max);
+
+    /* Reading thread processes the rejecting PUBREC. */
+    XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
+    g_canned_len = (int)sizeof(pubrec);
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    /* The reserved unit was credited back despite the rejection. */
+    ASSERT_EQ(1, test_client.server_recv_max);
+}
+#endif /* WOLFMQTT_MULTITHREAD */
 #endif /* WOLFMQTT_V5 */
 
 /* Regression test for MQTT Packet Identifier in-use collision check. The
@@ -3597,8 +3651,11 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos1_v5_write_failure_restores_recv_quota);
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
     RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
+#endif
+#ifdef WOLFMQTT_MULTITHREAD
     RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
+    RUN_TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject);
 #endif
 #endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -1299,6 +1299,82 @@ TEST(publish_v5_subscription_id_rejected)
     MqttClient_PropsFree(publish.props);
 }
 
+/* [MQTT-3.1.2-24] The whole PUBLISH Control Packet must fit the Server's
+ * Maximum Packet Size. A payload larger than tx_buf is streamed in tx_buf-sized
+ * fragments, each within the negotiated limit, so the per-write check cannot see
+ * that the cumulative packet exceeds it. The publish path must reject the whole
+ * oversized packet before any byte is written. */
+TEST(publish_v5_oversized_packet_rejected_before_write)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[400];
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    /* Larger than any single tx_buf-sized fragment (<=256), smaller than the
+     * whole PUBLISH (~417 bytes). */
+    test_client.packet_sz_max = 300;
+
+    XMEMSET(payload, 'x', sizeof(payload));
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_0;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)sizeof(payload);
+    publish.buffer_len = publish.total_len;
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_SERVER_PROP, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+/* Positive control: a PUBLISH whose whole size is within the Server's Maximum
+ * Packet Size must still be sent, so the new whole-packet check does not
+ * over-reject a legitimate large-but-permitted publish. */
+TEST(publish_v5_within_max_packet_size_allowed)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[400];
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.packet_sz_max = 1000; /* comfortably above the ~417-byte packet */
+
+    XMEMSET(payload, 'x', sizeof(payload));
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_0;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)sizeof(payload);
+    publish.buffer_len = publish.total_len;
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+
+    ASSERT_NE(MQTT_CODE_ERROR_SERVER_PROP, rc);
+    ASSERT_TRUE(g_frames_written > 0);
+}
+
 /* MQTT v5 [3.1.2.11.6]: only Max QoS 0 or 1 are legal. A non-conforming or
  * malicious broker that advertises a larger value (2 here) must be clamped to
  * MQTT_QOS_1 before being narrowed against this build's WOLFMQTT_MAX_QOS, so the
@@ -3351,6 +3427,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_v5_topic_alias_zero_rejected);
     RUN_TEST(publish_v5_topic_alias_exceeds_max_rejected);
     RUN_TEST(publish_v5_subscription_id_rejected);
+    RUN_TEST(publish_v5_oversized_packet_rejected_before_write);
+    RUN_TEST(publish_v5_within_max_packet_size_allowed);
 #ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes);
 #endif

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2143,6 +2143,121 @@ TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected)
     ASSERT_FALSE(g_pubrel_written);
 }
 
+/* [MQTT-4.9] A PUBREC rejection (reason >= 0x80) ends the QoS 2 exchange and
+ * frees the reserved Receive Maximum unit. MqttPublishMsg must credit it back
+ * on this path, which surfaces as PUBLISH_REJECTED rather than SUCCESS; without
+ * that credit a non-multithread build leaks one unit per rejection. */
+TEST(publish_qos2_v5_pubrec_reject_restores_receive_max)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBREC: type=0x50, remain=3, packet_id=15 (0x0F), reason=0x87. */
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x0F, 0x87 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
+    g_canned_len = (int)sizeof(pubrec);
+    g_canned_pos = 0;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 15;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+    /* The reserved unit was credited back, not leaked. */
+    ASSERT_EQ(1, test_client.server_recv_max);
+}
+
+#if WOLFMQTT_MAX_QOS >= 2
+/* [MQTT-4.3.3-10] A resumed session (Clean Start = 0) keeps its inbound QoS 2
+ * dedup state across reconnect, so a server retransmit still awaiting PUBREL is
+ * not delivered to the application a second time. */
+TEST(connect_clean0_preserves_qos2_dedup)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* v3.1.1 CONNACK: Session Present = 1 (resume), accepted. */
+    static const byte connack[] = { 0x20, 0x02, 0x01, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    /* A prior connection left an inbound QoS 2 id awaiting PUBREL. */
+    test_client.recv_qos2_pending[0] = 9;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(9, test_client.recv_qos2_pending[0]);
+}
+
+/* Clean Start = 1 clears the inbound QoS 2 dedup state, since packet ids
+ * restart for a fresh session. */
+TEST(connect_clean1_clears_qos2_dedup)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* v3.1.1 CONNACK: Session Present = 0, accepted. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    test_client.recv_qos2_pending[0] = 9;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(0, test_client.recv_qos2_pending[0]);
+}
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
+
 /* A v3.1.1 PUBACK carries no reason code, so the rejection check must not run
  * for protocol level < 5. Pre-seed resp.reason_code with a failure byte to
  * prove the protocol_level guard prevents a stale value from being misread as
@@ -2237,6 +2352,11 @@ TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
 #endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
 
 #ifdef WOLFMQTT_MULTITHREAD
+/* The write-only Receive Maximum lifecycle (reserve, enforce, release) is
+ * exercised only where the ack is tracked to completion: a non-blocking
+ * multithread build. A blocking multithread write-only reports success while
+ * abandoning the ack, so it does not reserve (see MqttPublishMsg). */
+#ifdef WOLFMQTT_NONBLOCK
 /* [MQTT-3.3.4-9] Receive Maximum bounds unacknowledged QoS>0 PUBLISH packets,
  * and MqttClient_Publish_WriteOnly must honor it like any other publish. With
  * the quota exhausted, a write-only QoS 1 publish must be refused before
@@ -2376,13 +2496,26 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
 
     /* The reserved unit was credited back despite the rejection. */
     ASSERT_EQ(1, test_client.server_recv_max);
+#ifdef WOLFMQTT_NONBLOCK
+    /* Under NONBLOCK the write-only pending response is left for the reader, so
+     * it must be completed with the rejection (so a poll observes it instead of
+     * spinning) and its quota back-reference cleared. In a blocking build the
+     * give-up path already removed it, so there is nothing left to inspect. */
+    ASSERT_NOT_NULL(test_client.firstPendResp);
+    ASSERT_TRUE(test_client.firstPendResp->packetDone);
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED,
+        test_client.firstPendResp->packet_ret);
+    ASSERT_NULL(test_client.firstPendResp->recvQuotaStat);
+#endif
 }
+#endif /* WOLFMQTT_NONBLOCK */
 
 #ifndef WOLFMQTT_NONBLOCK
 /* In a multithread build without NONBLOCK, MqttClient_Publish_WriteOnly reports
  * SUCCESS while the ack is still outstanding. The caller may then free its
  * MqttPublish (here on the stack), so no pending response may still reference
- * it, and the reserved quota must be released rather than orphaned. */
+ * it. Because the ack cannot be tracked to completion in this build, no
+ * Receive Maximum unit is reserved for it, so none can be orphaned. */
 TEST(publish_writeonly_v5_no_dangling_pendresp_on_success)
 {
     int rc;
@@ -2411,16 +2544,19 @@ TEST(publish_writeonly_v5_no_dangling_pendresp_on_success)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     /* No dangling reference to the soon-freed stack object. */
     ASSERT_NULL(test_client.firstPendResp);
-    /* The reserved unit was released, not orphaned. */
+    /* No unit was reserved, so the quota is untouched. */
     ASSERT_EQ(1, test_client.server_recv_max);
 }
 #endif /* !WOLFMQTT_NONBLOCK */
 
 #ifdef WOLFMQTT_NONBLOCK
-/* Cancelling a write-only publish whose ack is still outstanding must release
- * the reserved Receive Maximum unit, not leak it: the shipped multithread
- * example cancels on the non-success path. */
-TEST(publish_writeonly_v5_cancel_releases_receive_max)
+/* Cancelling a write-only publish whose ack is still outstanding must NOT credit
+ * the reserved Receive Maximum unit: the PUBLISH may already be on the wire,
+ * where the server keeps counting it [MQTT-4.9], so crediting it locally could
+ * push the client past the negotiated quota. The unit stays held until the ack
+ * arrives or the connection resets server_recv_max. The conservative leak is the
+ * safe failure; over-crediting an on-wire packet is not. */
+TEST(publish_writeonly_v5_cancel_holds_receive_max)
 {
     int rc;
     int i;
@@ -2453,8 +2589,9 @@ TEST(publish_writeonly_v5_cancel_releases_receive_max)
 
     MqttClient_CancelMessage(&test_client, (MqttObject*)&publish);
 
-    /* The cancel released the reserved unit rather than leaking it. */
-    ASSERT_EQ(1, test_client.server_recv_max);
+    /* The cancel removed the pending response but did NOT credit the unit: the
+     * PUBLISH may be on the wire, so the quota stays held (conservative). */
+    ASSERT_EQ(0, test_client.server_recv_max);
     ASSERT_NULL(test_client.firstPendResp);
 }
 #endif /* WOLFMQTT_NONBLOCK */
@@ -3723,6 +3860,11 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_success_returns_success);
     RUN_TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected);
+    RUN_TEST(publish_qos2_v5_pubrec_reject_restores_receive_max);
+#if WOLFMQTT_MAX_QOS >= 2
+    RUN_TEST(connect_clean0_preserves_qos2_dedup);
+    RUN_TEST(connect_clean1_clears_qos2_dedup);
+#endif
     RUN_TEST(publish_v311_ack_not_misread_as_rejected);
     RUN_TEST(publish_v5_topic_alias_zero_rejected);
     RUN_TEST(publish_v5_topic_alias_exceeds_max_rejected);
@@ -3742,14 +3884,13 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
 #endif
 #ifdef WOLFMQTT_MULTITHREAD
+#ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject);
-#ifndef WOLFMQTT_NONBLOCK
+    RUN_TEST(publish_writeonly_v5_cancel_holds_receive_max);
+#else
     RUN_TEST(publish_writeonly_v5_no_dangling_pendresp_on_success);
-#endif
-#ifdef WOLFMQTT_NONBLOCK
-    RUN_TEST(publish_writeonly_v5_cancel_releases_receive_max);
 #endif
 #endif
 #endif

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2044,6 +2044,10 @@ TEST(publish_qos1_v5_no_matching_subscribers_returns_success)
     ASSERT_EQ(MQTT_REASON_NO_MATCH_SUB, publish.resp.reason_code);
 }
 
+#if WOLFMQTT_MAX_QOS >= 2
+/* A QoS-capped build refuses a QoS 2 publish before it reaches the wire, so
+ * every test below that drives a QoS 2 handshake is capped to match. */
+
 /* QoS 2 completes the PUBLISH -> PUBREC -> PUBREL -> PUBCOMP handshake. A v5
  * broker can reject at the PUBCOMP with a reason code >= 0x80 (e.g. 0x92
  * Packet Identifier not found); MqttClient_Publish must surface that as
@@ -2186,7 +2190,6 @@ TEST(publish_qos2_v5_pubrec_reject_restores_receive_max)
     ASSERT_EQ(1, test_client.server_recv_max);
 }
 
-#if WOLFMQTT_MAX_QOS >= 2
 /* [MQTT-4.3.3-10] A session the server resumes (Clean Start = 0 answered with
  * Session Present = 1) keeps its inbound QoS 2 dedup state across reconnect, so
  * a server retransmit still awaiting PUBREL is not delivered to the application
@@ -2294,6 +2297,154 @@ TEST(connect_resume_declined_clears_qos2_dedup)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(0, test_client.recv_qos2_pending[0]);
 }
+
+static byte g_connect_wire[512];
+static int  g_connect_wire_len;
+
+static int mock_net_write_capture(void *context, const byte* buf, int buf_len,
+    int timeout_ms)
+{
+    (void)context; (void)timeout_ms;
+    if (buf != NULL && buf_len > 0 &&
+            g_connect_wire_len + buf_len <= (int)sizeof(g_connect_wire)) {
+        XMEMCPY(g_connect_wire + g_connect_wire_len, buf, (size_t)buf_len);
+        g_connect_wire_len += buf_len;
+    }
+    return buf_len; /* accept the whole chunk */
+}
+
+/* Point *props at the property block of the captured v5 CONNECT and return its
+ * length, or -1 if the frame is truncated. Layout: type byte, Remaining Length
+ * (VBI), 10-byte variable header ("MQTT" + level + flags + keep alive), then
+ * the Property Length (VBI) and the properties themselves. */
+static int connect_wire_props(const byte* wire, int len, const byte** props)
+{
+    int pos = 1; /* past the fixed header type byte */
+    int prop_len = 0;
+    int shift = 0;
+
+    while (pos < len && (wire[pos] & 0x80)) {
+        pos++;
+    }
+    pos++;     /* final Remaining Length byte */
+    pos += 10; /* v5 variable header */
+    while (pos < len) {
+        prop_len |= (int)(wire[pos] & 0x7F) << shift;
+        shift += 7;
+        if (!(wire[pos] & 0x80)) {
+            pos++;
+            break;
+        }
+        pos++;
+    }
+    if (pos > len || prop_len > len - pos) {
+        return -1;
+    }
+    *props = wire + pos;
+    return prop_len;
+}
+
+/* [MQTT-3.3.4] The inbound QoS 2 dedup table holds MQTT_MAX_RECV_QOS2 packet
+ * ids; without an advertised Receive Maximum a server may keep more QoS 2
+ * PUBLISHes un-PUBRELed than fit, and the ids that go untracked lose duplicate
+ * suppression [MQTT-4.3.3-10]. A v5 CONNECT must therefore carry Receive
+ * Maximum (0x21) set to the table size. */
+TEST(connect_v5_advertises_receive_max)
+{
+    int rc;
+    int i;
+    int prop_len;
+    const byte* props = NULL;
+    MqttConnect connect;
+    /* v5 CONNACK: accepted, Session Present = 0, no properties. */
+    static const byte connack[] = { 0x20, 0x03, 0x00, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    g_connect_wire_len = 0;
+    test_net.write = mock_net_write_capture;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* Receive Maximum is the only property, so the block is exactly the
+     * identifier plus its two-byte value. */
+    prop_len = connect_wire_props(g_connect_wire, g_connect_wire_len, &props);
+    ASSERT_EQ(3, prop_len);
+    ASSERT_EQ(MQTT_PROP_RECEIVE_MAX, props[0]);
+    ASSERT_EQ((MQTT_MAX_RECV_QOS2 >> 8) & 0xFF, props[1]);
+    ASSERT_EQ(MQTT_MAX_RECV_QOS2 & 0xFF, props[2]);
+
+    /* The client added no property to the caller's list. */
+    ASSERT_NULL(connect.props);
+}
+
+/* An application that set its own Receive Maximum keeps it: the client must not
+ * override the explicit choice, nor emit the property twice, nor leave its own
+ * node linked into the caller's list once the CONNECT is encoded. */
+TEST(connect_v5_app_receive_max_preserved)
+{
+    int rc;
+    int i;
+    int prop_len;
+    const byte* props = NULL;
+    MqttConnect connect;
+    MqttProp app_prop;
+    /* v5 CONNACK: accepted, Session Present = 0, no properties. */
+    static const byte connack[] = { 0x20, 0x03, 0x00, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    g_connect_wire_len = 0;
+    test_net.write = mock_net_write_capture;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&app_prop, 0, sizeof(app_prop));
+    app_prop.type = MQTT_PROP_RECEIVE_MAX;
+    app_prop.data_short = 5;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+    connect.props = &app_prop;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* Still a single Receive Maximum, carrying the application's value. */
+    prop_len = connect_wire_props(g_connect_wire, g_connect_wire_len, &props);
+    ASSERT_EQ(3, prop_len);
+    ASSERT_EQ(MQTT_PROP_RECEIVE_MAX, props[0]);
+    ASSERT_EQ(0, props[1]);
+    ASSERT_EQ(5, props[2]);
+
+    /* The caller's list is exactly as it was handed in. */
+    ASSERT_TRUE(connect.props == &app_prop);
+    ASSERT_NULL(app_prop.next);
+}
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 
 /* A v3.1.1 PUBACK carries no reason code, so the rejection check must not run
@@ -2324,7 +2475,8 @@ TEST(publish_v311_ack_not_misread_as_rejected)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
 }
 
-#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
+    WOLFMQTT_MAX_QOS >= 2
 /* Pins the documented WOLFMQTT_MULTITHREAD divergence for a QoS 2 PUBREC
  * rejection. A write-only publish registers a pending response for the PUBCOMP
  * and returns without reading; a separate "reading thread" (simulated here by
@@ -2387,7 +2539,7 @@ TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
     /* The publisher's own struct is NOT updated on this path. */
     ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
 }
-#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
+#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK && WOLFMQTT_MAX_QOS >= 2 */
 
 #ifdef WOLFMQTT_MULTITHREAD
 /* The write-only Receive Maximum lifecycle (reserve, enforce, release) is
@@ -2484,6 +2636,7 @@ TEST(publish_writeonly_v5_receive_max_released_on_puback)
     ASSERT_EQ(1, test_client.server_recv_max);
 }
 
+#if WOLFMQTT_MAX_QOS >= 2
 /* A write-only QoS 2 publish reserves a unit; a broker rejection at the PUBREC
  * stage (reason >= 0x80) ends the exchange with no PUBCOMP, so the unit must
  * still be credited back rather than leaked. */
@@ -2546,6 +2699,7 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
     ASSERT_NULL(test_client.firstPendResp->recvQuotaStat);
 #endif
 }
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
 #endif /* WOLFMQTT_NONBLOCK */
 
 #ifndef WOLFMQTT_NONBLOCK
@@ -3095,12 +3249,15 @@ TEST(wait_message_qos2_publish_acks_pubrec)
     ASSERT_EQ(9, g_last_ack_id);
 }
 
+#if WOLFMQTT_MAX_QOS >= 2
 /* [MQTT-4.3.3-10] Until the matching PUBREL is received, a retransmitted QoS 2
  * PUBLISH must be answered with another PUBREC but MUST NOT be delivered to the
  * application a second time. Two identical QoS 2 PUBLISH frames (both packet
  * id 9, no intervening PUBREL) arrive back to back; the message callback must
  * fire exactly once while both frames are acknowledged. Pre-fix the client had
- * no inbound QoS 2 dedup and delivered the duplicate, so g_msg_cb_calls was 2. */
+ * no inbound QoS 2 dedup and delivered the duplicate, so g_msg_cb_calls was 2.
+ * The dedup this asserts is compiled out below WOLFMQTT_MAX_QOS 2, so the test
+ * is capped to match. */
 TEST(wait_message_qos2_duplicate_publish_delivered_once)
 {
     int rc = MQTT_CODE_SUCCESS;
@@ -3141,6 +3298,7 @@ TEST(wait_message_qos2_duplicate_publish_delivered_once)
     ASSERT_TRUE(g_pubresp_written);
     ASSERT_EQ(1, g_msg_cb_calls);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
 
 /* The four PUBLISH-response packet types (PUBACK 4, PUBREC 5, PUBREL 6,
  * PUBCOMP 7) all decode through the same branch of MqttClient_HandlePacket, but
@@ -3895,14 +4053,16 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos1_v5_success_returns_success);
     RUN_TEST(publish_qos1_v5_no_matching_subscribers_returns_success);
+#if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_success_returns_success);
     RUN_TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_pubrec_reject_restores_receive_max);
-#if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(connect_clean0_preserves_qos2_dedup);
     RUN_TEST(connect_clean1_clears_qos2_dedup);
     RUN_TEST(connect_resume_declined_clears_qos2_dedup);
+    RUN_TEST(connect_v5_advertises_receive_max);
+    RUN_TEST(connect_v5_app_receive_max_preserved);
 #endif
     RUN_TEST(publish_v311_ack_not_misread_as_rejected);
     RUN_TEST(publish_v5_topic_alias_zero_rejected);
@@ -3919,14 +4079,17 @@ void run_mqtt_client_tests(void)
     RUN_TEST(cancel_message_retain_is_idempotent);
 #endif
     RUN_TEST(publish_qos1_v5_write_failure_restores_recv_quota);
-#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
+    WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
 #endif
 #ifdef WOLFMQTT_MULTITHREAD
 #ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
+#if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject);
+#endif
     RUN_TEST(publish_writeonly_v5_cancel_holds_receive_max);
 #else
     RUN_TEST(publish_writeonly_v5_no_dangling_pendresp_on_success);
@@ -3950,7 +4113,9 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_qos0_publish_no_ack);
     RUN_TEST(wait_message_qos1_publish_acks_puback);
     RUN_TEST(wait_message_qos2_publish_acks_pubrec);
+#if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(wait_message_qos2_duplicate_publish_delivered_once);
+#endif
     RUN_TEST(wait_message_pubrec_emits_pubrel);
     RUN_TEST(wait_message_pubrel_emits_pubcomp);
     RUN_TEST(wait_message_puback_emits_no_ack);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2187,9 +2187,10 @@ TEST(publish_qos2_v5_pubrec_reject_restores_receive_max)
 }
 
 #if WOLFMQTT_MAX_QOS >= 2
-/* [MQTT-4.3.3-10] A resumed session (Clean Start = 0) keeps its inbound QoS 2
- * dedup state across reconnect, so a server retransmit still awaiting PUBREL is
- * not delivered to the application a second time. */
+/* [MQTT-4.3.3-10] A session the server resumes (Clean Start = 0 answered with
+ * Session Present = 1) keeps its inbound QoS 2 dedup state across reconnect, so
+ * a server retransmit still awaiting PUBREL is not delivered to the application
+ * a second time. */
 TEST(connect_clean0_preserves_qos2_dedup)
 {
     int rc;
@@ -2247,6 +2248,43 @@ TEST(connect_clean1_clears_qos2_dedup)
     XMEMSET(&connect, 0, sizeof(connect));
     connect.keep_alive_sec = 60;
     connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(0, test_client.recv_qos2_pending[0]);
+}
+
+/* The server, not the client, decides whether a session resumes. A Clean Start
+ * = 0 request answered with Session Present = 0 is a fresh session, so stale
+ * inbound QoS 2 dedup state must be dropped; otherwise it would suppress a new
+ * PUBLISH that reuses one of those packet ids [MQTT-4.3.3-10]. */
+TEST(connect_resume_declined_clears_qos2_dedup)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* v3.1.1 CONNACK: Session Present = 0 (server declined resume), accepted. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    /* A prior connection left an inbound QoS 2 id awaiting PUBREL. */
+    test_client.recv_qos2_pending[0] = 9;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
     connect.client_id = "test_client";
 
     rc = MQTT_CODE_CONTINUE;
@@ -3864,6 +3902,7 @@ void run_mqtt_client_tests(void)
 #if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(connect_clean0_preserves_qos2_dedup);
     RUN_TEST(connect_clean1_clears_qos2_dedup);
+    RUN_TEST(connect_resume_declined_clears_qos2_dedup);
 #endif
     RUN_TEST(publish_v311_ack_not_misread_as_rejected);
     RUN_TEST(publish_v5_topic_alias_zero_rejected);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -519,6 +519,80 @@ TEST(connect_accepted_connack_returns_success)
     ASSERT_EQ(MQTT_CONNECT_ACK_CODE_ACCEPTED, connect.ack.return_code);
 }
 
+/* [MQTT-3.2.2-1] / [MQTT-3.2.2-4] When the Client requests Clean Session /
+ * Clean Start, the Server MUST report Session Present = 0. A successful CONNACK
+ * that reports Session Present = 1 in that case is a protocol violation, so the
+ * client must refuse the connection rather than report success. */
+TEST(connect_clean_session_present_mismatch_refused)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v3.1.1: type=0x20, remain=2, flags=0x01 (Session Present),
+     * return_code=0x00 (accepted). */
+    static const byte connack[] = { 0x20, 0x02, 0x01, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_ERROR_SERVER_PROP, rc);
+}
+
+/* Positive control: with Clean Session = 0 the client may resume a prior
+ * session, so Session Present = 1 is valid and must be accepted, confirming the
+ * cross-check keys off the requested Clean Session and does not over-reject. */
+TEST(connect_resume_session_present_accepted)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* CONNACK v3.1.1: flags=0x01 (Session Present), return_code=0x00. */
+    static const byte connack[] = { 0x20, 0x02, 0x01, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
 /* A broker that refuses the connection returns a CONNACK whose return code is
  * non-zero (0x05 = not authorized here). MqttClient_Connect must surface this
  * as MQTT_CODE_ERROR_CONNECT_REFUSED rather than MQTT_CODE_SUCCESS, else an
@@ -3373,6 +3447,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_with_mock_network);
     RUN_TEST(connect_clears_tx_buf_credentials);
     RUN_TEST(connect_accepted_connack_returns_success);
+    RUN_TEST(connect_clean_session_present_mismatch_refused);
+    RUN_TEST(connect_resume_session_present_accepted);
     RUN_TEST(connect_refused_connack_returns_connect_refused);
 #if defined(WOLFMQTT_V5)
     RUN_TEST(connect_accepted_connack_latches_v5_props);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2307,7 +2307,11 @@ TEST(publish_writeonly_v5_receive_max_released_on_puback)
     for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
         rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
     }
+#ifdef WOLFMQTT_NONBLOCK
+    /* Under NONBLOCK the unit stays reserved until the reader acks it; a
+     * blocking multithread build releases it at the give-up point instead. */
     ASSERT_EQ(0, test_client.server_recv_max);
+#endif
 
     /* Reading thread processes the PUBACK. */
     XMEMCPY(g_canned_buf, puback, sizeof(puback));
@@ -2355,7 +2359,11 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
     for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
         rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
     }
+#ifdef WOLFMQTT_NONBLOCK
+    /* Under NONBLOCK the unit stays reserved until the reader acks it; a
+     * blocking multithread build releases it at the give-up point instead. */
     ASSERT_EQ(0, test_client.server_recv_max);
+#endif
 
     /* Reading thread processes the rejecting PUBREC. */
     XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
@@ -2369,6 +2377,87 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
     /* The reserved unit was credited back despite the rejection. */
     ASSERT_EQ(1, test_client.server_recv_max);
 }
+
+#ifndef WOLFMQTT_NONBLOCK
+/* In a multithread build without NONBLOCK, MqttClient_Publish_WriteOnly reports
+ * SUCCESS while the ack is still outstanding. The caller may then free its
+ * MqttPublish (here on the stack), so no pending response may still reference
+ * it, and the reserved quota must be released rather than orphaned. */
+TEST(publish_writeonly_v5_no_dangling_pendresp_on_success)
+{
+    int rc;
+    MqttPublish publish; /* automatic storage: must not stay referenced */
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 23;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* No dangling reference to the soon-freed stack object. */
+    ASSERT_NULL(test_client.firstPendResp);
+    /* The reserved unit was released, not orphaned. */
+    ASSERT_EQ(1, test_client.server_recv_max);
+}
+#endif /* !WOLFMQTT_NONBLOCK */
+
+#ifdef WOLFMQTT_NONBLOCK
+/* Cancelling a write-only publish whose ack is still outstanding must release
+ * the reserved Receive Maximum unit, not leak it: the shipped multithread
+ * example cancels on the non-success path. */
+TEST(publish_writeonly_v5_cancel_releases_receive_max)
+{
+    int rc;
+    int i;
+    static MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 24;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    }
+    /* Reserved, ack still outstanding (returned CONTINUE). */
+    ASSERT_EQ(0, test_client.server_recv_max);
+
+    MqttClient_CancelMessage(&test_client, (MqttObject*)&publish);
+
+    /* The cancel released the reserved unit rather than leaking it. */
+    ASSERT_EQ(1, test_client.server_recv_max);
+    ASSERT_NULL(test_client.firstPendResp);
+}
+#endif /* WOLFMQTT_NONBLOCK */
 #endif /* WOLFMQTT_MULTITHREAD */
 #endif /* WOLFMQTT_V5 */
 
@@ -3656,6 +3745,12 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject);
+#ifndef WOLFMQTT_NONBLOCK
+    RUN_TEST(publish_writeonly_v5_no_dangling_pendresp_on_success);
+#endif
+#ifdef WOLFMQTT_NONBLOCK
+    RUN_TEST(publish_writeonly_v5_cancel_releases_receive_max);
+#endif
 #endif
 #endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2437,6 +2437,53 @@ TEST(wait_message_qos2_publish_acks_pubrec)
     ASSERT_EQ(9, g_last_ack_id);
 }
 
+/* [MQTT-4.3.3-10] Until the matching PUBREL is received, a retransmitted QoS 2
+ * PUBLISH must be answered with another PUBREC but MUST NOT be delivered to the
+ * application a second time. Two identical QoS 2 PUBLISH frames (both packet
+ * id 9, no intervening PUBREL) arrive back to back; the message callback must
+ * fire exactly once while both frames are acknowledged. Pre-fix the client had
+ * no inbound QoS 2 dedup and delivered the duplicate, so g_msg_cb_calls was 2. */
+TEST(wait_message_qos2_duplicate_publish_delivered_once)
+{
+    int rc = MQTT_CODE_SUCCESS;
+    int i;
+    /* Two v3.1.1 QoS2 PUBLISH frames, both packet_id=9, topic "a", payload
+     * "hi": type|qos2=0x34, remain=7. */
+    static const byte publish_qos2_dup[] = {
+        0x34, 0x07, 0x00, 0x01, 'a', 0x00, 0x09, 'h', 'i',
+        0x34, 0x07, 0x00, 0x01, 'a', 0x00, 0x09, 'h', 'i'
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    test_client.msg_cb = test_accept_message_cb;
+    g_msg_cb_calls = 0;
+
+    g_pubresp_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, publish_qos2_dup, sizeof(publish_qos2_dup));
+    g_canned_len = (int)sizeof(publish_qos2_dup);
+    g_canned_pos = 0;
+
+    /* Each successful WaitMessage returns after one frame, so pump until both
+     * staged frames are consumed or a real error is hit. */
+    for (i = 0; i < 40 && g_canned_pos < g_canned_len; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+        if (rc != MQTT_CODE_SUCCESS && rc != MQTT_CODE_CONTINUE) {
+            break;
+        }
+    }
+
+    /* Both PUBLISHes were acknowledged with a PUBREC, but the retransmit must
+     * not have reached the application. */
+    ASSERT_TRUE(g_pubresp_written);
+    ASSERT_EQ(1, g_msg_cb_calls);
+}
+
 /* The four PUBLISH-response packet types (PUBACK 4, PUBREC 5, PUBREL 6,
  * PUBCOMP 7) all decode through the same branch of MqttClient_HandlePacket, but
  * only PUBREC and PUBREL may advance the QoS handshake. The branch gates this
@@ -3222,6 +3269,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_qos0_publish_no_ack);
     RUN_TEST(wait_message_qos1_publish_acks_puback);
     RUN_TEST(wait_message_qos2_publish_acks_pubrec);
+    RUN_TEST(wait_message_qos2_duplicate_publish_delivered_once);
     RUN_TEST(wait_message_pubrec_emits_pubrel);
     RUN_TEST(wait_message_pubrel_emits_pubcomp);
     RUN_TEST(wait_message_puback_emits_no_ack);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -665,6 +665,76 @@ TEST(connect_v5_scrubs_connack_auth_data_from_rx_buf)
                              blob, blob_len));
 }
 
+/* [MQTT-4.12.0-1] A Client that did not include an Authentication Method in its
+ * CONNECT MUST NOT send an AUTH packet. After a CONNECT that negotiated no
+ * enhanced authentication, MqttClient_Auth must refuse to put an AUTH on the
+ * wire even when the caller supplies a well-formed AUTH carrying a method. */
+TEST(auth_without_connect_method_rejected)
+{
+    int rc;
+    MqttAuth auth;
+    MqttProp* prop;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    /* Fresh client: no CONNECT Authentication Method was negotiated. */
+
+    XMEMSET(&auth, 0, sizeof(auth));
+    auth.reason_code = MQTT_REASON_CONT_AUTH;
+    prop = MqttClient_PropsAdd(&auth.props);
+    ASSERT_NOT_NULL(prop);
+    prop->type = MQTT_PROP_AUTH_METHOD;
+    prop->data_str.str = (char*)"SCRAM-SHA-256";
+    prop->data_str.len = (word16)XSTRLEN("SCRAM-SHA-256");
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Auth(&test_client, &auth);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+    ASSERT_EQ(0, g_frames_written);
+
+    MqttClient_PropsFree(auth.props);
+}
+
+/* Positive control: after a CONNECT that did carry an Authentication Method,
+ * MqttClient_Auth must not be blocked by the new guard and the AUTH must reach
+ * the wire. Guards against the guard over-rejecting legitimate re-auth. */
+TEST(auth_with_connect_method_allowed)
+{
+    int rc;
+    MqttAuth auth;
+    MqttProp* prop;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.auth_method_set = 1; /* CONNECT negotiated a method */
+
+    XMEMSET(&auth, 0, sizeof(auth));
+    auth.reason_code = MQTT_REASON_CONT_AUTH;
+    prop = MqttClient_PropsAdd(&auth.props);
+    ASSERT_NOT_NULL(prop);
+    prop->type = MQTT_PROP_AUTH_METHOD;
+    prop->data_str.str = (char*)"SCRAM-SHA-256";
+    prop->data_str.len = (word16)XSTRLEN("SCRAM-SHA-256");
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Auth(&test_client, &auth);
+
+    /* Not blocked by the new guard, and the AUTH was written to the wire. */
+    ASSERT_NE(MQTT_CODE_ERROR_BAD_ARG, rc);
+    ASSERT_TRUE(g_frames_written > 0);
+
+    MqttClient_PropsFree(auth.props);
+}
+
 /* MQTT v5: a refused CONNACK (non-zero return code) must NOT mutate long-lived
  * client state even when it carries server properties, otherwise a rejected or
  * malicious broker could shrink the client's packet-size cap or lower its QoS
@@ -3231,6 +3301,8 @@ void run_mqtt_client_tests(void)
 #if defined(WOLFMQTT_V5)
     RUN_TEST(connect_accepted_connack_latches_v5_props);
     RUN_TEST(connect_v5_scrubs_connack_auth_data_from_rx_buf);
+    RUN_TEST(auth_without_connect_method_rejected);
+    RUN_TEST(auth_with_connect_method_allowed);
     RUN_TEST(connect_refused_connack_preserves_v5_defaults);
     RUN_TEST(connect_accepted_connack_clamps_illegal_max_qos);
     RUN_TEST(connect_accepted_connack_latches_topic_alias_max);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2234,6 +2234,87 @@ TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
     /* The publisher's own struct is NOT updated on this path. */
     ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
 }
+
+/* [MQTT-3.3.4-9] Receive Maximum bounds unacknowledged QoS>0 PUBLISH packets,
+ * and MqttClient_Publish_WriteOnly must honor it like any other publish. With
+ * the quota exhausted, a write-only QoS 1 publish must be refused before
+ * anything reaches the wire rather than slipping through unreserved. */
+TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 0; /* quota exhausted */
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 1;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_SERVER_PROP, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+/* A write-only QoS 1 publish reserves a Receive Maximum unit; when a reading
+ * thread later processes the PUBACK, the unit must be credited back so the
+ * reservation does not leak and permanently shrink the quota. */
+TEST(publish_writeonly_v5_receive_max_released_on_puback)
+{
+    int rc;
+    int i;
+    /* static so the registered pendResp does not point into freed stack. */
+    static MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBACK: type=0x40, remain=3, packet_id=21 (0x15), reason=0x00. */
+    static const byte puback[] = { 0x40, 0x03, 0x00, 0x15, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    test_client.server_recv_max = 1;
+    test_client.server_recv_max_negotiated = 1;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 21;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MqttClient_Publish_WriteOnly(&test_client, &publish, NULL);
+    /* The single unit was reserved and the call returned without waiting. */
+    ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
+    ASSERT_EQ(0, test_client.server_recv_max);
+
+    /* Reading thread processes the PUBACK. */
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    /* The reserved unit was credited back rather than leaked. */
+    ASSERT_EQ(1, test_client.server_recv_max);
+}
 #endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
 #endif /* WOLFMQTT_V5 */
 
@@ -3516,6 +3597,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos1_v5_write_failure_restores_recv_quota);
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
     RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
+    RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
+    RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
 #endif
 #endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -3675,6 +3675,81 @@ TEST(topic_filter_valid_shared_subscription)
     ASSERT_EQ(1, MqttPacket_TopicFilterValid("$share//sport", 13));
 }
 
+#ifdef WOLFMQTT_V5
+/* [MQTT-3.8.3-4] The No Local option MUST NOT be set on a Shared Subscription.
+ * A v5 SUBSCRIBE encoder given No Local on a '$share/...' filter must reject the
+ * packet instead of putting the illegal combination on the wire. */
+TEST(encode_subscribe_shared_no_local_rejected)
+{
+    byte tx_buf[64];
+    MqttSubscribe sub;
+    MqttTopic topic;
+    int rc;
+
+    XMEMSET(&sub, 0, sizeof(sub));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "$share/g/sport";
+    topic.qos = MQTT_QOS_0;
+    topic.sub_options = MQTT_SUBSCRIBE_NO_LOCAL;
+    sub.topics = &topic;
+    sub.topic_count = 1;
+    sub.packet_id = 1;
+    sub.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    rc = MqttEncode_Subscribe(tx_buf, (int)sizeof(tx_buf), &sub);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+/* Positive control: No Local on an ordinary (non-shared) filter is legal and
+ * must still encode, so the shared-subscription guard does not over-reject. */
+TEST(encode_subscribe_no_local_non_shared_accepted)
+{
+    byte tx_buf[64];
+    MqttSubscribe sub;
+    MqttTopic topic;
+    int rc;
+
+    XMEMSET(&sub, 0, sizeof(sub));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "sport/tennis";
+    topic.qos = MQTT_QOS_0;
+    topic.sub_options = MQTT_SUBSCRIBE_NO_LOCAL;
+    sub.topics = &topic;
+    sub.topic_count = 1;
+    sub.packet_id = 1;
+    sub.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+
+    rc = MqttEncode_Subscribe(tx_buf, (int)sizeof(tx_buf), &sub);
+    ASSERT_TRUE(rc > 0);
+}
+
+/* Broker decode side of [MQTT-3.8.3-4]: a v5 SUBSCRIBE reaching the broker with
+ * No Local set on a '$share/...' filter must be rejected as a Protocol Error,
+ * not accepted. */
+TEST(decode_subscribe_shared_no_local_rejected)
+{
+    /* v5 SUBSCRIBE: type=0x82, remain=0x10, packet_id=1, prop_len=0,
+     * filter "$share/g/x" (len 10), options=0x04 (No Local). */
+    byte rx_buf[] = {
+        0x82, 0x10,
+        0x00, 0x01,
+        0x00,
+        0x00, 0x0A, '$', 's', 'h', 'a', 'r', 'e', '/', 'g', '/', 'x',
+        0x04
+    };
+    MqttSubscribe sub;
+    MqttTopic topic_arr[1];
+    int rc;
+
+    XMEMSET(&sub, 0, sizeof(sub));
+    XMEMSET(topic_arr, 0, sizeof(topic_arr));
+    sub.topics = topic_arr;
+    sub.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttDecode_Subscribe(rx_buf, (int)sizeof(rx_buf), &sub);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+#endif /* WOLFMQTT_V5 */
+
 /* [MQTT-4.7.3-1] zero-length Topic Filter rejected by SUBSCRIBE decoder. */
 TEST(decode_subscribe_empty_topic_filter_rejected)
 {
@@ -5877,6 +5952,11 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_subscribe_packet_id_zero_rejected);
     RUN_TEST(topic_filter_valid_helper_table);
     RUN_TEST(topic_filter_valid_shared_subscription);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(encode_subscribe_shared_no_local_rejected);
+    RUN_TEST(encode_subscribe_no_local_non_shared_accepted);
+    RUN_TEST(decode_subscribe_shared_no_local_rejected);
+#endif
     RUN_TEST(decode_subscribe_empty_topic_filter_rejected);
     RUN_TEST(decode_subscribe_bad_hash_placement_rejected);
     RUN_TEST(decode_subscribe_hash_not_last_rejected);

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -3632,6 +3632,49 @@ TEST(topic_filter_valid_helper_table)
     ASSERT_EQ(1, MqttPacket_TopicFilterValid("sport/tennis", 12));
 }
 
+/* [MQTT-4.8.2] v5 shared-subscription filters take the form
+ * '$share/{ShareName}/{filter}': the ShareName must be non-empty and free of
+ * '/', '+' and '#', followed by a non-empty well-formed filter. An empty
+ * ShareName ('$share//topic') is malformed. Under v3.1.1 '$share/' carries no
+ * special meaning, so the same bytes are an ordinary filter with an empty topic
+ * level, which the spec permits, and must still pass. */
+TEST(topic_filter_valid_shared_subscription)
+{
+#ifdef WOLFMQTT_V5
+    /* Well-formed shared filters are accepted. */
+    ASSERT_EQ(1, MqttPacket_TopicFilterValid_ex("$share/g/sport", 14,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    ASSERT_EQ(1, MqttPacket_TopicFilterValid_ex("$share/g/sport/#", 16,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    ASSERT_EQ(1, MqttPacket_TopicFilterValid_ex("$share/g/sport/+/x", 18,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+
+    /* Empty ShareName ('$share//...') is malformed. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share//sport", 13,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    /* No '/' after ShareName means there is no trailing filter. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share/g", 8,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    /* Empty trailing filter. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share/g/", 9,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    /* A wildcard inside the ShareName is malformed. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share/a+b/x", 12,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share/a#/x", 11,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+    /* The trailing filter itself must be well-formed. */
+    ASSERT_EQ(0, MqttPacket_TopicFilterValid_ex("$share/g/a#b", 12,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5));
+#endif
+
+    /* v3.1.1: '$share/' is not special; '$share//sport' is an ordinary filter
+     * with an empty level, which is permitted, so it must pass. */
+    ASSERT_EQ(1, MqttPacket_TopicFilterValid_ex("$share//sport", 13,
+        MQTT_CONNECT_PROTOCOL_LEVEL_4));
+    ASSERT_EQ(1, MqttPacket_TopicFilterValid("$share//sport", 13));
+}
+
 /* [MQTT-4.7.3-1] zero-length Topic Filter rejected by SUBSCRIBE decoder. */
 TEST(decode_subscribe_empty_topic_filter_rejected)
 {
@@ -5833,6 +5876,7 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_subscribe_rejects_nul_in_filter);
     RUN_TEST(decode_subscribe_packet_id_zero_rejected);
     RUN_TEST(topic_filter_valid_helper_table);
+    RUN_TEST(topic_filter_valid_shared_subscription);
     RUN_TEST(decode_subscribe_empty_topic_filter_rejected);
     RUN_TEST(decode_subscribe_bad_hash_placement_rejected);
     RUN_TEST(decode_subscribe_hash_not_last_rejected);

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -769,11 +769,13 @@ typedef struct MqttBroker {
 #else
     BrokerClient* clients;
     BrokerSub*    subs;
-    /* Bumped whenever a BrokerSub is unlinked from `subs`. A fan-out loop
-     * snapshots it before a write that may re-entrantly free a subscriber and
-     * only re-validates its snapshotted successor when it changed, so the
-     * common (no free) case avoids an O(n) rescan of the whole list. */
+    /* Bumped on every structural change to `subs`. */
     word32        subs_gen;
+    /* Bumped whenever a BrokerClient is linked into or unlinked from
+     * `clients`. A fan-out snapshots it before the writes and only re-validates
+     * its collected destinations when it changed, so the common (nothing
+     * removed) case avoids an O(n) rescan per destination. */
+    word32        clients_gen;
 #ifdef WOLFMQTT_BROKER_RETAINED
     BrokerRetainedMsg* retained;
     int                retained_count;

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -769,6 +769,11 @@ typedef struct MqttBroker {
 #else
     BrokerClient* clients;
     BrokerSub*    subs;
+    /* Bumped whenever a BrokerSub is unlinked from `subs`. A fan-out loop
+     * snapshots it before a write that may re-entrantly free a subscriber and
+     * only re-validates its snapshotted successor when it changed, so the
+     * common (no free) case avoids an O(n) rescan of the whole list. */
+    word32        subs_gen;
 #ifdef WOLFMQTT_BROKER_RETAINED
     BrokerRetainedMsg* retained;
     int                retained_count;

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -480,14 +480,16 @@ WOLFMQTT_API int MqttClient_Publish_ex(
  *                          Note: MqttPublish and MqttMessage are same
                             structure.
  *  \param      pubCb       Function pointer to callback routine
- *  \note       Because this call only writes and another thread processes the
-                ACK, it never returns MQTT_CODE_ERROR_PUBLISH_REJECTED. On the
-                reading thread only a QoS 2 PUBREC rejection is surfaced (as
-                MQTT_CODE_ERROR_PUBLISH_REJECTED, returned in order to suppress
-                an illegal PUBREL per [MQTT-4.3.3]); a QoS 1 PUBACK or QoS 2
-                PUBCOMP reason code >= 0x80 is NOT detected on this path and the
-                publish appears successful. Use MqttClient_Publish/_ex when
-                reliable v5 broker-rejection detection for QoS>0 is required.
+ *  \note       Only one v5 broker rejection is surfaced on this path: a QoS 2
+                PUBREC with a reason code >= 0x80. The reading thread returns
+                MQTT_CODE_ERROR_PUBLISH_REJECTED for it (suppressing an illegal
+                PUBREL per [MQTT-4.3.3]) and completes this publish's pending
+                response with the same code, so a later poll of this function
+                returns MQTT_CODE_ERROR_PUBLISH_REJECTED instead of spinning on
+                MQTT_CODE_CONTINUE. A QoS 1 PUBACK or QoS 2 PUBCOMP reason code
+                >= 0x80 is NOT detected on this path and the publish appears
+                successful. Use MqttClient_Publish/_ex when reliable v5
+                broker-rejection detection for QoS>0 is required.
  *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or
                 MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -218,6 +218,15 @@ typedef struct _MqttSk {
     typedef int (*SN_ClientRegisterCb)(word16 topicId, const char* topicName, void *reg_ctx);
 #endif
 
+#if WOLFMQTT_MAX_QOS >= 2
+    /* Max distinct inbound QoS 2 packet ids tracked awaiting PUBREL, used to
+     * suppress re-delivery of a retransmitted PUBLISH [MQTT-4.3.3-10].
+     * Override in user_settings.h to trade memory for a larger dedup window. */
+    #ifndef MQTT_MAX_RECV_QOS2
+        #define MQTT_MAX_RECV_QOS2 16
+    #endif
+#endif
+
 /* Client structure */
 typedef struct _MqttClient {
     word32       flags; /* MqttClientFlags */
@@ -293,6 +302,14 @@ typedef struct _MqttClient {
     word16 server_recv_max_negotiated;
     /* Max Topic Alias value; absent CONNACK means 0 [3.1.2.11.8]. */
     word16 topic_alias_max;
+#endif
+
+#if WOLFMQTT_MAX_QOS >= 2
+    /* Inbound QoS 2 packet ids delivered to the application and awaiting their
+     * PUBREL. A retransmitted PUBLISH with an id still listed here is answered
+     * with PUBREC but not delivered a second time [MQTT-4.3.3-10]. Slot value 0
+     * is empty; a QoS 2 packet id is never 0. */
+    word16 recv_qos2_pending[MQTT_MAX_RECV_QOS2];
 #endif
 } MqttClient;
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -225,6 +225,12 @@ typedef struct _MqttSk {
     #ifndef MQTT_MAX_RECV_QOS2
         #define MQTT_MAX_RECV_QOS2 16
     #endif
+    /* Also advertised as the v5 CONNECT Receive Maximum (see
+     * MqttClient_Connect), so it must be a legal value for that property:
+     * 0 is a Protocol Error [MQTT-3.1.2.11.3] and the field is 16-bit. */
+    #if (MQTT_MAX_RECV_QOS2 < 1) || (MQTT_MAX_RECV_QOS2 > 65535)
+        #error "MQTT_MAX_RECV_QOS2 must be between 1 and 65535"
+    #endif
 #endif
 
 /* Client structure */

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -302,6 +302,10 @@ typedef struct _MqttClient {
     word16 server_recv_max_negotiated;
     /* Max Topic Alias value; absent CONNACK means 0 [3.1.2.11.8]. */
     word16 topic_alias_max;
+    /* Set when the current connection's CONNECT carried an Authentication
+     * Method; gates MqttClient_Auth so an AUTH is never sent on a connection
+     * that never negotiated enhanced authentication [MQTT-4.12.0-1]. */
+    byte   auth_method_set;
 #endif
 
 #if WOLFMQTT_MAX_QOS >= 2

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -716,6 +716,22 @@ WOLFMQTT_API int MqttPacket_FixedHeaderFlagsValid(byte type_flags);
  */
 WOLFMQTT_API int MqttPacket_TopicFilterValid(const char* filter, word16 len);
 
+/*! \brief      Validate an MQTT Topic Filter, additionally enforcing the MQTT
+ *              v5 shared-subscription form '$share/{ShareName}/{filter}'
+ *              [MQTT-4.8.2]: when protocol_level is 5 and the filter carries
+ *              the '$share/' prefix, the ShareName must be non-empty and must
+ *              not contain '/', '+' or '#', and must be followed by a
+ *              non-empty, well-formed trailing filter. Under v3.1.1
+ *              (protocol_level < 5) the '$share/' prefix has no special
+ *              meaning and only the generic wildcard rules apply.
+ *  \param      filter          Pointer to the topic filter bytes.
+ *  \param      len             Length of the filter in bytes.
+ *  \param      protocol_level  MQTT protocol level (4 = v3.1.1, 5 = v5).
+ *  \return     1 if the filter is well-formed, 0 if it is malformed.
+ */
+WOLFMQTT_API int MqttPacket_TopicFilterValid_ex(const char* filter,
+    word16 len, byte protocol_level);
+
 /*! \brief      Return non-zero if the Topic Filter contains a wildcard
  *              ('#' or '+'). Use only on a filter that has already
  *              passed MqttPacket_TopicFilterValid - wildcard placement

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -336,7 +336,11 @@ typedef struct _MqttMsgStat {
 
     byte isReadActive:1;
     byte isWriteActive:1;
-    byte recvQuotaHeld:1; /* v5 Receive Maximum unit reserved for this message */
+    /* v5 Receive Maximum unit reserved for this message. Its own storage unit,
+     * not a bitfield, because a reader thread may clear it (under lockClient)
+     * while the owning thread writes isReadActive/isWriteActive outside that
+     * lock; sharing a byte would make those a racy read-modify-write. */
+    byte recvQuotaHeld;
 } MqttMsgStat;
 
 #ifdef WOLFMQTT_MULTITHREAD

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -354,6 +354,12 @@ typedef struct _MqttPendResp {
     /* double linked list */
     struct _MqttPendResp* next;
     struct _MqttPendResp* prev;
+#ifdef WOLFMQTT_V5
+    /* Points to the message stat holding a reserved Receive Maximum unit so the
+     * thread that completes this response can release it, covering a write-only
+     * publish that never waits for its own ack. NULL when none is held. */
+    MqttMsgStat* recvQuotaStat;
+#endif
 } MqttPendResp;
 #endif /* WOLFMQTT_MULTITHREAD */
 


### PR DESCRIPTION
- f-8609: suppress duplicate delivery of a retransmitted QoS 2 PUBLISH awaiting PUBREL
- f-8611: reject an empty ShareName in v5 shared-subscription filters
- f-8612: reject No Local on a v5 shared subscription
- f-8613: reject a Subscription Identifier on a client-to-server PUBLISH
- f-8614: refuse AUTH when the CONNECT carried no Authentication Method
- f-8616: refuse a v5 CONNECT whose Will QoS exceeds Maximum QoS instead of downgrading
- f-8617: refuse a v5 CONNECT with Will Retain when retained messages are unsupported
- f-10343: enforce Maximum Packet Size over the whole PUBLISH, not per transport write
- f-10344: refuse a CONNACK reporting Session Present after Clean Session
- f-10345: enforce Receive Maximum quota for write-only publishes, releasing on ack, cancel, and disconnect
- f-556: make the broker fan-out use-after-free guard O(1) via a subscription generation counter
