### PR TITLE
Gh issues

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -142,6 +142,27 @@
       completing its own read could previously overwrite it between the read
       lock being dropped and the send lock being taken, sending the later
       Packet Identifier twice and never the earlier one [MQTT-4.6.0-2] (#608)
+    - Session state is keyed on the ClientId itself rather than a 32-bit hash
+      of it. Two different ClientIds sharing a hash would have let one
+      identity's replay entries and QoS 2 pending ids be treated as the
+      other's, which matters when the ClientId derives from untrusted input.
+      A ClientId longer than `MQTT_MAX_SESSION_CLIENT_ID` (64 by default) is
+      not recorded, so its Session state is dropped rather than partially
+      matched [MQTT-3.1.3-2]
+    - `MqttClient_Disconnect` no longer clears the CONNECT-sent flag. It
+      writes the DISCONNECT packet but does not close the transport, so
+      clearing that flag reopened the duplicate-CONNECT guard and allowed a
+      second CONNECT on the same Network Connection [MQTT-3.1.0-2]. A separate
+      flag now refuses further packets after DISCONNECT [MQTT-3.14.4-1]
+    - `MqttClient_CancelMessage` keeps the Packet Identifier of a packet that
+      already reached the wire. The peer can still answer it, and that
+      acknowledgement would otherwise complete whatever new exchange had taken
+      the identifier over; [MQTT-2.3.1-3] makes it reusable only once the
+      acknowledgement is processed. A packet that never fully went out still
+      releases its identifier immediately
+    - Retained replay copies of topics and payloads are zeroized before being
+      freed, so application data - which may include credentials - is not left
+      in reusable heap
     - Outbound Session state is now bound to the ClientId that created it, so
       a client object reused under a new ClientId no longer replays the
       previous Session's messages into the new one when the server answers

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -142,6 +142,38 @@
       completing its own read could previously overwrite it between the read
       lock being dropped and the send lock being taken, sending the later
       Packet Identifier twice and never the earlier one [MQTT-4.6.0-2] (#608)
+    - Outbound Session state is now bound to the ClientId that created it, so
+      a client object reused under a new ClientId no longer replays the
+      previous Session's messages into the new one when the server answers
+      Session Present = 1 [MQTT-3.1.3-2]
+    - A zero-byte QoS 1/2 PUBLISH is retained for replay. Section 3.3.3 allows
+      an empty payload and [MQTT-4.4.0-1] asks for it back like any other
+      unacknowledged message; it was previously treated as a payload that
+      could not be copied
+    - A v5 PUBLISH carrying properties is no longer retained for replay. The
+      pool stores no properties, so re-sending would strip Response Topic,
+      Correlation Data and the rest - a different message from the one the
+      server is waiting on. Retaining properties for replay is not implemented
+    - A replay entry that can never be re-sent (no retained payload) is dropped
+      on reconnect instead of holding its Packet Identifier for the life of the
+      connection, since no acknowledgement will release it [MQTT-2.3.1-3]
+    - The Packet Identifier reservation now records the acknowledgement that
+      ends its exchange, so a PUBACK naming a QoS 2 identifier cannot complete
+      it early [MQTT-2.3.1-3]. The reservation and its replay record are
+      released under one lock, closing a window where a publisher could reuse
+      the identifier in between and have the old ack delete the new exchange's
+      state
+    - The replay record is created before the PUBLISH reaches the wire. In
+      `WOLFMQTT_MULTITHREAD` builds a reader thread could otherwise process the
+      acknowledgement first, leaving an already-acknowledged message retained
+      and replayed after the next reconnect
+    - `MqttClient_Publish`, `MqttClient_Subscribe`, `MqttClient_Unsubscribe`
+      and `MqttClient_Ping` are refused after `MqttClient_Disconnect`
+      [MQTT-3.14.4-1]
+    - The duplicate-CONNECT guard reads the handshake flag under `lockClient`
+      rather than through `MqttClient_Flags`, which reports "no flags set" when
+      the lock cannot be taken and would have let a second CONNECT through
+      [MQTT-3.1.0-2]
     - `MqttClient_Connect` now resets the CONNACK wait state on the
       `MqttConnect` object it was given. Reusing one across reconnects - what
       the bundled examples do - left `mc_connect->ack` mid-read, so the second

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -70,8 +70,19 @@
       as Binary Data, which may contain 0x00, but the encoder measured it with
       `XSTRLEN` and truncated at the first one. Set `password_len` to send
       binary password bytes verbatim; leaving it 0 keeps the previous
-      NUL-terminated behaviour, so existing callers are unaffected. The field
-      is at the end of the struct, so layouts are unchanged (#588)
+      NUL-terminated behaviour, so existing callers are unaffected.
+      `MqttDecode_Connect` reports the wire length here, so a decode/re-encode
+      round trip no longer falls back to `XSTRLEN` over a pointer into a
+      buffer that is not NUL terminated. The field is at the end of the
+      struct, so the offsets of the existing members are unchanged (#588)
+    - `MqttMsgStat` and `MqttConnect` grew. `MqttMsgStat` is the first member
+      of every packet object, so `sizeof` changes for all of them and an
+      application must be rebuilt against this header rather than relinked
+      against the library. `MqttClient` also grows by the
+      `MQTT_MAX_SEND_INFLIGHT` identifier table and, unless
+      `WOLFMQTT_NO_SESSION_REPLAY` is defined, the `MQTT_MAX_REPLAY_MSGS`
+      replay pool - about 1.3 KB under `WOLFMQTT_STATIC_MEMORY` at the
+      defaults, which matters most on the targets that use it.
 
 * Fixes
     - The v3.1.1 `CONNACK` decoder accepted a Remaining Length above 2 and
@@ -93,7 +104,11 @@
       replays it with `DUP` set [MQTT-3.3.1-1] (#604)
     - Broker: a partly written QoS 0 `PUBLISH` is dropped instead of following
       the session into an orphan, where it was delivered a second time after
-      reconnect. QoS 0 allows no sender retry (#596)
+      reconnect. QoS 0 allows no sender retry (#596). A transient
+      `MQTT_CODE_ERROR_TIMEOUT` no longer counts as such a failure: the entry
+      stays queued so the drain resumes from its offset instead of leaving a
+      truncated packet on the wire, and the drop happens at the orphan
+      hand-off
     - WebSocket: both receive callbacks now close the connection on a
       non-binary data frame instead of feeding its payload to the MQTT parser
       [MQTT-6.0.0-1] (#610)
@@ -102,7 +117,10 @@
       cannot reuse one still awaiting its PUBACK or PUBCOMP [MQTT-2.3.1-4].
       Dynamic-memory builds already derived this from the per-subscriber
       queue. A delivery is skipped rather than sent with a reused identifier
-      when all BROKER_MAX_INFLIGHT_PER_SUB slots are outstanding (#614)
+      when all BROKER_MAX_INFLIGHT_PER_SUB slots are outstanding (#614). The
+      slot is released when a delivery ends without an acknowledgement: an
+      encode or write failure, or a v5 subscriber rejecting the QoS 2 delivery
+      at the PUBREC stage [MQTT-4.3.3]
     - The client now keeps unacknowledged outbound QoS > 0 messages as Session
       state and re-sends them after a `CleanSession=0` reconnect the server
       answers with Session Present = 1: a PUBLISH goes out again with its
@@ -115,11 +133,21 @@
       `MQTT_MAX_REPLAY_PAYLOAD`). A message that does not fit, or one streamed
       through a payload callback, is still sent but not retained. Define
       `WOLFMQTT_NO_SESSION_REPLAY` to compile the store out (#597, #598, #602)
+    - A v5 `PUBREC` with a reason code >= 0x80 ends the QoS 2 exchange
+      [MQTT-4.3.3], so the client now releases the Packet Identifier there
+      [MQTT-2.3.1-3] and drops the message from Session state instead of
+      replaying a PUBLISH the server explicitly refused
     - The QoS acknowledgement for a received PUBLISH is now staged on the wait
       object rather than in a field shared by every reader. Another thread
       completing its own read could previously overwrite it between the read
       lock being dropped and the send lock being taken, sending the later
       Packet Identifier twice and never the earlier one [MQTT-4.6.0-2] (#608)
+    - `MqttClient_Connect` now resets the CONNACK wait state on the
+      `MqttConnect` object it was given. Reusing one across reconnects - what
+      the bundled examples do - left `mc_connect->ack` mid-read, so the second
+      handshake skipped the CONNACK read and handed whatever was still in
+      `rx_buf` to the PUBLISH payload handler instead of waiting for the new
+      CONNACK [MQTT-3.2.0-1]
     - The client's inbound QoS 2 de-duplication table is now bound to the
       ClientId that populated it. Reusing one `MqttClient` under a new
       ClientId no longer inherits the previous Session's pending packet ids

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -103,6 +103,18 @@
       Dynamic-memory builds already derived this from the per-subscriber
       queue. A delivery is skipped rather than sent with a reused identifier
       when all BROKER_MAX_INFLIGHT_PER_SUB slots are outstanding (#614)
+    - The client now keeps unacknowledged outbound QoS > 0 messages as Session
+      state and re-sends them after a `CleanSession=0` reconnect the server
+      answers with Session Present = 1: a PUBLISH goes out again with its
+      original Packet Identifier and `DUP` set, and a QoS 2 exchange already
+      past PUBREC re-sends the PUBREL instead [MQTT-4.4.0-1],
+      [MQTT-3.3.1-1]. Replaying a PUBLISH needs its topic and payload after
+      the caller's `MqttPublish` is gone, so the client copies them into a
+      bounded pool of `MQTT_MAX_REPLAY_MSGS` entries (4 by default; under
+      `WOLFMQTT_STATIC_MEMORY` also bounded by `MQTT_MAX_REPLAY_TOPIC` and
+      `MQTT_MAX_REPLAY_PAYLOAD`). A message that does not fit, or one streamed
+      through a payload callback, is still sent but not retained. Define
+      `WOLFMQTT_NO_SESSION_REPLAY` to compile the store out (#597, #598, #602)
     - The QoS acknowledgement for a received PUBLISH is now staged on the wait
       object rather than in a field shared by every reader. Another thread
       completing its own read could previously overwrite it between the read

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,6 +66,12 @@
     - `MqttEncode_Connect` rejects a zero-byte ClientId paired with
       `clean_session` 0 for MQTT v3.1.1 [MQTT-3.1.3-7]. MQTT v5.0 drops the
       coupling and still allows it (#585)
+    - `MqttConnect` gains `password_len`. [MQTT-3.1.3.5] defines the Password
+      as Binary Data, which may contain 0x00, but the encoder measured it with
+      `XSTRLEN` and truncated at the first one. Set `password_len` to send
+      binary password bytes verbatim; leaving it 0 keeps the previous
+      NUL-terminated behaviour, so existing callers are unaffected. The field
+      is at the end of the struct, so layouts are unchanged (#588)
 
 * Fixes
     - The v3.1.1 `CONNACK` decoder accepted a Remaining Length above 2 and
@@ -91,6 +97,16 @@
     - WebSocket: both receive callbacks now close the connection on a
       non-binary data frame instead of feeding its payload to the MQTT parser
       [MQTT-6.0.0-1] (#610)
+    - Broker: static-memory fan-out now tracks the outbound QoS 1/2 Packet
+      Identifiers each subscriber has not yet acknowledged, so a new PUBLISH
+      cannot reuse one still awaiting its PUBACK or PUBCOMP [MQTT-2.3.1-4].
+      Dynamic-memory builds already derived this from the per-subscriber
+      queue. A delivery is skipped rather than sent with a reused identifier
+      when all BROKER_MAX_INFLIGHT_PER_SUB slots are outstanding (#614)
+    - The client's inbound QoS 2 de-duplication table is now bound to the
+      ClientId that populated it. Reusing one `MqttClient` under a new
+      ClientId no longer inherits the previous Session's pending packet ids
+      when the server answers Session Present = 1 [MQTT-3.1.3-2] (#595)
 
 ### v2.1.0 (07/02/2026)
 Release 2.1.0 has been developed according to wolfSSL's development and QA

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,6 +46,51 @@
       `cmd_timeout_ms`. This is the only v5 rejection surfaced on the write-only
       path; a QoS 1 PUBACK or QoS 2 PUBCOMP reason code >= 0x80 is still not
       detected there. Supersedes the v2.1.0 note below.
+    - The client now tracks the MQTT handshake separately from the transport.
+      `MqttClient_Publish`, `MqttClient_Subscribe`, `MqttClient_Unsubscribe`,
+      `MqttClient_Ping` and `MqttClient_Disconnect` return
+      `MQTT_CODE_ERROR_STAT` when called before `MqttClient_Connect` on a
+      Network Connection [MQTT-3.1.0-1], and a second `MqttClient_Connect` on
+      the same connection is refused with the same code [MQTT-3.1.0-2]. An
+      application that reconnects must call `MqttClient_NetDisconnect` first,
+      as the bundled examples already do (#590, #591)
+    - The client keeps a connection-level record of outbound Packet
+      Identifiers still awaiting their `PUBACK`, `PUBCOMP`, `SUBACK` or
+      `UNSUBACK`, in every build rather than only under
+      `WOLFMQTT_MULTITHREAD`. A new `SUBSCRIBE`, `UNSUBSCRIBE` or QoS>0
+      `PUBLISH` reusing one is refused with `MQTT_CODE_ERROR_PACKET_ID`
+      [MQTT-2.3.1-2]. Re-sending the same `PUBLISH` with `duplicate` set keeps
+      its identifier, as [MQTT-2.3.1-3] requires. The window is
+      `MQTT_MAX_SEND_INFLIGHT` (16 by default), overridable in
+      `user_settings.h` (#589, #599, #601, #605, #611, #612, #613)
+    - `MqttEncode_Connect` rejects a zero-byte ClientId paired with
+      `clean_session` 0 for MQTT v3.1.1 [MQTT-3.1.3-7]. MQTT v5.0 drops the
+      coupling and still allows it (#585)
+
+* Fixes
+    - The v3.1.1 `CONNACK` decoder accepted a Remaining Length above 2 and
+      swallowed the extra bytes; it now requires exactly 2 outside v5 (#603)
+    - `PUBACK`, `PUBREC`, `PUBREL` and `PUBCOMP` carrying Packet Identifier 0
+      were treated as spurious and ignored. They are now rejected with
+      `MQTT_CODE_ERROR_PACKET_ID`, which closes the connection
+      [MQTT-4.8.0-1] (#607)
+    - Broker: a refused `CONNACK` whose write returned `MQTT_CODE_CONTINUE`
+      was never resumed, so the client saw a truncated packet and never
+      received the return code. The connection is now held open until the
+      refusal is fully written and then closed (#592)
+    - Broker: keep-alive monitoring no longer runs while an accepted `CONNACK`
+      is still partly written, which could close the connection mid-handshake
+      in `WOLFMQTT_NONBLOCK` builds. The handshake stays bounded by
+      `BROKER_CONNECT_TIMEOUT_SEC` (#594)
+    - Broker: a QoS>0 `PUBLISH` that got some bytes out and then failed inside
+      one blocking write is now marked for retransmission, so session recovery
+      replays it with `DUP` set [MQTT-3.3.1-1] (#604)
+    - Broker: a partly written QoS 0 `PUBLISH` is dropped instead of following
+      the session into an orphan, where it was delivered a second time after
+      reconnect. QoS 0 allows no sender retry (#596)
+    - WebSocket: both receive callbacks now close the connection on a
+      non-binary data frame instead of feeding its payload to the MQTT parser
+      [MQTT-6.0.0-1] (#610)
 
 ### v2.1.0 (07/02/2026)
 Release 2.1.0 has been developed according to wolfSSL's development and QA

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -103,6 +103,11 @@
       Dynamic-memory builds already derived this from the per-subscriber
       queue. A delivery is skipped rather than sent with a reused identifier
       when all BROKER_MAX_INFLIGHT_PER_SUB slots are outstanding (#614)
+    - The QoS acknowledgement for a received PUBLISH is now staged on the wait
+      object rather than in a field shared by every reader. Another thread
+      completing its own read could previously overwrite it between the read
+      lock being dropped and the send lock being taken, sending the later
+      Packet Identifier twice and never the earlier one [MQTT-4.6.0-2] (#608)
     - The client's inbound QoS 2 de-duplication table is now bound to the
       ClientId that populated it. Reusing one `MqttClient` under a new
       ClientId no longer inherits the previous Session's pending packet ids

--- a/examples/websocket/net_libwebsockets.c
+++ b/examples/websocket/net_libwebsockets.c
@@ -78,6 +78,17 @@ static int callback_mqtt(struct lws *wsi, enum lws_callback_reasons reason,
     }
     else if (reason == LWS_CALLBACK_CLIENT_RECEIVE) {
         if (in && len > 0) {
+            /* [MQTT-6.0.0-1] MQTT over WebSocket is carried in binary data
+             * frames: "If any other type of data frame is received the
+             * recipient MUST close the Network Connection." A text frame's
+             * payload is not an MQTT byte stream, so it must never reach the
+             * packet parser. */
+            if (!lws_frame_is_binary(wsi)) {
+                lwsl_err("WebSocket non-binary data frame received "
+                         "[MQTT-6.0.0-1]\n");
+                net->status = -1;
+                return -1; /* close connection */
+            }
             /* Check if we have enough space in the buffer */
             if (net->rx_len + len <= sizeof(net->rx_buffer)) {
                 /* Append new data to existing buffer */

--- a/examples/websocket/net_libwebsockets.c
+++ b/examples/websocket/net_libwebsockets.c
@@ -77,18 +77,20 @@ static int callback_mqtt(struct lws *wsi, enum lws_callback_reasons reason,
         net->wsi = NULL;
     }
     else if (reason == LWS_CALLBACK_CLIENT_RECEIVE) {
+        /* [MQTT-6.0.0-1] MQTT over WebSocket is carried in binary data
+         * frames: "If any other type of data frame is received the recipient
+         * MUST close the Network Connection." A text frame's payload is not
+         * an MQTT byte stream, so it must never reach the packet parser. The
+         * rule is about the frame type, not its payload, so this is checked
+         * before the empty-frame test below - an empty text frame must close
+         * the connection too. */
+        if (!lws_frame_is_binary(wsi)) {
+            lwsl_err("WebSocket non-binary data frame received "
+                     "[MQTT-6.0.0-1]\n");
+            net->status = -1;
+            return -1; /* close connection */
+        }
         if (in && len > 0) {
-            /* [MQTT-6.0.0-1] MQTT over WebSocket is carried in binary data
-             * frames: "If any other type of data frame is received the
-             * recipient MUST close the Network Connection." A text frame's
-             * payload is not an MQTT byte stream, so it must never reach the
-             * packet parser. */
-            if (!lws_frame_is_binary(wsi)) {
-                lwsl_err("WebSocket non-binary data frame received "
-                         "[MQTT-6.0.0-1]\n");
-                net->status = -1;
-                return -1; /* close connection */
-            }
             /* Check if we have enough space in the buffer */
             if (net->rx_len + len <= sizeof(net->rx_buffer)) {
                 /* Append new data to existing buffer */

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -1119,17 +1119,21 @@ static int callback_broker_mqtt(struct lws *wsi,
         if (bc_ptr == NULL || *bc_ptr == NULL) return 0;
         bc = *bc_ptr;
         ws = (BrokerWsCtx*)bc->ws_ctx;
-        if (ws == NULL || in == NULL || len == 0) return 0;
+        if (ws == NULL) return 0;
 
         /* [MQTT-6.0.0-1] MQTT over WebSocket is carried in binary data
          * frames: "If any other type of data frame is received the recipient
          * MUST close the Network Connection." A text frame's payload is not
-         * an MQTT byte stream, so it must never reach the packet parser. */
+         * an MQTT byte stream, so it must never reach the packet parser. The
+         * rule is about the frame type, not its payload, so this runs before
+         * the empty-frame check below - an empty text frame must close the
+         * connection too. */
         if (!lws_frame_is_binary(wsi)) {
             WBLOG_ERR(broker, "broker: ws non-binary data frame wsi=%p "
                 "[MQTT-6.0.0-1]", (void*)wsi);
             return -1; /* close connection */
         }
+        if (in == NULL || len == 0) return 0;
 
         /* Append data to rx_buffer */
         if (ws->rx_len + len <= sizeof(ws->rx_buffer)) {
@@ -2168,7 +2172,8 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                      * as the MQTT_CODE_CONTINUE case above. */
                     cur->retransmit_dup = 1;
                 }
-                else if (bc->client.write.pos > 0) {
+                else if (bc->client.write.pos > 0 &&
+                        wr_rc != MQTT_CODE_ERROR_TIMEOUT) {
                     /* MQTT 3.1.1 section 4.3.1: at QoS 0 "no retry is
                      * performed by the sender" and the message "arrives at the
                      * receiver either once or not at all". Bytes of this
@@ -2177,7 +2182,20 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                      * and be sent a second time after reconnect. Section 4.1
                      * makes only QoS 0 messages *pending transmission*
                      * optional Session state, and this one is no longer
-                     * pending - drop it. */
+                     * pending - drop it.
+                     *
+                     * MQTT_CODE_ERROR_TIMEOUT is excluded because it is not a
+                     * dead socket: BrokerPosix_Write returns it when select()
+                     * merely times out. Dropping the entry there would clear
+                     * client.write.pos, so a caller that keeps the connection
+                     * (the fan-out drains discard this return value) would
+                     * write the next queued PUBLISH straight behind the
+                     * truncated prefix and the subscriber would parse its head
+                     * as the previous packet's payload. The entry stays queued
+                     * and the drain resumes from write.pos instead. The main
+                     * loop still tears the connection down on this result, and
+                     * the orphan hand-off then drops the half-sent QoS 0 entry
+                     * for the same section 4.3.1 reason. */
                     BrokerOutPub* free_me = cur;
 
                     if (prev == NULL) {
@@ -3604,6 +3622,44 @@ static BrokerOrphanSession* BrokerOrphan_Take(MqttBroker* broker,
     o->session_expiry_sec = bc->session_expiry_sec;
     o->orphan_since = WOLFMQTT_BROKER_GET_TIME_S();
 
+    /* A QoS 0 PUBLISH whose bytes are partly on the wire is no longer
+     * "pending transmission", so MQTT 3.1.1 section 4.1 does not carry it into
+     * the Session and section 4.3.1 forbids a retry. Drop it here rather than
+     * let it follow the orphan and be delivered a second time after reconnect.
+     *
+     * client.write.pos is the offset into the entry the drain was writing,
+     * which is the first one still in BROKER_OUTQ_QUEUED - not necessarily
+     * out_q_head. BrokerClient_DrainOutQueue walks past entries in
+     * PUBLISH_SENT / PUBREL_SENT (QoS > 0 awaiting an acknowledgement), and
+     * those stay linked ahead of it. */
+    if (bc->client.write.pos > 0) {
+        BrokerOutPub* partial = bc->out_q_head;
+        BrokerOutPub* partial_prev = NULL;
+
+        while (partial != NULL && partial->state != BROKER_OUTQ_QUEUED) {
+            partial_prev = partial;
+            partial = partial->next;
+        }
+        if (partial != NULL && partial->qos == MQTT_QOS_0) {
+            if (partial_prev == NULL) {
+                bc->out_q_head = partial->next;
+            }
+            else {
+                partial_prev->next = partial->next;
+            }
+            if (bc->out_q_tail == partial) {
+                bc->out_q_tail = partial_prev;
+            }
+            bc->out_q_count--;
+            WBLOG_DBG(broker,
+                "broker: dropping partially sent qos0 topic=%s client_id=%s",
+                BrokerLog_Sanitize(partial->topic),
+                BrokerLog_Sanitize(bc->client_id));
+            BrokerOutPub_Free(partial);
+            bc->client.write.pos = 0;
+        }
+    }
+
     /* Move out_q ownership. bc->out_q_* must be cleared so
      * BrokerClient_FreeOutQueue (called from BrokerClient_Free)
      * doesn't double-free. */
@@ -4436,9 +4492,9 @@ static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id,
     }
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
         if (bc->out_inflight[i].packet_id == packet_id &&
-                bc->out_inflight[i].qos == qos) {
+                bc->out_inflight[i].qos == (byte)qos) {
             bc->out_inflight[i].packet_id = 0;
-            bc->out_inflight[i].qos = MQTT_QOS_0;
+            bc->out_inflight[i].qos = (byte)MQTT_QOS_0;
             return;
         }
     }
@@ -4455,6 +4511,9 @@ static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc,
     word16 first;
     int i;
 
+    if (broker == NULL || bc == NULL) {
+        return 0;
+    }
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
         if (bc->out_inflight[i].packet_id == 0) {
             break;
@@ -4476,7 +4535,7 @@ static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc,
                 broker->next_packet_id = 1;
             }
             bc->out_inflight[i].packet_id = candidate;
-            bc->out_inflight[i].qos = qos;
+            bc->out_inflight[i].qos = (byte)qos;
             return candidate;
         }
         candidate++;
@@ -5546,12 +5605,13 @@ static int BrokerRetained_DeliverToClient(MqttBroker* broker,
             out_pub.buffer = (rm->payload_len > 0) ? rm->payload : NULL;
             out_pub.total_len = rm->payload_len;
             if (eff_qos >= MQTT_QOS_1) {
-                out_pub.packet_id = BrokerStaticOutId_Take(broker, bc, eff_qos);
+                out_pub.packet_id = BrokerStaticOutId_Take(broker, bc,
+                    eff_qos);
                 if (out_pub.packet_id == 0) {
-            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
-             * because every one is still awaiting its acknowledgement.
-             * Reusing one would make the pending exchange ambiguous, so skip
-             * this delivery instead. */
+                    /* [MQTT-2.3.1-4] No identifier is free for this
+                     * subscriber because every one is still awaiting its
+                     * acknowledgement. Reusing one would make the pending
+                     * exchange ambiguous, so skip this delivery instead. */
                     WBLOG_ERR(broker, "broker: static retained delivery "
                         "dropped sock=%d (no free packet id)", (int)bc->sock);
                     continue;
@@ -5578,6 +5638,14 @@ static int BrokerRetained_DeliverToClient(MqttBroker* broker,
                     /* Scrub the retained (possibly retained-will) payload from
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
+                }
+                if (wr_rc != MQTT_CODE_CONTINUE && wr_rc != enc_rc &&
+                        eff_qos >= MQTT_QOS_1) {
+                    /* The write failed outright, so the delivery is over and
+                     * no acknowledgement can release the identifier. This
+                     * path leaves the subscriber connected, so holding the
+                     * slot would leak it [MQTT-2.3.1-3]. */
+                    BrokerStaticOutId_Release(bc, out_pub.packet_id, eff_qos);
                 }
             }
             else {
@@ -5877,12 +5945,13 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                 out_pub.buffer = (payload_len > 0) ? (byte*)payload : NULL;
                 out_pub.total_len = payload_len;
                 if (eff_qos >= MQTT_QOS_1) {
-                    out_pub.packet_id = BrokerStaticOutId_Take(broker, wc, eff_qos);
+                    out_pub.packet_id = BrokerStaticOutId_Take(broker, wc,
+                        eff_qos);
                     if (out_pub.packet_id == 0) {
-            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
-             * because every one is still awaiting its acknowledgement.
-             * Reusing one would make the pending exchange ambiguous, so skip
-             * this delivery instead. */
+                        /* [MQTT-2.3.1-4] No identifier is free for this
+                         * subscriber because every one is still awaiting its
+                         * acknowledgement. Reusing one would make the pending
+                         * exchange ambiguous, so skip this delivery. */
                         WBLOG_ERR(broker, "broker: static delivery dropped "
                             "sock=%d (no free packet id)", (int)wc->sock);
                         continue;
@@ -5899,11 +5968,18 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                     if (wr_rc != MQTT_CODE_CONTINUE) {
                         BROKER_FORCE_ZERO(wc->tx_buf, enc_rc);
                     }
+                    if (wr_rc != MQTT_CODE_CONTINUE && wr_rc != enc_rc &&
+                            eff_qos >= MQTT_QOS_1) {
+                        /* Write failed and the subscriber stays connected, so
+                         * nothing else will release the identifier. */
+                        BrokerStaticOutId_Release(wc, out_pub.packet_id,
+                            eff_qos);
+                    }
                 }
                 else {
                     /* The PUBLISH never reached the wire, so no PUBACK or
-                     * PUBCOMP will ever release the identifier. Give the slot back
-                     * now [MQTT-2.3.1-3]. */
+                     * PUBCOMP will ever release the identifier. Give the slot
+                     * back now [MQTT-2.3.1-3]. */
                     BrokerStaticOutId_Release(wc, out_pub.packet_id, eff_qos);
                 }
             }
@@ -6592,35 +6668,34 @@ static int BrokerHandle_Connect(BrokerClient* bc, int rx_len,
         }
     }
     if (mc.password) {
-        word16 plen = 0;
-        if (MqttDecode_Num((byte*)mc.password - MQTT_DATA_LEN_SIZE,
-                &plen, MQTT_DATA_LEN_SIZE) == MQTT_DATA_LEN_SIZE) {
-        #ifdef WOLFMQTT_STATIC_MEMORY
-            if (plen >= BROKER_MAX_PASSWORD_LEN) {
-                WBLOG_ERR(broker,
-                    "broker: password too long (%u >= %d) sock=%d",
-                    (unsigned)plen, BROKER_MAX_PASSWORD_LEN,
-                    (int)bc->sock);
-            #ifdef WOLFMQTT_V5
-                if (mc.protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
-                    ack.return_code = MQTT_REASON_BAD_USER_OR_PASS;
-                }
-                else
-            #endif
-                {
-                    ack.return_code =
-                        MQTT_CONNECT_ACK_CODE_REFUSED_BAD_USER_PWD;
-                }
-                goto send_connack;
+        /* [MQTT-3.1.3.5] Password is Binary Data, so its length comes from
+         * the wire (MqttDecode_Connect reports it in password_len), not from
+         * XSTRLEN over a pointer into a rx_buf that is not NUL terminated. */
+        word16 plen = mc.password_len;
+    #ifdef WOLFMQTT_STATIC_MEMORY
+        if (plen >= BROKER_MAX_PASSWORD_LEN) {
+            WBLOG_ERR(broker,
+                "broker: password too long (%u >= %d) sock=%d",
+                (unsigned)plen, BROKER_MAX_PASSWORD_LEN,
+                (int)bc->sock);
+        #ifdef WOLFMQTT_V5
+            if (mc.protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
+                ack.return_code = MQTT_REASON_BAD_USER_OR_PASS;
             }
+            else
         #endif
-            /* [MQTT-3.1.3.5] Password is Binary Data and may legally
-             * contain 0x00. The binary-sensitive store records the
-             * actual length in bc->password_len so wipe and compare
-             * paths don't fall back to XSTRLEN truncation. */
-            BROKER_STORE_BIN_SENSITIVE(bc->password, bc->password_len,
-                mc.password, plen, BROKER_MAX_PASSWORD_LEN);
+            {
+                ack.return_code =
+                    MQTT_CONNECT_ACK_CODE_REFUSED_BAD_USER_PWD;
+            }
+            goto send_connack;
         }
+    #endif
+        /* The binary-sensitive store records the actual length in
+         * bc->password_len so wipe and compare paths don't fall back to
+         * XSTRLEN truncation. */
+        BROKER_STORE_BIN_SENSITIVE(bc->password, bc->password_len,
+            mc.password, plen, BROKER_MAX_PASSWORD_LEN);
     }
     if (broker->auth_user || broker->auth_pass) {
         int auth_ok = 1;
@@ -7756,10 +7831,10 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                     out_pub.packet_id = BrokerStaticOutId_Take(broker,
                         sub->client, eff_qos);
                     if (out_pub.packet_id == 0) {
-            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
-             * because every one is still awaiting its acknowledgement.
-             * Reusing one would make the pending exchange ambiguous, so skip
-             * this delivery instead. */
+                        /* [MQTT-2.3.1-4] No identifier is free for this
+                         * subscriber because every one is still awaiting its
+                         * acknowledgement. Reusing one would make the pending
+                         * exchange ambiguous, so skip this delivery. */
                         WBLOG_ERR(broker, "broker: static live delivery "
                             "dropped sock=%d (no free packet id)",
                             (int)sub->client->sock);
@@ -7795,8 +7870,8 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                 }
                 else {
                     /* The PUBLISH never reached the wire, so no PUBACK or
-                     * PUBCOMP will ever release the identifier. Give the slot back
-                     * now [MQTT-2.3.1-3]. */
+                     * PUBCOMP will ever release the identifier. Give the slot
+                     * back now [MQTT-2.3.1-3]. */
                     BrokerStaticOutId_Release(sub->client, out_pub.packet_id,
                         eff_qos);
                     WBLOG_ERR(broker,
@@ -8124,6 +8199,9 @@ static int BrokerHandle_PublishRec(BrokerClient* bc, int rx_len)
             reason_code >= 0x80) {
         /* A rejecting PUBREC ends this delivery; no PUBREL follows. */
     #ifdef WOLFMQTT_STATIC_MEMORY
+        /* No PUBCOMP will ever arrive for this identifier, so give the slot
+         * back now or the subscriber runs out of them [MQTT-2.3.1-4]. */
+        BrokerStaticOutId_Release(bc, resp.packet_id, MQTT_QOS_2);
         BrokerStaticOrphan_OnPubReject(bc->broker, bc, resp.packet_id);
     #else
         BrokerClient_OnPubReject(bc, resp.packet_id);
@@ -8519,7 +8597,8 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                 #ifdef WOLFMQTT_STATIC_MEMORY
                     /* [MQTT-2.3.1-3] PUBACK completes the QoS 1 exchange, so
                      * the identifier is free for the next delivery. */
-                    BrokerStaticOutId_Release(bc, ack_resp.packet_id, MQTT_QOS_1);
+                    BrokerStaticOutId_Release(bc, ack_resp.packet_id,
+                        MQTT_QOS_1);
                     BrokerStaticOrphan_OnPubAck(broker, bc,
                         ack_resp.packet_id);
                 #else
@@ -8576,7 +8655,8 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                 if (comp_rc >= 0) {
                 #ifdef WOLFMQTT_STATIC_MEMORY
                     /* [MQTT-2.3.1-3] PUBCOMP completes the QoS 2 exchange. */
-                    BrokerStaticOutId_Release(bc, comp_resp.packet_id, MQTT_QOS_2);
+                    BrokerStaticOutId_Release(bc, comp_resp.packet_id,
+                        MQTT_QOS_2);
                     BrokerStaticOrphan_OnPubComp(broker, bc,
                         comp_resp.packet_id);
                 #else

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -4397,6 +4397,79 @@ static word16 BrokerNextPacketId(MqttBroker* broker)
     }
     return id;
 }
+
+/* Outbound Packet Identifier occupancy for the static-memory fan-out, which
+ * has no per-subscriber queue to derive it from. [MQTT-2.3.1-4] holds a Server
+ * sending a QoS > 0 PUBLISH to the same rule as a Client: the identifier stays
+ * in use until the matching PUBACK (QoS 1) or PUBCOMP (QoS 2) is processed. */
+static int BrokerStaticOutId_InUse(const BrokerClient* bc, word16 packet_id)
+{
+    int i;
+
+    for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
+        if (bc->out_inflight[i] == packet_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id)
+{
+    int i;
+
+    if (bc == NULL || packet_id == 0) {
+        return;
+    }
+    for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
+        if (bc->out_inflight[i] == packet_id) {
+            bc->out_inflight[i] = 0;
+            return;
+        }
+    }
+}
+
+/* Pick an identifier this subscriber is not already waiting on and record it.
+ * Returns 0 when every value is outstanding or the table is full, which the
+ * callers treat as "cannot deliver this QoS > 0 PUBLISH now" rather than
+ * reusing an identifier the client has not acknowledged. */
+static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc)
+{
+    word16 candidate;
+    word16 first;
+    int i;
+
+    for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
+        if (bc->out_inflight[i] == 0) {
+            break;
+        }
+    }
+    if (i == BROKER_MAX_INFLIGHT_PER_SUB) {
+        return 0; /* every in-flight slot is taken */
+    }
+
+    candidate = broker->next_packet_id;
+    if (candidate == 0) {
+        candidate = 1;
+    }
+    first = candidate;
+    do {
+        if (!BrokerStaticOutId_InUse(bc, candidate)) {
+            broker->next_packet_id = (word16)(candidate + 1);
+            if (broker->next_packet_id == 0) {
+                broker->next_packet_id = 1;
+            }
+            bc->out_inflight[i] = candidate;
+            return candidate;
+        }
+        candidate++;
+        if (candidate == 0) {
+            candidate = 1;
+        }
+    } while (candidate != first);
+
+    return 0;
+}
 #else
 static int BrokerPacketIdInQueue(const BrokerOutPub* out_q, word16 packet_id)
 {
@@ -5456,7 +5529,16 @@ static int BrokerRetained_DeliverToClient(MqttBroker* broker,
             out_pub.buffer = (rm->payload_len > 0) ? rm->payload : NULL;
             out_pub.total_len = rm->payload_len;
             if (eff_qos >= MQTT_QOS_1) {
-                out_pub.packet_id = BrokerNextPacketId(broker);
+                out_pub.packet_id = BrokerStaticOutId_Take(broker, bc);
+                if (out_pub.packet_id == 0) {
+            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
+             * because every one is still awaiting its acknowledgement.
+             * Reusing one would make the pending exchange ambiguous, so skip
+             * this delivery instead. */
+                    WBLOG_ERR(broker, "broker: static retained delivery "
+                        "dropped sock=%d (no free packet id)", (int)bc->sock);
+                    continue;
+                }
             }
 #ifdef WOLFMQTT_V5
             out_pub.protocol_level = bc->protocol_level;
@@ -5772,7 +5854,16 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                 out_pub.buffer = (payload_len > 0) ? (byte*)payload : NULL;
                 out_pub.total_len = payload_len;
                 if (eff_qos >= MQTT_QOS_1) {
-                    out_pub.packet_id = BrokerNextPacketId(broker);
+                    out_pub.packet_id = BrokerStaticOutId_Take(broker, wc);
+                    if (out_pub.packet_id == 0) {
+            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
+             * because every one is still awaiting its acknowledgement.
+             * Reusing one would make the pending exchange ambiguous, so skip
+             * this delivery instead. */
+                        WBLOG_ERR(broker, "broker: static delivery dropped "
+                            "sock=%d (no free packet id)", (int)wc->sock);
+                        continue;
+                    }
                 }
 #ifdef WOLFMQTT_V5
                 out_pub.protocol_level = wc->protocol_level;
@@ -7633,7 +7724,18 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                 out_pub.topic_name = topic;
                 out_pub.qos = eff_qos;
                 if (eff_qos >= MQTT_QOS_1) {
-                    out_pub.packet_id = BrokerNextPacketId(broker);
+                    out_pub.packet_id = BrokerStaticOutId_Take(broker,
+                        sub->client);
+                    if (out_pub.packet_id == 0) {
+            /* [MQTT-2.3.1-4] No identifier is free for this subscriber
+             * because every one is still awaiting its acknowledgement.
+             * Reusing one would make the pending exchange ambiguous, so skip
+             * this delivery instead. */
+                        WBLOG_ERR(broker, "broker: static live delivery "
+                            "dropped sock=%d (no free packet id)",
+                            (int)sub->client->sock);
+                        continue;
+                    }
                 }
                 out_pub.retain = 0;
                 out_pub.duplicate = 0;
@@ -8381,6 +8483,9 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                         MQTT_PACKET_TYPE_PUBLISH_ACK, &ack_resp);
                 if (ack_rc >= 0) {
                 #ifdef WOLFMQTT_STATIC_MEMORY
+                    /* [MQTT-2.3.1-3] PUBACK completes the QoS 1 exchange, so
+                     * the identifier is free for the next delivery. */
+                    BrokerStaticOutId_Release(bc, ack_resp.packet_id);
                     BrokerStaticOrphan_OnPubAck(broker, bc,
                         ack_resp.packet_id);
                 #else
@@ -8436,6 +8541,8 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                         MQTT_PACKET_TYPE_PUBLISH_COMP, &comp_resp);
                 if (comp_rc >= 0) {
                 #ifdef WOLFMQTT_STATIC_MEMORY
+                    /* [MQTT-2.3.1-3] PUBCOMP completes the QoS 2 exchange. */
+                    BrokerStaticOutId_Release(bc, comp_resp.packet_id);
                     BrokerStaticOrphan_OnPubComp(broker, bc,
                         comp_resp.packet_id);
                 #else

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -1121,6 +1121,16 @@ static int callback_broker_mqtt(struct lws *wsi,
         ws = (BrokerWsCtx*)bc->ws_ctx;
         if (ws == NULL || in == NULL || len == 0) return 0;
 
+        /* [MQTT-6.0.0-1] MQTT over WebSocket is carried in binary data
+         * frames: "If any other type of data frame is received the recipient
+         * MUST close the Network Connection." A text frame's payload is not
+         * an MQTT byte stream, so it must never reach the packet parser. */
+        if (!lws_frame_is_binary(wsi)) {
+            WBLOG_ERR(broker, "broker: ws non-binary data frame wsi=%p "
+                "[MQTT-6.0.0-1]", (void*)wsi);
+            return -1; /* close connection */
+        }
+
         /* Append data to rx_buffer */
         if (ws->rx_len + len <= sizeof(ws->rx_buffer)) {
             XMEMCPY(ws->rx_buffer + ws->rx_len, in, len);
@@ -2145,6 +2155,40 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                  * on the next reconnect. Subsequent writes on the
                  * same dead socket would just stack more errors, so
                  * stop the drain here. */
+                if (bc->client.write.pos > 0 && cur->qos > MQTT_QOS_0) {
+                    /* Part of this PUBLISH did reach the subscriber before
+                     * the error - a blocking write loop leaves write.pos at
+                     * what it managed to send, and a resumed nonblocking
+                     * write keeps its offset. The replay after session
+                     * recovery is therefore a re-delivery attempt and
+                     * [MQTT-3.3.1-1] requires it to carry DUP=1, the same
+                     * as the MQTT_CODE_CONTINUE case above. */
+                    cur->retransmit_dup = 1;
+                }
+                else if (bc->client.write.pos > 0) {
+                    /* MQTT 3.1.1 section 4.3.1: at QoS 0 "no retry is
+                     * performed by the sender" and the message "arrives at the
+                     * receiver either once or not at all". Bytes of this
+                     * PUBLISH are already on the wire, so leaving the entry
+                     * queued would let it follow the Session into an orphan
+                     * and be sent a second time after reconnect. Section 4.1
+                     * makes only QoS 0 messages *pending transmission*
+                     * optional Session state, and this one is no longer
+                     * pending - drop it. */
+                    BrokerOutPub* free_me = cur;
+
+                    if (prev == NULL) {
+                        bc->out_q_head = cur->next;
+                    }
+                    else {
+                        prev->next = cur->next;
+                    }
+                    if (bc->out_q_tail == cur) {
+                        bc->out_q_tail = prev;
+                    }
+                    bc->out_q_count--;
+                    BrokerOutPub_Free(free_me);
+                }
                 WBLOG_ERR(bc->broker,
                     "broker: drain write failed sock=%d topic=%s rc=%d",
                     (int)bc->sock, BrokerLog_Sanitize(cur->topic), wr_rc);
@@ -6956,6 +7000,18 @@ send_connack:
 
     /* Return 0 if auth rejected so caller can disconnect */
     if (ack.return_code != MQTT_CONNECT_ACK_CODE_ACCEPTED) {
+#ifndef WOLFMQTT_STATIC_MEMORY
+        if (rc == MQTT_CODE_CONTINUE) {
+            /* MQTT 3.1.1 section 3.1.4 has the Server send a CONNACK carrying
+             * the non-zero return code and then close the Network Connection.
+             * Closing now would deliver only the bytes already written, so the
+             * client could never read why it was refused. Keep the socket open
+             * until BrokerClient_ResumeConnAck finishes the write; it then
+             * performs the close. */
+            bc->connack_pending_len = ack_len;
+            bc->connack_refused = 1;
+        }
+#endif
         return 0;
     }
 
@@ -7989,6 +8045,29 @@ static void BrokerClient_AbnormalClose(MqttBroker* broker, BrokerClient* bc)
     BrokerClient_Remove(broker, bc);
 }
 
+/* Tear down a client whose CONNECT did not leave it live. A refused or
+ * undecodable CONNECT established no Session, so its tracking is simply
+ * dropped. A CONNECT accepted internally whose CONNACK could not be written
+ * did resume or create Session state; preserve that according to the
+ * negotiated expiry. No Will is published: a client refused at CONNECT never
+ * had one stored, and an accepted-but-unacknowledged one is handled by the
+ * abnormal-close path instead. */
+static void BrokerClient_EndConnect(MqttBroker* broker, BrokerClient* bc)
+{
+    if (bc->session_established) {
+        if (bc->session_expiry_sec == 0) {
+            BrokerSubs_EndClientSession(broker, bc);
+        }
+        else {
+            BrokerSubs_OrphanClient(broker, bc);
+        }
+    }
+    else {
+        BrokerSubs_RemoveClient(broker, bc);
+    }
+    BrokerClient_Remove(broker, bc);
+}
+
 /* Returns non-zero for return codes that require the broker to close the
  * client connection. Includes:
  *   - Wire-level decode errors (malformed packet, wrong packet type).
@@ -8013,13 +8092,17 @@ static int BrokerRcIsFatal(int rc)
 }
 
 #ifndef WOLFMQTT_STATIC_MEMORY
-/* Finish an accepted CONNACK whose write returned MQTT_CODE_CONTINUE. Returns
- * CONTINUE while it is still in flight, MQTT_CODE_SUCCESS once fully written
- * (deliveries queued meanwhile are then drained), or a negative code after
- * closing the client on a write failure. */
+/* Finish a CONNACK whose write returned MQTT_CODE_CONTINUE. Returns CONTINUE
+ * while it is still in flight and MQTT_CODE_SUCCESS once an accepted CONNACK
+ * is fully written (deliveries queued meanwhile are then drained). Any other
+ * value means the client has been removed and the caller must not touch it
+ * again: either the write failed, or a refused CONNACK finished delivering its
+ * return code and the Network Connection was closed as section 3.1.4
+ * requires. */
 static int BrokerClient_ResumeConnAck(MqttBroker* broker, BrokerClient* bc)
 {
     int rc;
+    int refused = (bc->connack_refused != 0);
 
     rc = MqttPacket_Write(&bc->client, bc->tx_buf, bc->connack_pending_len);
     if (rc == MQTT_CODE_CONTINUE) {
@@ -8029,10 +8112,30 @@ static int BrokerClient_ResumeConnAck(MqttBroker* broker, BrokerClient* bc)
         WBLOG_ERR(broker, "broker: CONNACK write failed sock=%d rc=%d",
             (int)bc->sock, rc);
         bc->connack_pending_len = 0;
-        BrokerClient_AbnormalClose(broker, bc);
+        bc->connack_refused = 0;
+        if (refused) {
+            BrokerClient_EndConnect(broker, bc);
+        }
+        else {
+            BrokerClient_AbnormalClose(broker, bc);
+        }
         return (rc < 0) ? rc : MQTT_CODE_ERROR_NETWORK;
     }
     bc->connack_pending_len = 0;
+    if (refused) {
+        /* The refusal reached the client in full; now close the Network
+         * Connection, which is what the immediate close was trying to do
+         * before it truncated the return code. */
+        bc->connack_refused = 0;
+        WBLOG_INFO(broker, "broker: refused CONNACK delivered sock=%d",
+            (int)bc->sock);
+        BrokerClient_EndConnect(broker, bc);
+        return MQTT_CODE_ERROR_NETWORK;
+    }
+    /* The CONNACK step is complete, so keep alive monitoring starts now
+     * (MQTT 3.1.1 section 3.1.4). Re-baseline the deadline off this moment
+     * rather than the CONNECT that arrived before the slow write. */
+    bc->last_rx = WOLFMQTT_BROKER_GET_TIME_S();
     if (bc->out_q_count > 0) {
         BrokerClient_DrainOutQueue(bc);
     }
@@ -8240,24 +8343,17 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                         && bc->connack_pending_len == 0
             #endif
                         ) {
-                    /* Refused/decode-failed CONNECTs have no established
-                     * Session. A CONNECT accepted internally whose CONNACK
-                     * write failed has already resumed/created Session state;
-                     * preserve it according to the negotiated expiry. */
-                    if (bc->session_established) {
-                        if (bc->session_expiry_sec == 0) {
-                            BrokerSubs_EndClientSession(broker, bc);
-                        }
-                        else {
-                            BrokerSubs_OrphanClient(broker, bc);
-                        }
-                    }
-                    else {
-                        BrokerSubs_RemoveClient(broker, bc);
-                    }
-                    BrokerClient_Remove(broker, bc);
+                    BrokerClient_EndConnect(broker, bc);
                     return 0;
                 }
+            #ifndef WOLFMQTT_STATIC_MEMORY
+                if (bc->connack_refused) {
+                    /* The refusal is still going out. The client is not
+                     * connected and must not be marked so; ResumeConnAck
+                     * closes it once the return code has been delivered. */
+                    break;
+                }
+            #endif
                 bc->connected = 1;
                 break;
             }
@@ -8509,6 +8605,36 @@ check_timeouts:
 #endif
 
     /* Check keepalive timeout (MQTT spec 3.1.2.10: 1.5x keep alive) */
+#ifndef WOLFMQTT_STATIC_MEMORY
+    if (bc->connack_pending_len != 0) {
+        /* MQTT 3.1.1 section 3.1.4 orders "Start message delivery and keep
+         * alive monitoring" after the CONNACK step, so an accepted CONNACK
+         * that is still only partly written must not be cut short by this
+         * client's own keepalive deadline. Reads are withheld until that write
+         * completes, so last_rx cannot advance meanwhile and the deadline
+         * would otherwise always win on a slow link. The handshake stays
+         * bounded by BROKER_CONNECT_TIMEOUT_SEC (measured from the CONNECT
+         * that produced this CONNACK) so a peer that never drains its socket
+         * cannot hold the client slot forever. */
+        WOLFMQTT_BROKER_TIME_T now = WOLFMQTT_BROKER_GET_TIME_S();
+
+        if (now >= bc->last_rx && (now - bc->last_rx) >
+                (WOLFMQTT_BROKER_TIME_T)BROKER_CONNECT_TIMEOUT_SEC) {
+            WBLOG_ERR(broker, "broker: CONNACK write timeout sock=%d",
+                (int)bc->sock);
+            bc->connack_pending_len = 0;
+            if (bc->connack_refused) {
+                bc->connack_refused = 0;
+                BrokerClient_EndConnect(broker, bc);
+            }
+            else {
+                BrokerClient_AbnormalClose(broker, bc);
+            }
+            return 0;
+        }
+    }
+    else
+#endif
     if (bc->keep_alive_sec > 0) {
         WOLFMQTT_BROKER_TIME_T now = WOLFMQTT_BROKER_GET_TIME_S();
         WOLFMQTT_BROKER_TIME_T deadline = (WOLFMQTT_BROKER_TIME_T)

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -2155,6 +2155,9 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                  * on the next reconnect. Subsequent writes on the
                  * same dead socket would just stack more errors, so
                  * stop the drain here. */
+                WBLOG_ERR(bc->broker,
+                    "broker: drain write failed sock=%d topic=%s rc=%d",
+                    (int)bc->sock, BrokerLog_Sanitize(cur->topic), wr_rc);
                 if (bc->client.write.pos > 0 && cur->qos > MQTT_QOS_0) {
                     /* Part of this PUBLISH did reach the subscriber before
                      * the error - a blocking write loop leaves write.pos at
@@ -2189,9 +2192,6 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                     bc->out_q_count--;
                     BrokerOutPub_Free(free_me);
                 }
-                WBLOG_ERR(bc->broker,
-                    "broker: drain write failed sock=%d topic=%s rc=%d",
-                    (int)bc->sock, BrokerLog_Sanitize(cur->topic), wr_rc);
                 return (wr_rc < 0) ? wr_rc : MQTT_CODE_ERROR_NETWORK;
             }
         }

--- a/src/mqtt_broker.c
+++ b/src/mqtt_broker.c
@@ -2191,6 +2191,14 @@ static int BrokerClient_DrainOutQueue(BrokerClient* bc)
                     }
                     bc->out_q_count--;
                     BrokerOutPub_Free(free_me);
+                    /* MqttSocket_Write resumes a partial send at
+                     * client.write.pos inside the caller's buffer and only
+                     * clears it after a completed write. The entry those bytes
+                     * belonged to is gone, so leaving the offset set would make
+                     * the next queued PUBLISH start mid-buffer and go out
+                     * truncated. */
+                    bc->client.write.pos = 0;
+                    bc->client.write.len = 0;
                 }
                 return (wr_rc < 0) ? wr_rc : MQTT_CODE_ERROR_NETWORK;
             }
@@ -4407,14 +4415,19 @@ static int BrokerStaticOutId_InUse(const BrokerClient* bc, word16 packet_id)
     int i;
 
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
-        if (bc->out_inflight[i] == packet_id) {
+        if (bc->out_inflight[i].packet_id == packet_id) {
             return 1;
         }
     }
     return 0;
 }
 
-static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id)
+/* Free the slot only when the acknowledgement matches the QoS the delivery
+ * went out with: MQTT 3.1.1 section 4.3.3 completes a QoS 2 delivery with
+ * PUBCOMP, so a PUBACK naming that identifier must not release it while
+ * PUBREC/PUBREL/PUBCOMP are still outstanding. */
+static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id,
+    MqttQoS qos)
 {
     int i;
 
@@ -4422,8 +4435,10 @@ static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id)
         return;
     }
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
-        if (bc->out_inflight[i] == packet_id) {
-            bc->out_inflight[i] = 0;
+        if (bc->out_inflight[i].packet_id == packet_id &&
+                bc->out_inflight[i].qos == qos) {
+            bc->out_inflight[i].packet_id = 0;
+            bc->out_inflight[i].qos = MQTT_QOS_0;
             return;
         }
     }
@@ -4433,14 +4448,15 @@ static void BrokerStaticOutId_Release(BrokerClient* bc, word16 packet_id)
  * Returns 0 when every value is outstanding or the table is full, which the
  * callers treat as "cannot deliver this QoS > 0 PUBLISH now" rather than
  * reusing an identifier the client has not acknowledged. */
-static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc)
+static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc,
+    MqttQoS qos)
 {
     word16 candidate;
     word16 first;
     int i;
 
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
-        if (bc->out_inflight[i] == 0) {
+        if (bc->out_inflight[i].packet_id == 0) {
             break;
         }
     }
@@ -4459,7 +4475,8 @@ static word16 BrokerStaticOutId_Take(MqttBroker* broker, BrokerClient* bc)
             if (broker->next_packet_id == 0) {
                 broker->next_packet_id = 1;
             }
-            bc->out_inflight[i] = candidate;
+            bc->out_inflight[i].packet_id = candidate;
+            bc->out_inflight[i].qos = qos;
             return candidate;
         }
         candidate++;
@@ -5529,7 +5546,7 @@ static int BrokerRetained_DeliverToClient(MqttBroker* broker,
             out_pub.buffer = (rm->payload_len > 0) ? rm->payload : NULL;
             out_pub.total_len = rm->payload_len;
             if (eff_qos >= MQTT_QOS_1) {
-                out_pub.packet_id = BrokerStaticOutId_Take(broker, bc);
+                out_pub.packet_id = BrokerStaticOutId_Take(broker, bc, eff_qos);
                 if (out_pub.packet_id == 0) {
             /* [MQTT-2.3.1-4] No identifier is free for this subscriber
              * because every one is still awaiting its acknowledgement.
@@ -5562,6 +5579,12 @@ static int BrokerRetained_DeliverToClient(MqttBroker* broker,
                      * the subscriber tx_buf, mirroring the will fan-out. */
                     BROKER_FORCE_ZERO(bc->tx_buf, enc_rc);
                 }
+            }
+            else {
+                /* The PUBLISH never reached the wire, so no PUBACK or
+                 * PUBCOMP will ever release the identifier. Give the slot back
+                 * now [MQTT-2.3.1-3]. */
+                BrokerStaticOutId_Release(bc, out_pub.packet_id, eff_qos);
             }
         }
     }
@@ -5854,7 +5877,7 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                 out_pub.buffer = (payload_len > 0) ? (byte*)payload : NULL;
                 out_pub.total_len = payload_len;
                 if (eff_qos >= MQTT_QOS_1) {
-                    out_pub.packet_id = BrokerStaticOutId_Take(broker, wc);
+                    out_pub.packet_id = BrokerStaticOutId_Take(broker, wc, eff_qos);
                     if (out_pub.packet_id == 0) {
             /* [MQTT-2.3.1-4] No identifier is free for this subscriber
              * because every one is still awaiting its acknowledgement.
@@ -5876,6 +5899,12 @@ static void BrokerClient_PublishWillImmediate(MqttBroker* broker,
                     if (wr_rc != MQTT_CODE_CONTINUE) {
                         BROKER_FORCE_ZERO(wc->tx_buf, enc_rc);
                     }
+                }
+                else {
+                    /* The PUBLISH never reached the wire, so no PUBACK or
+                     * PUBCOMP will ever release the identifier. Give the slot back
+                     * now [MQTT-2.3.1-3]. */
+                    BrokerStaticOutId_Release(wc, out_pub.packet_id, eff_qos);
                 }
             }
         }
@@ -7725,7 +7754,7 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                 out_pub.qos = eff_qos;
                 if (eff_qos >= MQTT_QOS_1) {
                     out_pub.packet_id = BrokerStaticOutId_Take(broker,
-                        sub->client);
+                        sub->client, eff_qos);
                     if (out_pub.packet_id == 0) {
             /* [MQTT-2.3.1-4] No identifier is free for this subscriber
              * because every one is still awaiting its acknowledgement.
@@ -7765,6 +7794,11 @@ static int BrokerHandle_Publish(BrokerClient* bc, int rx_len,
                     BROKER_FORCE_ZERO(sub->client->tx_buf, sub_rc);
                 }
                 else {
+                    /* The PUBLISH never reached the wire, so no PUBACK or
+                     * PUBCOMP will ever release the identifier. Give the slot back
+                     * now [MQTT-2.3.1-3]. */
+                    BrokerStaticOutId_Release(sub->client, out_pub.packet_id,
+                        eff_qos);
                     WBLOG_ERR(broker,
                         "broker: PUBLISH fwd encode failed "
                         "sock=%d -> sock=%d rc=%d",
@@ -8485,7 +8519,7 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                 #ifdef WOLFMQTT_STATIC_MEMORY
                     /* [MQTT-2.3.1-3] PUBACK completes the QoS 1 exchange, so
                      * the identifier is free for the next delivery. */
-                    BrokerStaticOutId_Release(bc, ack_resp.packet_id);
+                    BrokerStaticOutId_Release(bc, ack_resp.packet_id, MQTT_QOS_1);
                     BrokerStaticOrphan_OnPubAck(broker, bc,
                         ack_resp.packet_id);
                 #else
@@ -8542,7 +8576,7 @@ static int BrokerClient_Process(MqttBroker* broker, BrokerClient* bc)
                 if (comp_rc >= 0) {
                 #ifdef WOLFMQTT_STATIC_MEMORY
                     /* [MQTT-2.3.1-3] PUBCOMP completes the QoS 2 exchange. */
-                    BrokerStaticOutId_Release(bc, comp_resp.packet_id);
+                    BrokerStaticOutId_Release(bc, comp_resp.packet_id, MQTT_QOS_2);
                     BrokerStaticOrphan_OnPubComp(broker, bc,
                         comp_resp.packet_id);
                 #else

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -500,9 +500,9 @@ static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
 }
 #endif /* WOLFMQTT_V5 */
 
-#if WOLFMQTT_MAX_QOS >= 2
-/* Fingerprint the ClientId so the inbound QoS 2 table can tell whether a
- * resumed Session belongs to the same one. A collision leaves stale entries in
+#ifdef WOLFMQTT_SESSION_ID_HASH
+/* Fingerprint the ClientId so the Session state can tell whether a resumed
+ * Session belongs to the same one. A collision leaves stale entries in
  * place, which is exactly the behaviour before this check existed, so the
  * cheap hash only ever improves on it. Never returns 0; that value marks
  * "no Session recorded". */
@@ -520,7 +520,9 @@ static word32 MqttClient_ClientIdHash(const char* client_id)
     }
     return (hash == 0) ? 1 : hash;
 }
+#endif /* WOLFMQTT_SESSION_ID_HASH */
 
+#if WOLFMQTT_MAX_QOS >= 2
 /* Inbound QoS 2 de-duplication. A subscribing client that has delivered a
  * QoS 2 PUBLISH to the application and answered with PUBREC records its packet
  * id until the matching PUBREL arrives, so a retransmitted PUBLISH is
@@ -2992,7 +2994,9 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
     word32 connect_flags = 0;
+#ifdef WOLFMQTT_SESSION_ID_HASH
     int session_id_matched = 0;
+#endif
 #if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
     MqttProp recv_max_prop;
     MqttProp* app_props = NULL;
@@ -3414,6 +3418,7 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
     }
 
+#ifdef WOLFMQTT_SESSION_ID_HASH
     /* [MQTT-3.1.3-2] The ClientId identifies the Client and its Session, so
      * session state carries over only when the ClientId is the same one that
      * created it. Recorded here, before the per-table decisions below, because
@@ -3424,6 +3429,7 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         session_id_matched = (id_hash == client->session_client_id_hash);
         client->session_client_id_hash = id_hash;
     }
+#endif
 
 #if WOLFMQTT_MAX_QOS >= 2
     /* The server's Session Present flag, not the client's request, decides

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -719,6 +719,49 @@ static void MqttClient_Replay_Reset(MqttClient* client)
     }
     client->replayIdx = MQTT_MAX_REPLAY_MSGS;
 }
+
+/* Lock-taking wrappers for the callers that reach the store from outside the
+ * client lock. Keeping the #ifdef inside a helper avoids leaving a bare scope
+ * block behind at each call site in single-threaded builds. */
+static void MqttClient_Replay_AddSafe(MqttClient* client, MqttPublish* publish)
+{
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    MqttClient_Replay_Add(client, publish);
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
+static void MqttClient_Replay_PubRelSentSafe(MqttClient* client,
+    word16 packet_id)
+{
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    MqttClient_Replay_PubRelSent(client, packet_id);
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
+static void MqttClient_Replay_RemoveSafe(MqttClient* client, word16 packet_id)
+{
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    MqttClient_Replay_Remove(client, packet_id);
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
 #endif /* !WOLFMQTT_NO_SESSION_REPLAY */
 
 /* Outbound Packet Identifier occupancy.
@@ -1288,15 +1331,7 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
                     MqttClient_SendIdRelease(client, packet_id);
                 #ifndef WOLFMQTT_NO_SESSION_REPLAY
                     /* Completely acknowledged, so it leaves Session state. */
-                #ifdef WOLFMQTT_MULTITHREAD
-                    if (wm_SemLock(&client->lockClient) == 0)
-                #endif
-                    {
-                        MqttClient_Replay_Remove(client, packet_id);
-                #ifdef WOLFMQTT_MULTITHREAD
-                        wm_SemUnlock(&client->lockClient);
-                #endif
-                    }
+                    MqttClient_Replay_RemoveSafe(client, packet_id);
                 #endif
                 }
             #ifdef WOLFMQTT_V5
@@ -1649,6 +1684,16 @@ static int MqttClient_HandlePacket(MqttClient* client,
                     }
                     wm_SemUnlock(&client->lockClient);
                 }
+            #endif
+                /* [MQTT-2.3.1-3] The Packet Identifier is available for
+                 * reuse once the exchange it belongs to is complete, and this
+                 * one is: no PUBREL and no PUBCOMP follow a rejecting PUBREC.
+                 * The message also leaves Session state - the server declined
+                 * it, so [MQTT-4.4.0-1] does not ask for it back after a
+                 * reconnect. */
+                MqttClient_SendIdRelease(client, packet_id);
+            #ifndef WOLFMQTT_NO_SESSION_REPLAY
+                MqttClient_Replay_RemoveSafe(client, packet_id);
             #endif
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PUBLISH_REJECTED);
             }
@@ -2378,16 +2423,8 @@ wait_again:
              * after a CleanSession 0 reconnect [MQTT-4.4.0-1]. */
             if (rc == MQTT_CODE_SUCCESS &&
                     mms_stat->ackPacketType == MQTT_PACKET_TYPE_PUBLISH_REL) {
-            #ifdef WOLFMQTT_MULTITHREAD
-                if (wm_SemLock(&client->lockClient) == 0)
-            #endif
-                {
-                    MqttClient_Replay_PubRelSent(client,
-                        mms_stat->ackPacketId);
-            #ifdef WOLFMQTT_MULTITHREAD
-                    wm_SemUnlock(&client->lockClient);
-            #endif
-                }
+                MqttClient_Replay_PubRelSentSafe(client,
+                    mms_stat->ackPacketId);
             }
         #endif
 
@@ -2685,6 +2722,100 @@ static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
 #endif
 
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
+/* Encode the replay packet for client->replay[client->replayIdx] into
+ * client->tx_buf. Returns the encoded length, 0 when the slot has nothing to
+ * send, or a negative error when the client lock could not be taken.
+ *
+ * When the entry cannot be rebuilt it is dropped here and its Packet
+ * Identifier is reported through dropped_id so the caller can release the
+ * reservation the reconnect took for it. That release cannot happen inside
+ * this function: MqttClient_SendIdRelease takes client->lockClient, which is
+ * held below and is not recursive.
+ *
+ * Takes client->lockClient because the receive path frees a slot as soon as
+ * its acknowledgement arrives: the slot fields, and the topic and payload
+ * buffers the encoder copies out of it, must not be read without it. The
+ * caller already holds lockSend, which is the lockSend -> lockClient order
+ * used everywhere else. */
+static int MqttClient_Replay_EncodeNext(MqttClient* client, word16* dropped_id)
+{
+    MqttReplayMsg* slot;
+    int rc = 0;
+    int keep = 0;
+
+    *dropped_id = 0;
+#ifdef WOLFMQTT_MULTITHREAD
+    rc = wm_SemLock(&client->lockClient);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+#endif
+    slot = &client->replay[client->replayIdx];
+
+    /* Empty slots, and PUBLISHes whose payload could not be retained, have
+     * nothing to send. The entry is kept rather than dropped: the server may
+     * still acknowledge the message it stands for, and that acknowledgement
+     * is what releases both the slot and its Packet Identifier
+     * [MQTT-2.3.1-3]. */
+    if (slot->packet_id == 0 || (!slot->pubrelSent && !slot->haveCopy)) {
+        rc = 0;
+        keep = 1;
+    }
+    else if (slot->pubrelSent) {
+        MqttPublishResp rel;
+
+        XMEMSET(&rel, 0, sizeof(rel));
+        rel.packet_id = slot->packet_id;
+        rel.packet_type = MQTT_PACKET_TYPE_PUBLISH_REL;
+    #ifdef WOLFMQTT_V5
+        rel.protocol_level = client->protocol_level;
+    #endif
+        rc = MqttEncode_PublishResp(client->tx_buf, client->tx_buf_len,
+            MQTT_PACKET_TYPE_PUBLISH_REL, &rel);
+    }
+    else {
+        MqttPublish pub;
+
+        XMEMSET(&pub, 0, sizeof(pub));
+        pub.packet_id = slot->packet_id;
+        pub.qos = (MqttQoS)slot->qos;
+        pub.retain = slot->retain;
+        pub.duplicate = 1; /* [MQTT-3.3.1-1] */
+        pub.topic_name = slot->topic;
+        pub.buffer = slot->payload;
+        pub.buffer_len = slot->payload_len;
+        pub.total_len = slot->payload_len;
+    #ifdef WOLFMQTT_V5
+        pub.protocol_level = client->protocol_level;
+    #endif
+        rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len, &pub, 0);
+        /* MqttEncode_Publish declares the full Remaining Length in the fixed
+         * header but clamps the payload it copies to what tx_buf holds,
+         * leaving the remainder to MqttClient_Publish_WritePayload. The replay
+         * sends a single buffer and has no such second stage, so a clamped
+         * payload would put a short packet on the wire behind a longer
+         * declared length and desynchronize the stream. Drop it instead. */
+        if (rc > 0 && pub.buffer_pos != slot->payload_len) {
+            rc = 0;
+        }
+    }
+
+    if (rc <= 0 && !keep) {
+        /* Cannot rebuild this one (e.g. it no longer fits tx_buf). Drop it
+         * rather than stalling the rest of the replay, and report the
+         * identifier so the caller can give it back - nothing will ever
+         * acknowledge a message the client has abandoned. */
+        CLIENT_FORCE_ZERO(client->tx_buf, client->tx_buf_len);
+        *dropped_id = slot->packet_id;
+        MqttClient_Replay_FreeSlot(slot);
+        rc = 0;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+    return rc;
+}
+
 /* Re-send the retained Session messages after a CleanSession 0 reconnect the
  * server answered with Session Present = 1. [MQTT-4.4.0-1] requires every
  * unacknowledged QoS > 0 PUBLISH and PUBREL to go out again with its original
@@ -2697,16 +2828,8 @@ static int MqttClient_ReplaySession(MqttClient* client,
     int rc = MQTT_CODE_SUCCESS;
 
     while (client->replayIdx < MQTT_MAX_REPLAY_MSGS) {
-        MqttReplayMsg* slot = &client->replay[client->replayIdx];
         int xfer;
-
-        /* Empty slots, and PUBLISHes whose payload could not be retained,
-         * have nothing to send. */
-        if (slot->packet_id == 0 ||
-                (!slot->pubrelSent && !slot->haveCopy)) {
-            client->replayIdx++;
-            continue;
-        }
+        word16 dropped_id;
 
         if (!mc_connect->stat.isWriteActive) {
             rc = MqttWriteStart(client, &mc_connect->stat);
@@ -2714,43 +2837,17 @@ static int MqttClient_ReplaySession(MqttClient* client,
                 return rc; /* MQTT_CODE_CONTINUE while another write runs */
             }
 
-            if (slot->pubrelSent) {
-                MqttPublishResp rel;
-
-                XMEMSET(&rel, 0, sizeof(rel));
-                rel.packet_id = slot->packet_id;
-                rel.packet_type = MQTT_PACKET_TYPE_PUBLISH_REL;
-            #ifdef WOLFMQTT_V5
-                rel.protocol_level = client->protocol_level;
-            #endif
-                rc = MqttEncode_PublishResp(client->tx_buf,
-                    client->tx_buf_len, MQTT_PACKET_TYPE_PUBLISH_REL, &rel);
-            }
-            else {
-                MqttPublish pub;
-
-                XMEMSET(&pub, 0, sizeof(pub));
-                pub.packet_id = slot->packet_id;
-                pub.qos = (MqttQoS)slot->qos;
-                pub.retain = slot->retain;
-                pub.duplicate = 1; /* [MQTT-3.3.1-1] */
-                pub.topic_name = slot->topic;
-                pub.buffer = slot->payload;
-                pub.buffer_len = slot->payload_len;
-                pub.total_len = slot->payload_len;
-            #ifdef WOLFMQTT_V5
-                pub.protocol_level = client->protocol_level;
-            #endif
-                rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len,
-                    &pub, 0);
-            }
+            rc = MqttClient_Replay_EncodeNext(client, &dropped_id);
             if (rc <= 0) {
-                /* Cannot rebuild this one (e.g. it no longer fits tx_buf).
-                 * Drop it rather than stalling the rest of the replay. */
-                CLIENT_FORCE_ZERO(client->tx_buf, client->tx_buf_len);
                 MqttWriteStop(client, &mc_connect->stat);
-                MqttClient_Replay_FreeSlot(slot);
-                client->replayIdx++;
+                if (rc < 0) {
+                    return rc; /* client lock failed */
+                }
+                /* Outside the client lock, which SendIdRelease takes. */
+                if (dropped_id != 0) {
+                    MqttClient_SendIdRelease(client, dropped_id);
+                }
+                client->replayIdx++; /* nothing to send from this slot */
                 continue;
             }
             client->write.len = rc;
@@ -2810,6 +2907,35 @@ static int MqttClient_CheckConnectSent(MqttClient *client)
     return MQTT_CODE_SUCCESS;
 }
 
+#ifndef WOLFMQTT_NO_TIME
+/* Apply the auto keep-alive decision once a connect attempt has reached a
+ * final result. Shared by the normal handshake tail and by the
+ * [MQTT-4.4.0-1] replay resume path, which returns to the caller before
+ * reaching that tail; must not be called for MQTT_CODE_CONTINUE, which would
+ * discard a v5 Server Keep Alive before the attempt has finished. */
+static void MqttClient_ConnectKeepAlive(MqttClient* client,
+    const MqttConnect* mc_connect, int rc)
+{
+    if (rc == MQTT_CODE_SUCCESS) {
+        /* Connection accepted: arm auto keep-alive. A v5 Server Keep Alive
+         * (applied while processing CONNACK) takes precedence, including a
+         * value of 0 which disables keep-alive per [MQTT-3.1.2.11.2];
+         * otherwise use the client-requested value. */
+        if (!client->keep_alive_from_server) {
+            client->keep_alive_sec = mc_connect->keep_alive_sec;
+        }
+        /* Baseline the idle timer from the completed handshake so the first
+         * ping is scheduled a full interval out, not immediately. */
+        client->last_tx_time = WOLFMQTT_GET_TIME_S();
+    }
+    else {
+        /* Connect failed or was refused: leave the scheduler disarmed. */
+        client->keep_alive_sec = 0;
+    }
+    client->keep_alive_from_server = 0;
+}
+#endif
+
 int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
@@ -2826,13 +2952,29 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
     if (mc_connect->stat.write == MQTT_MSG_PAYLOAD) {
-        /* Resuming the [MQTT-4.4.0-1] replay this call started earlier; the
-         * handshake below is already done. */
-        rc = MqttClient_ReplaySession(client, mc_connect);
-        if (rc == MQTT_CODE_SUCCESS) {
-            mc_connect->stat.write = MQTT_MSG_BEGIN;
+        /* MQTT_MSG_PAYLOAD is not part of the CONNECT write sequence
+         * (MQTT_MSG_BEGIN -> MQTT_MSG_HEADER -> MQTT_MSG_AUTH/MQTT_MSG_WAIT);
+         * it marks an [MQTT-4.4.0-1] replay this call started earlier and did
+         * not finish. The CONNECT_SENT check pairs the sentinel with the
+         * Network Connection it was set on, so one left behind by a failed
+         * replay cannot make the replay the first packet of a new connection
+         * [MQTT-3.1.0-1]. */
+        if (MqttClient_CheckConnectSent(client) == MQTT_CODE_SUCCESS) {
+            rc = MqttClient_ReplaySession(client, mc_connect);
+            if (rc != MQTT_CODE_CONTINUE) {
+                /* Finished, either way: clear the sentinel so a failed replay
+                 * cannot bypass the handshake on the next call, and settle
+                 * the keep-alive scheduler the tail of this function never
+                 * reached. */
+                mc_connect->stat.write = MQTT_MSG_BEGIN;
+            #ifndef WOLFMQTT_NO_TIME
+                MqttClient_ConnectKeepAlive(client, mc_connect, rc);
+            #endif
+            }
+            return rc;
         }
-        return rc;
+        /* Stale sentinel on a fresh Network Connection: start over. */
+        mc_connect->stat.write = MQTT_MSG_BEGIN;
     }
 #endif
 
@@ -3182,6 +3324,16 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     /* reset state */
     mc_connect->stat.write = MQTT_MSG_BEGIN;
 
+    /* The CONNACK exchange is finished, so its wait state must not carry into
+     * a later handshake on the same object - the bundled examples reuse one
+     * MqttConnect across reconnects. MqttClient_WaitType dispatches on the
+     * stat of the object it was given, here mc_connect->ack: left at
+     * MQTT_MSG_PAYLOAD it would skip the read on the next call and hand
+     * whatever is still in rx_buf to the PUBLISH payload handler instead of
+     * waiting for the new CONNACK. */
+    mc_connect->ack.stat.read = MQTT_MSG_BEGIN;
+    mc_connect->ack.stat.ack = MQTT_MSG_BEGIN;
+
     /* CONNACK was received and decoded, but the broker refused the
      * connection. The specific reason is in mc_connect->ack.return_code
      * (MqttConnectAckReturnCodes for v3.1.1, MqttReasonCodes for v5). */
@@ -3246,34 +3398,22 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             client->replayIdx = 0;
             mc_connect->stat.write = MQTT_MSG_PAYLOAD;
             rc = MqttClient_ReplaySession(client, mc_connect);
-            if (rc == MQTT_CODE_SUCCESS) {
-                mc_connect->stat.write = MQTT_MSG_BEGIN;
-            }
-            else {
+            if (rc == MQTT_CODE_CONTINUE) {
+                /* The application re-enters through the resume block at the
+                 * top of this function, which arms keep-alive when the replay
+                 * finally completes. */
                 return rc;
             }
+            /* Clear the resume sentinel on success and on failure alike: a
+             * failed replay must not leave an MqttConnect that a later call
+             * would mistake for a resume and use to skip the handshake. */
+            mc_connect->stat.write = MQTT_MSG_BEGIN;
         }
     }
 #endif
 
 #ifndef WOLFMQTT_NO_TIME
-    if (rc == MQTT_CODE_SUCCESS) {
-        /* Connection accepted: arm auto keep-alive. A v5 Server Keep Alive
-         * (applied while processing CONNACK) takes precedence, including a
-         * value of 0 which disables keep-alive per [MQTT-3.1.2.11.2];
-         * otherwise use the client-requested value. */
-        if (!client->keep_alive_from_server) {
-            client->keep_alive_sec = mc_connect->keep_alive_sec;
-        }
-        /* Baseline the idle timer from the completed handshake so the first
-         * ping is scheduled a full interval out, not immediately. */
-        client->last_tx_time = WOLFMQTT_GET_TIME_S();
-    }
-    else {
-        /* Connect failed or was refused: leave the scheduler disarmed. */
-        client->keep_alive_sec = 0;
-    }
-    client->keep_alive_from_server = 0;
+    MqttClient_ConnectKeepAlive(client, mc_connect, rc);
 #endif
 
     return rc;
@@ -3818,15 +3958,7 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
             /* The PUBLISH is on the wire and unacknowledged, so it is now
              * Session state the client must be able to re-send after a
              * CleanSession 0 reconnect [MQTT-4.4.0-1]. */
-        #ifdef WOLFMQTT_MULTITHREAD
-            if (wm_SemLock(&client->lockClient) == 0)
-        #endif
-            {
-                MqttClient_Replay_Add(client, publish);
-        #ifdef WOLFMQTT_MULTITHREAD
-                wm_SemUnlock(&client->lockClient);
-        #endif
-            }
+            MqttClient_Replay_AddSafe(client, publish);
         #endif
 
             publish->stat.write = MQTT_MSG_WAIT;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -557,6 +557,158 @@ static void MqttClient_RecvQos2_Remove(MqttClient* client, word16 packet_id)
 }
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 
+/* Outbound Packet Identifier occupancy.
+ *
+ * [MQTT-2.3.1-2] "Each time a Client sends a new packet of one of these types
+ * it MUST assign it a currently unused Packet Identifier", and [MQTT-2.3.1-3]
+ * makes the identifier available for reuse only "after the Client has
+ * processed the corresponding acknowledgement packet" - PUBACK for QoS 1,
+ * PUBCOMP for QoS 2, SUBACK or UNSUBACK for the subscription packets.
+ *
+ * The WOLFMQTT_MULTITHREAD pending-response list already rejects a colliding
+ * identifier, but it is not compiled in other builds and its entries are
+ * dropped as soon as the waiting call returns - including on a timeout, where
+ * no acknowledgement was processed at all. This table is the connection-level
+ * record the rule actually asks for, so it is kept in every build. It is
+ * cleared when a Network Connection starts or ends, because the client holds
+ * no outbound session state across one.
+ *
+ * These are called from both the send and receive paths, so they take
+ * client->lockClient themselves; no caller may already hold it. */
+static int MqttClient_SendIds_Find(const MqttClient* client, word16 packet_id)
+{
+    int i;
+
+    for (i = 0; i < MQTT_MAX_SEND_INFLIGHT; i++) {
+        if (client->send_inflight[i].packet_id == packet_id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/* Claim packet_id for a new outbound packet sent through owner. Returns
+ * MQTT_CODE_SUCCESS when it was free (or when isRetransmit says this is a
+ * re-send of the same Control Packet, which [MQTT-2.3.1-3] requires to keep
+ * its original identifier), and MQTT_CODE_ERROR_PACKET_ID when it is still
+ * awaiting its acknowledgement. */
+static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
+    void* owner, int isRetransmit)
+{
+    int rc = MQTT_CODE_SUCCESS;
+    int i;
+
+    if (client == NULL || packet_id == 0) {
+        return MQTT_CODE_SUCCESS; /* nothing to track */
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    rc = wm_SemLock(&client->lockClient);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+#endif
+    i = MqttClient_SendIds_Find(client, packet_id);
+    if (i >= 0) {
+        /* Only a re-send of the same Control Packet may keep an identifier
+         * that is still awaiting its acknowledgement; it takes over the
+         * existing slot. A new message is refused even when the caller reuses
+         * the same message object, which says nothing about whether the
+         * earlier exchange finished. Resuming a partially written packet does
+         * not come through here: it re-enters past MQTT_MSG_BEGIN. */
+        if (!isRetransmit) {
+            rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PACKET_ID);
+        }
+        else {
+            client->send_inflight[i].owner = owner;
+        }
+    }
+    else {
+        i = MqttClient_SendIds_Find(client, 0);
+        if (i >= 0) {
+            client->send_inflight[i].packet_id = packet_id;
+            client->send_inflight[i].owner = owner;
+        }
+        /* Table full: this identifier goes untracked, so a later collision
+         * with it is not caught. Refusing the send instead would break an
+         * application legitimately keeping more than MQTT_MAX_SEND_INFLIGHT
+         * packets in flight, so the check is best effort past that point -
+         * raise MQTT_MAX_SEND_INFLIGHT to widen the window. */
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+    return rc;
+}
+
+/* Release packet_id once its acknowledgement has been processed. */
+static void MqttClient_SendIdRelease(MqttClient* client, word16 packet_id)
+{
+    int i;
+
+    if (client == NULL || packet_id == 0) {
+        return;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    i = MqttClient_SendIds_Find(client, packet_id);
+    if (i >= 0) {
+        client->send_inflight[i].packet_id = 0;
+        client->send_inflight[i].owner = NULL;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
+/* Release whatever identifier this message object reserved. Used when the
+ * application abandons the exchange through MqttClient_CancelMessage, which
+ * cannot tell which packet type the object holds. */
+static void MqttClient_SendIdReleaseOwner(MqttClient* client, const void* owner)
+{
+    int i;
+
+    if (client == NULL || owner == NULL) {
+        return;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    for (i = 0; i < MQTT_MAX_SEND_INFLIGHT; i++) {
+        if (client->send_inflight[i].packet_id != 0 &&
+                client->send_inflight[i].owner == owner) {
+            client->send_inflight[i].packet_id = 0;
+            client->send_inflight[i].owner = NULL;
+        }
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
+/* Drop every reservation. The identifiers were only in use on the Network
+ * Connection that is starting or ending, and the client keeps no outbound
+ * session state across one. */
+static void MqttClient_SendIdsReset(MqttClient* client)
+{
+    if (client == NULL) {
+        return;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    XMEMSET(client->send_inflight, 0, sizeof(client->send_inflight));
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
 #ifdef WOLFMQTT_MULTITHREAD
 
 /* These RespList functions assume caller has locked client->lockClient mutex */
@@ -962,6 +1114,16 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
                 p_publish_resp);
             if (rc >= 0) {
                 packet_id = p_publish_resp->packet_id;
+                /* [MQTT-2.3.1-3] The Packet Identifier becomes available for
+                 * reuse once the corresponding acknowledgement is processed:
+                 * PUBACK for QoS 1, PUBCOMP for QoS 2. PUBREC and PUBREL are
+                 * intermediate steps of the QoS 2 flow and do not release it.
+                 * An inbound PUBREL belongs to a PUBLISH this client received,
+                 * whose identifier is tracked separately. */
+                if (packet_type == MQTT_PACKET_TYPE_PUBLISH_ACK ||
+                    packet_type == MQTT_PACKET_TYPE_PUBLISH_COMP) {
+                    MqttClient_SendIdRelease(client, packet_id);
+                }
             #ifdef WOLFMQTT_V5
                 if (doProps) {
                     int tmp = Handle_Props(client, p_publish_resp->props,
@@ -990,6 +1152,8 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             rc = MqttDecode_SubscribeAck(rx_buf, rx_len, p_subscribe_ack);
             if (rc >= 0) {
                 packet_id = p_subscribe_ack->packet_id;
+                /* [MQTT-2.3.1-3] SUBACK releases the SUBSCRIBE identifier. */
+                MqttClient_SendIdRelease(client, packet_id);
             #ifdef WOLFMQTT_V5
                 if (doProps) {
                     int tmp = Handle_Props(client, p_subscribe_ack->props,
@@ -1019,6 +1183,9 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             rc = MqttDecode_UnsubscribeAck(rx_buf, rx_len, p_unsubscribe_ack);
             if (rc >= 0) {
                 packet_id = p_unsubscribe_ack->packet_id;
+                /* [MQTT-2.3.1-3] UNSUBACK releases the UNSUBSCRIBE
+                 * identifier. */
+                MqttClient_SendIdRelease(client, packet_id);
             #ifdef WOLFMQTT_V5
                 if (doProps) {
                     int tmp = Handle_Props(client, p_unsubscribe_ack->props,
@@ -2349,6 +2516,12 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         }
         XMEMSET(&mc_connect->ack, 0, sizeof(mc_connect->ack));
 
+        /* A new handshake starts a fresh outbound Packet Identifier space:
+         * the client keeps no unacknowledged outbound PUBLISH/PUBREL across a
+         * Network Connection, so nothing from the previous one is still in
+         * flight [MQTT-2.3.1-3]. */
+        MqttClient_SendIdsReset(client);
+
         /* Record whether this connection negotiates enhanced authentication so
          * a later MqttClient_Auth can be refused when no Authentication Method
          * was sent [MQTT-4.12.0-1]. Recomputed each connect, so it also resets
@@ -3103,6 +3276,22 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         #endif
             client->write.len = rc;
 
+            if (publish->qos > MQTT_QOS_0) {
+                /* [MQTT-2.3.1-2] A new QoS>0 PUBLISH must carry a currently
+                 * unused Packet Identifier. A re-send of this same PUBLISH is
+                 * required to keep its original identifier [MQTT-2.3.1-3] and
+                 * carries DUP=1 [MQTT-3.3.1-1], so it is allowed through. */
+                rc = MqttClient_SendIdReserve(client, publish->packet_id,
+                        publish, publish->duplicate);
+                if (rc != MQTT_CODE_SUCCESS) {
+                    MqttWriteStop(client, &publish->stat);
+                #ifdef WOLFMQTT_V5
+                    MqttClient_RestoreRecvQuota(client, publish);
+                #endif
+                    return rc;
+                }
+            }
+
         #ifdef WOLFMQTT_MULTITHREAD
             if (publish->qos > MQTT_QOS_0) {
                 resp_type = (publish->qos == MQTT_QOS_1) ?
@@ -3126,6 +3315,7 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 }
                 if (rc != 0) {
                     MqttWriteStop(client, &publish->stat);
+                    MqttClient_SendIdReleaseOwner(client, publish);
                 #ifdef WOLFMQTT_V5
                     MqttClient_RestoreRecvQuota(client, publish);
                 #endif
@@ -3385,6 +3575,17 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
         }
         client->write.len = rc;
 
+        /* [MQTT-2.3.1-2] A new SUBSCRIBE must carry a currently unused Packet
+         * Identifier; it is released by its SUBACK [MQTT-2.3.1-3]. SUBSCRIBE
+         * has no DUP bit, so a repeat while one is unacknowledged cannot be
+         * told apart from a new subscription and is refused. */
+        rc = MqttClient_SendIdReserve(client, subscribe->packet_id,
+                subscribe, 0);
+        if (rc != MQTT_CODE_SUCCESS) {
+            MqttWriteStop(client, &subscribe->stat);
+            return rc;
+        }
+
     #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);
         if (rc == 0) {
@@ -3395,6 +3596,7 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
         }
         if (rc != 0) {
             MqttWriteStop(client, &subscribe->stat);
+            MqttClient_SendIdReleaseOwner(client, subscribe);
             return rc; /* Error locking client */
         }
     #endif
@@ -3418,6 +3620,8 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
     #endif
         MqttWriteStop(client, &subscribe->stat);
         if (rc != xfer) {
+            /* The cancel below gives the identifier back: nothing usable
+             * reached the wire [MQTT-2.3.1-3]. */
             MqttClient_CancelMessage(client, (MqttObject*)subscribe);
             return rc;
         }
@@ -3516,6 +3720,17 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
         }
         client->write.len = rc;
 
+        /* [MQTT-2.3.1-2] A new UNSUBSCRIBE must carry a currently unused
+         * Packet Identifier; it is released by its UNSUBACK [MQTT-2.3.1-3].
+         * UNSUBSCRIBE has no DUP bit, so a repeat while one is unacknowledged
+         * cannot be told apart from a new request and is refused. */
+        rc = MqttClient_SendIdReserve(client, unsubscribe->packet_id,
+                unsubscribe, 0);
+        if (rc != MQTT_CODE_SUCCESS) {
+            MqttWriteStop(client, &unsubscribe->stat);
+            return rc;
+        }
+
     #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);
         if (rc == 0) {
@@ -3527,6 +3742,7 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
         }
         if (rc != 0) {
             MqttWriteStop(client, &unsubscribe->stat);
+            MqttClient_SendIdReleaseOwner(client, unsubscribe);
             return rc;
         }
     #endif
@@ -3550,6 +3766,8 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
     #endif
         MqttWriteStop(client, &unsubscribe->stat);
         if (rc != xfer) {
+            /* The cancel below gives the identifier back: nothing usable
+             * reached the wire [MQTT-2.3.1-3]. */
             MqttClient_CancelMessage(client, (MqttObject*)unsubscribe);
             return rc;
         }
@@ -4213,6 +4431,14 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
     mms_stat->write = MQTT_MSG_BEGIN;
     mms_stat->read = MQTT_MSG_BEGIN;
 
+    /* Give back any outbound Packet Identifier this object reserved. Cancel is
+     * the application saying it is done with the exchange and is reusing the
+     * object, so the identifier must not stay claimed for the rest of the
+     * connection - unlike the Receive Maximum unit below, a reused identifier
+     * is the application's own call rather than a flow-control promise made to
+     * the server. */
+    MqttClient_SendIdReleaseOwner(client, msg);
+
     /* Do not credit the reserved Receive Maximum unit here. Cancelling an
      * abandoned QoS>0 publish that already reached the wire must retain the
      * unit while the connection stays open - the server still counts it against
@@ -4389,6 +4615,10 @@ int MqttClient_NetDisconnect(MqttClient *client)
         return rc;
     }
 #endif
+
+    /* The Network Connection is going away and the client keeps no outbound
+     * session state across one, so nothing stays in flight [MQTT-2.3.1-3]. */
+    MqttClient_SendIdsReset(client);
 
     return MqttSocket_Disconnect(client);
 }

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2525,13 +2525,6 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
-        /* A new handshake starts a fresh outbound Packet Identifier space:
-         * the client keeps no unacknowledged outbound PUBLISH/PUBREL across a
-         * Network Connection, so nothing from the previous one is still in
-         * flight [MQTT-2.3.1-3]. Must stay outside the WOLFMQTT_V5 block
-         * below - the table exists in every build. */
-        MqttClient_SendIdsReset(client);
-
         /* [MQTT-3.1.0-2] A Client can only send the CONNECT Packet once over a
          * Network Connection; a Server must treat a second one as a protocol
          * violation and disconnect. A partially written CONNECT re-enters with
@@ -2543,6 +2536,17 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
                 MQTT_CLIENT_FLAG_CONNECT_SENT) != 0) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
         }
+
+        /* Past the guard, so this really is a new handshake: start a fresh
+         * outbound Packet Identifier space. The client keeps no
+         * unacknowledged outbound PUBLISH/PUBREL across a Network Connection,
+         * so nothing from a previous one is still in flight [MQTT-2.3.1-3].
+         * Must run after the guard above - a refused duplicate CONNECT would
+         * otherwise wipe identifiers still in flight on the live connection -
+         * and outside the WOLFMQTT_V5 block below, since the table exists in
+         * every build. */
+        MqttClient_SendIdsReset(client);
+
     #ifdef WOLFMQTT_V5
         #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -574,7 +574,9 @@ static void MqttClient_RecvQos2_Remove(MqttClient* client, word16 packet_id)
  * no outbound session state across one.
  *
  * These are called from both the send and receive paths, so they take
- * client->lockClient themselves; no caller may already hold it. */
+ * client->lockClient themselves; no caller may already hold it. Every caller
+ * has already rejected a NULL client, as MqttWriteStop and the other internal
+ * helpers here assume. */
 static int MqttClient_SendIds_Find(const MqttClient* client, word16 packet_id)
 {
     int i;
@@ -598,7 +600,7 @@ static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
     int rc = MQTT_CODE_SUCCESS;
     int i;
 
-    if (client == NULL || packet_id == 0) {
+    if (packet_id == 0) {
         return MQTT_CODE_SUCCESS; /* nothing to track */
     }
 #ifdef WOLFMQTT_MULTITHREAD
@@ -645,7 +647,7 @@ static void MqttClient_SendIdRelease(MqttClient* client, word16 packet_id)
 {
     int i;
 
-    if (client == NULL || packet_id == 0) {
+    if (packet_id == 0) {
         return;
     }
 #ifdef WOLFMQTT_MULTITHREAD
@@ -670,7 +672,7 @@ static void MqttClient_SendIdReleaseOwner(MqttClient* client, const void* owner)
 {
     int i;
 
-    if (client == NULL || owner == NULL) {
+    if (owner == NULL) {
         return;
     }
 #ifdef WOLFMQTT_MULTITHREAD
@@ -695,9 +697,6 @@ static void MqttClient_SendIdReleaseOwner(MqttClient* client, const void* owner)
  * session state across one. */
 static void MqttClient_SendIdsReset(MqttClient* client)
 {
-    if (client == NULL) {
-        return;
-    }
 #ifdef WOLFMQTT_MULTITHREAD
     if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
         return;
@@ -2461,11 +2460,27 @@ static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
  * the send APIs consult MQTT_CLIENT_FLAG_CONNECT_SENT to refuse a PUBLISH,
  * SUBSCRIBE, UNSUBSCRIBE, PINGREQ or DISCONNECT that would otherwise become
  * the first MQTT packet on the wire. A Client need not wait for CONNACK
- * (section 3.1.4), so this checks only that CONNECT has been sent. */
+ * (section 3.1.4), so this checks only that CONNECT has been sent. Callers
+ * have already rejected a NULL client. */
 static int MqttClient_CheckConnectSent(MqttClient *client)
 {
-    if ((MqttClient_Flags(client, 0, 0) &
-            MQTT_CLIENT_FLAG_CONNECT_SENT) == 0) {
+    word32 flags;
+#ifdef WOLFMQTT_MULTITHREAD
+    int rc;
+#endif
+
+#ifdef WOLFMQTT_MULTITHREAD
+    rc = wm_SemLock(&client->lockClient);
+    if (rc != 0) {
+        return rc;
+    }
+#endif
+    flags = client->flags;
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+
+    if ((flags & MQTT_CLIENT_FLAG_CONNECT_SENT) == 0) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
     }
     return MQTT_CODE_SUCCESS;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2288,6 +2288,22 @@ static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 #endif
 
+/* [MQTT-3.1.0-1] After a Network Connection is established by a Client to a
+ * Server, the first Packet sent from the Client to the Server MUST be a
+ * CONNECT Packet. MQTT_CLIENT_FLAG_IS_CONNECTED tracks only the transport, so
+ * the send APIs consult MQTT_CLIENT_FLAG_CONNECT_SENT to refuse a PUBLISH,
+ * SUBSCRIBE, UNSUBSCRIBE, PINGREQ or DISCONNECT that would otherwise become
+ * the first MQTT packet on the wire. A Client need not wait for CONNACK
+ * (section 3.1.4), so this checks only that CONNECT has been sent. */
+static int MqttClient_CheckConnectSent(MqttClient *client)
+{
+    if ((MqttClient_Flags(client, 0, 0) &
+            MQTT_CLIENT_FLAG_CONNECT_SENT) == 0) {
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
+    }
+    return MQTT_CODE_SUCCESS;
+}
+
 int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
@@ -2303,6 +2319,17 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
+        /* [MQTT-3.1.0-2] A Client can only send the CONNECT Packet once over a
+         * Network Connection; a Server must treat a second one as a protocol
+         * violation and disconnect. A partially written CONNECT re-enters with
+         * stat.write past MQTT_MSG_BEGIN, so resuming one is unaffected -
+         * only a new handshake attempt on the same transport is refused. The
+         * application must close the Network Connection with
+         * MqttClient_NetDisconnect before connecting again. */
+        if ((MqttClient_Flags(client, 0, 0) &
+                MQTT_CLIENT_FLAG_CONNECT_SENT) != 0) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
+        }
     #ifdef WOLFMQTT_V5
         #ifdef WOLFMQTT_MULTITHREAD
         rc = wm_SemLock(&client->lockClient);
@@ -2460,6 +2487,11 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             && client->write.total > 0
         #endif
         ) {
+            /* Part of the CONNECT is already on the wire, so this Network
+             * Connection has had its one CONNECT [MQTT-3.1.0-2] and the other
+             * send APIs are no longer blocked by [MQTT-3.1.0-1]. Resuming this
+             * same write re-enters past MQTT_MSG_BEGIN and is unaffected. */
+            (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
             /* keep send locked and return early.
              * Note: tx_buf still contains credentials until write completes */
             return rc;
@@ -2473,9 +2505,17 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         MqttWriteStop(client, &mc_connect->stat);
 
         if (rc != xfer) {
+            /* Nothing usable reached the peer, so leave the handshake state
+             * clear and let the caller retry on this Network Connection. */
             MqttClient_CancelMessage(client, (MqttObject*)mc_connect);
             return rc;
         }
+
+        /* CONNECT is on the wire: this Network Connection has had its one
+         * CONNECT [MQTT-3.1.0-2], and the other send APIs are no longer
+         * blocked by [MQTT-3.1.0-1]. A Client need not wait for CONNACK
+         * before sending more packets (section 3.1.4). */
+        (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
 
     #ifdef WOLFMQTT_V5
         /* Enhanced authentication */
@@ -2953,6 +2993,12 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
+    /* [MQTT-3.1.0-1] CONNECT must be the first packet on the connection. */
+    rc = MqttClient_CheckConnectSent(client);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+
 #ifdef WOLFMQTT_V5
     /* Use specified protocol version if set */
     publish->protocol_level = client->protocol_level;
@@ -3308,6 +3354,12 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
+    /* [MQTT-3.1.0-1] CONNECT must be the first packet on the connection. */
+    rc = MqttClient_CheckConnectSent(client);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+
 #ifdef WOLFMQTT_V5
     /* Use specified protocol version if set */
     subscribe->protocol_level = client->protocol_level;
@@ -3431,6 +3483,12 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
     /* Validate required arguments */
     if (client == NULL || unsubscribe == NULL) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
+    }
+
+    /* [MQTT-3.1.0-1] CONNECT must be the first packet on the connection. */
+    rc = MqttClient_CheckConnectSent(client);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
     }
 
 #ifdef WOLFMQTT_V5
@@ -3591,6 +3649,12 @@ int MqttClient_Ping_ex(MqttClient *client, MqttPing* ping)
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
 
+    /* [MQTT-3.1.0-1] CONNECT must be the first packet on the connection. */
+    rc = MqttClient_CheckConnectSent(client);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+
     if (ping->stat.write == MQTT_MSG_BEGIN) {
         /* Flag write active / lock mutex */
         if ((rc = MqttWriteStart(client, &ping->stat)) != 0) {
@@ -3703,6 +3767,13 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *p_disconnect)
     if (client == NULL) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
+
+    /* [MQTT-3.1.0-1] CONNECT must be the first packet on the connection. */
+    rc = MqttClient_CheckConnectSent(client);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
+
     if (disconnect == NULL) {
         disconnect = &lcl_disconnect;
         XMEMSET(disconnect, 0, sizeof(*disconnect));

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2461,7 +2461,11 @@ static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
  * SUBSCRIBE, UNSUBSCRIBE, PINGREQ or DISCONNECT that would otherwise become
  * the first MQTT packet on the wire. A Client need not wait for CONNACK
  * (section 3.1.4), so this checks only that CONNECT has been sent. Callers
- * have already rejected a NULL client. */
+ * have already rejected a NULL client. Reads client->flags directly rather
+ * than through MqttClient_Flags so a lock failure is propagated instead of
+ * being reported as "no flags set", and so the NULL branch inside that helper
+ * does not leave GCC a path where client is NULL after the caller checked it
+ * (which produced a false -Warray-bounds under partial inlining). */
 static int MqttClient_CheckConnectSent(MqttClient *client)
 {
     word32 flags;
@@ -2501,6 +2505,13 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
+        /* A new handshake starts a fresh outbound Packet Identifier space:
+         * the client keeps no unacknowledged outbound PUBLISH/PUBREL across a
+         * Network Connection, so nothing from the previous one is still in
+         * flight [MQTT-2.3.1-3]. Must stay outside the WOLFMQTT_V5 block
+         * below - the table exists in every build. */
+        MqttClient_SendIdsReset(client);
+
         /* [MQTT-3.1.0-2] A Client can only send the CONNECT Packet once over a
          * Network Connection; a Server must treat a second one as a protocol
          * violation and disconnect. A partially written CONNECT re-enters with
@@ -2530,12 +2541,6 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
             return rc;
         }
         XMEMSET(&mc_connect->ack, 0, sizeof(mc_connect->ack));
-
-        /* A new handshake starts a fresh outbound Packet Identifier space:
-         * the client keeps no unacknowledged outbound PUBLISH/PUBREL across a
-         * Network Connection, so nothing from the previous one is still in
-         * flight [MQTT-2.3.1-3]. */
-        MqttClient_SendIdsReset(client);
 
         /* Record whether this connection negotiates enhanced authentication so
          * a later MqttClient_Auth can be refused when no Authentication Method
@@ -2666,20 +2671,33 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     }
     if (mc_connect->stat.write == MQTT_MSG_HEADER) {
         int xfer = client->write.len;
+        int wrote;
 
         /* Send connect packet */
         rc = MqttPacket_Write(client, client->tx_buf, xfer);
+
+        /* Bytes this call put on the transport. MqttSocket_Write leaves
+         * write.pos at the partial count and clears it only on a complete
+         * write, so read it before MqttWriteStop resets the state. */
+        wrote = (rc == xfer) ? xfer : client->write.pos;
+        if (wrote > 0) {
+            /* CONNECT bytes are on the wire, so this Network Connection has
+             * had its one CONNECT [MQTT-3.1.0-2] and the other send APIs are
+             * no longer blocked by [MQTT-3.1.0-1]. A Client need not wait for
+             * CONNACK before sending more packets (section 3.1.4). Keyed on
+             * bytes rather than the return code: a nonblocking write reports
+             * MQTT_CODE_CONTINUE even when it accepted nothing, and a
+             * blocking one reports an error after getting part of the packet
+             * out. Resuming this same write re-enters past MQTT_MSG_BEGIN, so
+             * the once-per-connection guard does not see it. */
+            (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
+        }
     #ifdef WOLFMQTT_NONBLOCK
         if (rc == MQTT_CODE_CONTINUE
         #ifdef WOLFMQTT_ALLOW_NODATA_UNLOCK
             && client->write.total > 0
         #endif
         ) {
-            /* Part of the CONNECT is already on the wire, so this Network
-             * Connection has had its one CONNECT [MQTT-3.1.0-2] and the other
-             * send APIs are no longer blocked by [MQTT-3.1.0-1]. Resuming this
-             * same write re-enters past MQTT_MSG_BEGIN and is unaffected. */
-            (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
             /* keep send locked and return early.
              * Note: tx_buf still contains credentials until write completes */
             return rc;
@@ -2693,17 +2711,12 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         MqttWriteStop(client, &mc_connect->stat);
 
         if (rc != xfer) {
-            /* Nothing usable reached the peer, so leave the handshake state
-             * clear and let the caller retry on this Network Connection. */
+            /* The handshake state set above stands or not on whether bytes
+             * reached the peer, so a retry is refused only when some of this
+             * CONNECT is already out there. */
             MqttClient_CancelMessage(client, (MqttObject*)mc_connect);
             return rc;
         }
-
-        /* CONNECT is on the wire: this Network Connection has had its one
-         * CONNECT [MQTT-3.1.0-2], and the other send APIs are no longer
-         * blocked by [MQTT-3.1.0-1]. A Client need not wait for CONNACK
-         * before sending more packets (section 3.1.4). */
-        (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
 
     #ifdef WOLFMQTT_V5
         /* Enhanced authentication */
@@ -3346,6 +3359,7 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
         case MQTT_MSG_HEADER:
         {
             int xfer = client->write.len;
+            int wrote;
 
             /* Send publish packet */
             rc = MqttPacket_Write(client, client->tx_buf, xfer);
@@ -3359,6 +3373,10 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 return rc;
             }
         #endif
+            /* Bytes this call put on the transport, read before MqttWriteStop
+             * resets the write state. A blocking write can get part of the
+             * packet out and then fail. */
+            wrote = (rc == xfer) ? xfer : client->write.pos;
             client->write.len = 0; /* reset len, so publish chunk resets */
 
             /* if failure or no data was written yet */
@@ -3371,6 +3389,14 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 MqttClient_RestoreRecvQuota(client, publish);
             #endif
                 MqttClient_CancelMessage(client, (MqttObject*)publish);
+                if (wrote > 0) {
+                    /* Part of the PUBLISH reached the server, so it may have
+                     * seen the Packet Identifier. Reclaim the reservation the
+                     * cancel just dropped so a new message cannot take it
+                     * [MQTT-2.3.1-3]. */
+                    (void)MqttClient_SendIdReserve(client, publish->packet_id,
+                            publish, 1);
+                }
                 return rc;
             }
 
@@ -3399,6 +3425,11 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 MqttClient_RestoreRecvQuota(client, publish);
             #endif
                 MqttClient_CancelMessage(client, (MqttObject*)publish);
+                /* Reaching the payload means the fixed header - and with it
+                 * the Packet Identifier - is already on the wire, so keep the
+                 * reservation the cancel dropped [MQTT-2.3.1-3]. */
+                (void)MqttClient_SendIdReserve(client, publish->packet_id,
+                        publish, 1);
                 break;
             }
 
@@ -3620,6 +3651,7 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
     }
     if (subscribe->stat.write == MQTT_MSG_HEADER) {
         int xfer = client->write.len;
+        int wrote;
 
         /* Send subscribe packet */
         rc = MqttPacket_Write(client, client->tx_buf, xfer);
@@ -3633,11 +3665,19 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
             return rc;
         }
     #endif
+        /* Bytes this call put on the transport, read before MqttWriteStop
+         * resets the write state. */
+        wrote = (rc == xfer) ? xfer : client->write.pos;
         MqttWriteStop(client, &subscribe->stat);
         if (rc != xfer) {
-            /* The cancel below gives the identifier back: nothing usable
-             * reached the wire [MQTT-2.3.1-3]. */
             MqttClient_CancelMessage(client, (MqttObject*)subscribe);
+            if (wrote > 0) {
+                /* Part of the SUBSCRIBE reached the server, so it may have
+                 * seen the Packet Identifier. Reclaim the reservation the
+                 * cancel just dropped [MQTT-2.3.1-3]. */
+                (void)MqttClient_SendIdReserve(client, subscribe->packet_id,
+                        subscribe, 1);
+            }
             return rc;
         }
 
@@ -3766,6 +3806,7 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
     }
     if (unsubscribe->stat.write == MQTT_MSG_HEADER) {
         int xfer = client->write.len;
+        int wrote;
 
         /* Send unsubscribe packet */
         rc = MqttPacket_Write(client, client->tx_buf, xfer);
@@ -3779,11 +3820,19 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
             return rc;
         }
     #endif
+        /* Bytes this call put on the transport, read before MqttWriteStop
+         * resets the write state. */
+        wrote = (rc == xfer) ? xfer : client->write.pos;
         MqttWriteStop(client, &unsubscribe->stat);
         if (rc != xfer) {
-            /* The cancel below gives the identifier back: nothing usable
-             * reached the wire [MQTT-2.3.1-3]. */
             MqttClient_CancelMessage(client, (MqttObject*)unsubscribe);
+            if (wrote > 0) {
+                /* Part of the UNSUBSCRIBE reached the server, so it may have
+                 * seen the Packet Identifier. Reclaim the reservation the
+                 * cancel just dropped [MQTT-2.3.1-3]. */
+                (void)MqttClient_SendIdReserve(client, unsubscribe->packet_id,
+                        unsubscribe, 1);
+            }
             return rc;
         }
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -577,6 +577,150 @@ static void MqttClient_RecvQos2_Remove(MqttClient* client, word16 packet_id)
 }
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+/* Client-side outbound Session state. MQTT 3.1.1 section 4.1 keeps
+ * unacknowledged QoS 1 and QoS 2 messages as Session state, and
+ * [MQTT-4.4.0-1] requires them re-sent with their original Packet Identifiers
+ * after a CleanSession 0 reconnect. The caller's MqttPublish is gone by then,
+ * so the topic and payload are copied here.
+ *
+ * These run under client->lockClient in multithread builds, taken by the
+ * MqttClient_SendId* callers they sit alongside. */
+static MqttReplayMsg* MqttClient_Replay_Find(MqttClient* client,
+    word16 packet_id)
+{
+    int i;
+
+    for (i = 0; i < MQTT_MAX_REPLAY_MSGS; i++) {
+        if (client->replay[i].packet_id == packet_id) {
+            return &client->replay[i];
+        }
+    }
+    return NULL;
+}
+
+static void MqttClient_Replay_FreeSlot(MqttReplayMsg* slot)
+{
+#ifndef WOLFMQTT_STATIC_MEMORY
+    if (slot->topic != NULL) {
+        WOLFMQTT_FREE(slot->topic);
+    }
+    if (slot->payload != NULL) {
+        WOLFMQTT_FREE(slot->payload);
+    }
+#endif
+    XMEMSET(slot, 0, sizeof(*slot));
+}
+
+/* Retain a copy of an outbound QoS > 0 PUBLISH. A message that does not fit
+ * the pool is left unretained rather than refused: it still goes out, it just
+ * cannot be replayed, which is the same position the client was in before the
+ * store existed. */
+static void MqttClient_Replay_Add(MqttClient* client, MqttPublish* publish)
+{
+    MqttReplayMsg* slot;
+    size_t topic_len;
+
+    if (publish->packet_id == 0 || publish->topic_name == NULL) {
+        return;
+    }
+    /* A re-send reuses the entry the original PUBLISH created. */
+    slot = MqttClient_Replay_Find(client, publish->packet_id);
+    if (slot == NULL) {
+        slot = MqttClient_Replay_Find(client, 0);
+    }
+    if (slot == NULL) {
+        return; /* pool full: not retained */
+    }
+    MqttClient_Replay_FreeSlot(slot);
+
+    slot->packet_id = publish->packet_id;
+    slot->qos = (byte)publish->qos;
+    slot->retain = publish->retain;
+
+    /* A streamed publish delivers its payload through a callback, so there is
+     * nothing here to copy; the entry still tracks the QoS 2 PUBREL stage. */
+    if (publish->buffer == NULL || publish->total_len == 0 ||
+            publish->buffer_len < publish->total_len) {
+        return;
+    }
+    topic_len = XSTRLEN(publish->topic_name);
+
+#ifdef WOLFMQTT_STATIC_MEMORY
+    if (topic_len >= MQTT_MAX_REPLAY_TOPIC ||
+            publish->total_len > MQTT_MAX_REPLAY_PAYLOAD) {
+        return; /* too large for the fixed slot */
+    }
+    XMEMCPY(slot->topic, publish->topic_name, topic_len);
+    slot->topic[topic_len] = '\0';
+    XMEMCPY(slot->payload, publish->buffer, publish->total_len);
+#else
+    slot->topic = (char*)WOLFMQTT_MALLOC(topic_len + 1);
+    if (slot->topic == NULL) {
+        return;
+    }
+    XMEMCPY(slot->topic, publish->topic_name, topic_len);
+    slot->topic[topic_len] = '\0';
+
+    slot->payload = (byte*)WOLFMQTT_MALLOC(publish->total_len);
+    if (slot->payload == NULL) {
+        WOLFMQTT_FREE(slot->topic);
+        slot->topic = NULL;
+        return;
+    }
+    XMEMCPY(slot->payload, publish->buffer, publish->total_len);
+#endif
+    slot->payload_len = publish->total_len;
+    slot->haveCopy = 1;
+}
+
+/* QoS 2 advanced past PUBREC, so [MQTT-4.4.0-1] replays the PUBREL rather
+ * than the PUBLISH. Recorded even when no copy was retained: a PUBREL needs
+ * only the Packet Identifier. */
+static void MqttClient_Replay_PubRelSent(MqttClient* client, word16 packet_id)
+{
+    MqttReplayMsg* slot;
+
+    if (packet_id == 0) {
+        return;
+    }
+    slot = MqttClient_Replay_Find(client, packet_id);
+    if (slot == NULL) {
+        slot = MqttClient_Replay_Find(client, 0);
+        if (slot == NULL) {
+            return;
+        }
+        MqttClient_Replay_FreeSlot(slot);
+        slot->packet_id = packet_id;
+        slot->qos = MQTT_QOS_2;
+    }
+    slot->pubrelSent = 1;
+}
+
+static void MqttClient_Replay_Remove(MqttClient* client, word16 packet_id)
+{
+    MqttReplayMsg* slot;
+
+    if (packet_id == 0) {
+        return;
+    }
+    slot = MqttClient_Replay_Find(client, packet_id);
+    if (slot != NULL) {
+        MqttClient_Replay_FreeSlot(slot);
+    }
+}
+
+static void MqttClient_Replay_Reset(MqttClient* client)
+{
+    int i;
+
+    for (i = 0; i < MQTT_MAX_REPLAY_MSGS; i++) {
+        MqttClient_Replay_FreeSlot(&client->replay[i]);
+    }
+    client->replayIdx = MQTT_MAX_REPLAY_MSGS;
+}
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
+
 /* Outbound Packet Identifier occupancy.
  *
  * [MQTT-2.3.1-2] "Each time a Client sends a new packet of one of these types
@@ -1142,6 +1286,18 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
                 if (packet_type == MQTT_PACKET_TYPE_PUBLISH_ACK ||
                     packet_type == MQTT_PACKET_TYPE_PUBLISH_COMP) {
                     MqttClient_SendIdRelease(client, packet_id);
+                #ifndef WOLFMQTT_NO_SESSION_REPLAY
+                    /* Completely acknowledged, so it leaves Session state. */
+                #ifdef WOLFMQTT_MULTITHREAD
+                    if (wm_SemLock(&client->lockClient) == 0)
+                #endif
+                    {
+                        MqttClient_Replay_Remove(client, packet_id);
+                #ifdef WOLFMQTT_MULTITHREAD
+                        wm_SemUnlock(&client->lockClient);
+                #endif
+                    }
+                #endif
                 }
             #ifdef WOLFMQTT_V5
                 if (doProps) {
@@ -2217,6 +2373,24 @@ wait_again:
                 rc = MQTT_CODE_SUCCESS; /* success */
             }
 
+        #ifndef WOLFMQTT_NO_SESSION_REPLAY
+            /* A PUBREL this client sent is replayed instead of its PUBLISH
+             * after a CleanSession 0 reconnect [MQTT-4.4.0-1]. */
+            if (rc == MQTT_CODE_SUCCESS &&
+                    mms_stat->ackPacketType == MQTT_PACKET_TYPE_PUBLISH_REL) {
+            #ifdef WOLFMQTT_MULTITHREAD
+                if (wm_SemLock(&client->lockClient) == 0)
+            #endif
+                {
+                    MqttClient_Replay_PubRelSent(client,
+                        mms_stat->ackPacketId);
+            #ifdef WOLFMQTT_MULTITHREAD
+                    wm_SemUnlock(&client->lockClient);
+            #endif
+                }
+            }
+        #endif
+
             /* The staged acknowledgement is spent. */
             mms_stat->ackPacketType = MQTT_PACKET_TYPE_RESERVED;
             mms_stat->ack = MQTT_MSG_BEGIN; /* reset write state */
@@ -2406,6 +2580,10 @@ int MqttClient_Init(MqttClient *client, MqttNet* net,
 void MqttClient_DeInit(MqttClient *client)
 {
     if (client != NULL) {
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+        /* Release the retained outbound Session copies. */
+        MqttClient_Replay_Reset(client);
+#endif
 #ifdef WOLFMQTT_MULTITHREAD
     #ifdef ENABLE_MQTT_CURL
         if ((client->init_flags & MQTT_CLIENT_INIT_LOCK_CURL) != 0U) {
@@ -2506,6 +2684,96 @@ static int MqttConnect_HasRecvMax(const MqttConnect* mc_connect)
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
 #endif
 
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+/* Re-send the retained Session messages after a CleanSession 0 reconnect the
+ * server answered with Session Present = 1. [MQTT-4.4.0-1] requires every
+ * unacknowledged QoS > 0 PUBLISH and PUBREL to go out again with its original
+ * Packet Identifier, and [MQTT-3.3.1-1] requires DUP on the re-delivered
+ * PUBLISH. Resumable: client->replayIdx records how far it got, so a
+ * nonblocking caller re-enters and continues rather than restarting. */
+static int MqttClient_ReplaySession(MqttClient* client,
+    MqttConnect* mc_connect)
+{
+    int rc = MQTT_CODE_SUCCESS;
+
+    while (client->replayIdx < MQTT_MAX_REPLAY_MSGS) {
+        MqttReplayMsg* slot = &client->replay[client->replayIdx];
+        int xfer;
+
+        /* Empty slots, and PUBLISHes whose payload could not be retained,
+         * have nothing to send. */
+        if (slot->packet_id == 0 ||
+                (!slot->pubrelSent && !slot->haveCopy)) {
+            client->replayIdx++;
+            continue;
+        }
+
+        if (!mc_connect->stat.isWriteActive) {
+            rc = MqttWriteStart(client, &mc_connect->stat);
+            if (rc != MQTT_CODE_SUCCESS) {
+                return rc; /* MQTT_CODE_CONTINUE while another write runs */
+            }
+
+            if (slot->pubrelSent) {
+                MqttPublishResp rel;
+
+                XMEMSET(&rel, 0, sizeof(rel));
+                rel.packet_id = slot->packet_id;
+                rel.packet_type = MQTT_PACKET_TYPE_PUBLISH_REL;
+            #ifdef WOLFMQTT_V5
+                rel.protocol_level = client->protocol_level;
+            #endif
+                rc = MqttEncode_PublishResp(client->tx_buf,
+                    client->tx_buf_len, MQTT_PACKET_TYPE_PUBLISH_REL, &rel);
+            }
+            else {
+                MqttPublish pub;
+
+                XMEMSET(&pub, 0, sizeof(pub));
+                pub.packet_id = slot->packet_id;
+                pub.qos = (MqttQoS)slot->qos;
+                pub.retain = slot->retain;
+                pub.duplicate = 1; /* [MQTT-3.3.1-1] */
+                pub.topic_name = slot->topic;
+                pub.buffer = slot->payload;
+                pub.buffer_len = slot->payload_len;
+                pub.total_len = slot->payload_len;
+            #ifdef WOLFMQTT_V5
+                pub.protocol_level = client->protocol_level;
+            #endif
+                rc = MqttEncode_Publish(client->tx_buf, client->tx_buf_len,
+                    &pub, 0);
+            }
+            if (rc <= 0) {
+                /* Cannot rebuild this one (e.g. it no longer fits tx_buf).
+                 * Drop it rather than stalling the rest of the replay. */
+                CLIENT_FORCE_ZERO(client->tx_buf, client->tx_buf_len);
+                MqttWriteStop(client, &mc_connect->stat);
+                MqttClient_Replay_FreeSlot(slot);
+                client->replayIdx++;
+                continue;
+            }
+            client->write.len = rc;
+        }
+
+        xfer = client->write.len;
+        rc = MqttPacket_Write(client, client->tx_buf, xfer);
+    #ifdef WOLFMQTT_NONBLOCK
+        if (rc == MQTT_CODE_CONTINUE) {
+            return rc; /* keep send locked and resume here */
+        }
+    #endif
+        MqttWriteStop(client, &mc_connect->stat);
+        if (rc != xfer) {
+            return rc; /* transport failed; the entry stays retained */
+        }
+        client->replayIdx++;
+    }
+
+    return MQTT_CODE_SUCCESS;
+}
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
+
 /* [MQTT-3.1.0-1] After a Network Connection is established by a Client to a
  * Server, the first Packet sent from the Client to the Server MUST be a
  * CONNECT Packet. MQTT_CLIENT_FLAG_IS_CONNECTED tracks only the transport, so
@@ -2555,6 +2823,18 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
     if (client == NULL || mc_connect == NULL) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
     }
+
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    if (mc_connect->stat.write == MQTT_MSG_PAYLOAD) {
+        /* Resuming the [MQTT-4.4.0-1] replay this call started earlier; the
+         * handshake below is already done. */
+        rc = MqttClient_ReplaySession(client, mc_connect);
+        if (rc == MQTT_CODE_SUCCESS) {
+            mc_connect->stat.write = MQTT_MSG_BEGIN;
+        }
+        return rc;
+    }
+#endif
 
     if (mc_connect->stat.write == MQTT_MSG_BEGIN) {
         /* [MQTT-3.1.0-2] A Client can only send the CONNECT Packet once over a
@@ -2941,6 +3221,38 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
                 sizeof(client->recv_qos2_pending));
         }
         client->session_client_id_hash = id_hash;
+    }
+#endif
+
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    if (rc == MQTT_CODE_SUCCESS) {
+        if (!(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
+            /* A fresh Session starts with no outbound state to re-send. */
+            MqttClient_Replay_Reset(client);
+        }
+        else {
+            int i;
+
+            /* The server resumed the Session, so these messages are still in
+             * flight as far as it is concerned: keep their Packet Identifiers
+             * reserved (MqttClient_Connect cleared the table above) and
+             * re-send them [MQTT-4.4.0-1]. */
+            for (i = 0; i < MQTT_MAX_REPLAY_MSGS; i++) {
+                if (client->replay[i].packet_id != 0) {
+                    (void)MqttClient_SendIdReserve(client,
+                        client->replay[i].packet_id, &client->replay[i], 1);
+                }
+            }
+            client->replayIdx = 0;
+            mc_connect->stat.write = MQTT_MSG_PAYLOAD;
+            rc = MqttClient_ReplaySession(client, mc_connect);
+            if (rc == MQTT_CODE_SUCCESS) {
+                mc_connect->stat.write = MQTT_MSG_BEGIN;
+            }
+            else {
+                return rc;
+            }
+        }
     }
 #endif
 
@@ -3501,6 +3813,22 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
             if (publish->qos == MQTT_QOS_0) {
                 break;
             }
+
+        #ifndef WOLFMQTT_NO_SESSION_REPLAY
+            /* The PUBLISH is on the wire and unacknowledged, so it is now
+             * Session state the client must be able to re-send after a
+             * CleanSession 0 reconnect [MQTT-4.4.0-1]. */
+        #ifdef WOLFMQTT_MULTITHREAD
+            if (wm_SemLock(&client->lockClient) == 0)
+        #endif
+            {
+                MqttClient_Replay_Add(client, publish);
+        #ifdef WOLFMQTT_MULTITHREAD
+                wm_SemUnlock(&client->lockClient);
+        #endif
+            }
+        #endif
+
             publish->stat.write = MQTT_MSG_WAIT;
         }
         FALL_THROUGH;

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -501,6 +501,26 @@ static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
 #endif /* WOLFMQTT_V5 */
 
 #if WOLFMQTT_MAX_QOS >= 2
+/* Fingerprint the ClientId so the inbound QoS 2 table can tell whether a
+ * resumed Session belongs to the same one. A collision leaves stale entries in
+ * place, which is exactly the behaviour before this check existed, so the
+ * cheap hash only ever improves on it. Never returns 0; that value marks
+ * "no Session recorded". */
+static word32 MqttClient_ClientIdHash(const char* client_id)
+{
+    word32 hash = 2166136261U; /* FNV-1a 32-bit offset basis */
+    const byte* p;
+
+    if (client_id == NULL) {
+        return 1;
+    }
+    for (p = (const byte*)client_id; *p != '\0'; p++) {
+        hash ^= (word32)*p;
+        hash *= 16777619U; /* FNV-1a 32-bit prime */
+    }
+    return (hash == 0) ? 1 : hash;
+}
+
 /* Inbound QoS 2 de-duplication. A subscribing client that has delivered a
  * QoS 2 PUBLISH to the application and answered with PUBREC records its packet
  * id until the matching PUBREL arrives, so a retransmitted PUBLISH is
@@ -2873,10 +2893,18 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
      * pending packet ids so they cannot suppress a new inbound QoS 2 PUBLISH
      * that reuses one [MQTT-4.3.3-10]. Packet ids also restart per connection,
      * so a fresh session must start with an empty table. */
-    if (rc == MQTT_CODE_SUCCESS &&
-            !(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
-        XMEMSET(client->recv_qos2_pending, 0,
-            sizeof(client->recv_qos2_pending));
+    if (rc == MQTT_CODE_SUCCESS) {
+        word32 id_hash = MqttClient_ClientIdHash(mc_connect->client_id);
+
+        /* [MQTT-3.1.3-2] the ClientId identifies the Session state, so a
+         * Session Present answer for a different ClientId is a different
+         * Session and must not inherit the previous one's pending ids. */
+        if (!(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT) ||
+                id_hash != client->session_client_id_hash) {
+            XMEMSET(client->recv_qos2_pending, 0,
+                sizeof(client->recv_qos2_pending));
+        }
+        client->session_client_id_hash = id_hash;
     }
 #endif
 

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -639,11 +639,24 @@ static void MqttClient_Replay_Add(MqttClient* client, MqttPublish* publish)
     slot->retain = publish->retain;
 
     /* A streamed publish delivers its payload through a callback, so there is
-     * nothing here to copy; the entry still tracks the QoS 2 PUBREL stage. */
-    if (publish->buffer == NULL || publish->total_len == 0 ||
-            publish->buffer_len < publish->total_len) {
+     * nothing here to copy; the entry still tracks the QoS 2 PUBREL stage.
+     * A zero-byte payload is not that case - section 3.3.3 allows one, and
+     * [MQTT-4.4.0-1] asks for it back like any other unacknowledged
+     * message - so only a short buffer disqualifies the copy. */
+    if (publish->total_len > 0 &&
+            (publish->buffer == NULL ||
+             publish->buffer_len < publish->total_len)) {
         return;
     }
+#ifdef WOLFMQTT_V5
+    /* The pool retains no properties, so a v5 PUBLISH that carries any could
+     * only be replayed with Response Topic, Correlation Data and the rest
+     * stripped - a different message from the one the server is waiting on.
+     * Leave it unretained rather than re-send it altered. */
+    if (publish->props != NULL) {
+        return;
+    }
+#endif
     topic_len = XSTRLEN(publish->topic_name);
 
 #ifdef WOLFMQTT_STATIC_MEMORY
@@ -653,7 +666,9 @@ static void MqttClient_Replay_Add(MqttClient* client, MqttPublish* publish)
     }
     XMEMCPY(slot->topic, publish->topic_name, topic_len);
     slot->topic[topic_len] = '\0';
-    XMEMCPY(slot->payload, publish->buffer, publish->total_len);
+    if (publish->total_len > 0) {
+        XMEMCPY(slot->payload, publish->buffer, publish->total_len);
+    }
 #else
     slot->topic = (char*)WOLFMQTT_MALLOC(topic_len + 1);
     if (slot->topic == NULL) {
@@ -662,13 +677,15 @@ static void MqttClient_Replay_Add(MqttClient* client, MqttPublish* publish)
     XMEMCPY(slot->topic, publish->topic_name, topic_len);
     slot->topic[topic_len] = '\0';
 
-    slot->payload = (byte*)WOLFMQTT_MALLOC(publish->total_len);
-    if (slot->payload == NULL) {
-        WOLFMQTT_FREE(slot->topic);
-        slot->topic = NULL;
-        return;
+    if (publish->total_len > 0) {
+        slot->payload = (byte*)WOLFMQTT_MALLOC(publish->total_len);
+        if (slot->payload == NULL) {
+            WOLFMQTT_FREE(slot->topic);
+            slot->topic = NULL;
+            return;
+        }
+        XMEMCPY(slot->payload, publish->buffer, publish->total_len);
     }
-    XMEMCPY(slot->payload, publish->buffer, publish->total_len);
 #endif
     slot->payload_len = publish->total_len;
     slot->haveCopy = 1;
@@ -736,6 +753,19 @@ static void MqttClient_Replay_AddSafe(MqttClient* client, MqttPublish* publish)
 #endif
 }
 
+static void MqttClient_Replay_RemoveSafe(MqttClient* client, word16 packet_id)
+{
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    MqttClient_Replay_Remove(client, packet_id);
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
 static void MqttClient_Replay_PubRelSentSafe(MqttClient* client,
     word16 packet_id)
 {
@@ -745,19 +775,6 @@ static void MqttClient_Replay_PubRelSentSafe(MqttClient* client,
     }
 #endif
     MqttClient_Replay_PubRelSent(client, packet_id);
-#ifdef WOLFMQTT_MULTITHREAD
-    wm_SemUnlock(&client->lockClient);
-#endif
-}
-
-static void MqttClient_Replay_RemoveSafe(MqttClient* client, word16 packet_id)
-{
-#ifdef WOLFMQTT_MULTITHREAD
-    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
-        return;
-    }
-#endif
-    MqttClient_Replay_Remove(client, packet_id);
 #ifdef WOLFMQTT_MULTITHREAD
     wm_SemUnlock(&client->lockClient);
 #endif
@@ -802,7 +819,7 @@ static int MqttClient_SendIds_Find(const MqttClient* client, word16 packet_id)
  * its original identifier), and MQTT_CODE_ERROR_PACKET_ID when it is still
  * awaiting its acknowledgement. */
 static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
-    void* owner, int isRetransmit)
+    void* owner, int isRetransmit, MqttPacketType ack_type)
 {
     int rc = MQTT_CODE_SUCCESS;
     int i;
@@ -829,6 +846,7 @@ static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
         }
         else {
             client->send_inflight[i].owner = owner;
+            client->send_inflight[i].ack_type = (byte)ack_type;
         }
     }
     else {
@@ -836,6 +854,7 @@ static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
         if (i >= 0) {
             client->send_inflight[i].packet_id = packet_id;
             client->send_inflight[i].owner = owner;
+            client->send_inflight[i].ack_type = (byte)ack_type;
         }
         /* Table full: this identifier goes untracked, so a later collision
          * with it is not caught. Refusing the send instead would break an
@@ -849,8 +868,18 @@ static int MqttClient_SendIdReserve(MqttClient* client, word16 packet_id,
     return rc;
 }
 
-/* Release packet_id once its acknowledgement has been processed. */
-static void MqttClient_SendIdRelease(MqttClient* client, word16 packet_id)
+/* Release packet_id once its acknowledgement has been processed. ack_type is
+ * the packet type that arrived; the reservation is only given back when it
+ * matches the terminal acknowledgement the exchange was waiting for, so a
+ * PUBACK naming a QoS 2 identifier cannot end that exchange early
+ * [MQTT-2.3.1-3]. Pass MQTT_PACKET_TYPE_RESERVED to release regardless.
+ *
+ * Also drops the Session replay record for the same identifier, under the same
+ * lock: releasing first and removing afterwards would let a publisher reuse
+ * the identifier in between, and this ack would then delete the new
+ * exchange's replay state. */
+static void MqttClient_SendIdRelease(MqttClient* client, word16 packet_id,
+    MqttPacketType ack_type)
 {
     int i;
 
@@ -864,9 +893,26 @@ static void MqttClient_SendIdRelease(MqttClient* client, word16 packet_id)
 #endif
     i = MqttClient_SendIds_Find(client, packet_id);
     if (i >= 0) {
-        client->send_inflight[i].packet_id = 0;
-        client->send_inflight[i].owner = NULL;
+        if (ack_type != MQTT_PACKET_TYPE_RESERVED &&
+                client->send_inflight[i].ack_type !=
+                    MQTT_PACKET_TYPE_RESERVED &&
+                client->send_inflight[i].ack_type != (byte)ack_type) {
+            /* Wrong acknowledgement for this exchange: leave it in flight. */
+            i = -1;
+        }
+        else {
+            client->send_inflight[i].packet_id = 0;
+            client->send_inflight[i].owner = NULL;
+            client->send_inflight[i].ack_type =
+                (byte)MQTT_PACKET_TYPE_RESERVED;
+        }
     }
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    if (i >= 0) {
+        /* Completely acknowledged, so it leaves Session state. */
+        MqttClient_Replay_Remove(client, packet_id);
+    }
+#endif
 #ifdef WOLFMQTT_MULTITHREAD
     wm_SemUnlock(&client->lockClient);
 #endif
@@ -892,6 +938,8 @@ static void MqttClient_SendIdReleaseOwner(MqttClient* client, const void* owner)
                 client->send_inflight[i].owner == owner) {
             client->send_inflight[i].packet_id = 0;
             client->send_inflight[i].owner = NULL;
+            client->send_inflight[i].ack_type =
+                (byte)MQTT_PACKET_TYPE_RESERVED;
         }
     }
 #ifdef WOLFMQTT_MULTITHREAD
@@ -1328,11 +1376,7 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
                  * whose identifier is tracked separately. */
                 if (packet_type == MQTT_PACKET_TYPE_PUBLISH_ACK ||
                     packet_type == MQTT_PACKET_TYPE_PUBLISH_COMP) {
-                    MqttClient_SendIdRelease(client, packet_id);
-                #ifndef WOLFMQTT_NO_SESSION_REPLAY
-                    /* Completely acknowledged, so it leaves Session state. */
-                    MqttClient_Replay_RemoveSafe(client, packet_id);
-                #endif
+                    MqttClient_SendIdRelease(client, packet_id, packet_type);
                 }
             #ifdef WOLFMQTT_V5
                 if (doProps) {
@@ -1363,7 +1407,8 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
             if (rc >= 0) {
                 packet_id = p_subscribe_ack->packet_id;
                 /* [MQTT-2.3.1-3] SUBACK releases the SUBSCRIBE identifier. */
-                MqttClient_SendIdRelease(client, packet_id);
+                MqttClient_SendIdRelease(client, packet_id,
+                    MQTT_PACKET_TYPE_SUBSCRIBE_ACK);
             #ifdef WOLFMQTT_V5
                 if (doProps) {
                     int tmp = Handle_Props(client, p_subscribe_ack->props,
@@ -1395,7 +1440,8 @@ static int MqttClient_DecodePacket(MqttClient* client, byte* rx_buf,
                 packet_id = p_unsubscribe_ack->packet_id;
                 /* [MQTT-2.3.1-3] UNSUBACK releases the UNSUBSCRIBE
                  * identifier. */
-                MqttClient_SendIdRelease(client, packet_id);
+                MqttClient_SendIdRelease(client, packet_id,
+                    MQTT_PACKET_TYPE_UNSUBSCRIBE_ACK);
             #ifdef WOLFMQTT_V5
                 if (doProps) {
                     int tmp = Handle_Props(client, p_unsubscribe_ack->props,
@@ -1691,10 +1737,8 @@ static int MqttClient_HandlePacket(MqttClient* client,
                  * The message also leaves Session state - the server declined
                  * it, so [MQTT-4.4.0-1] does not ask for it back after a
                  * reconnect. */
-                MqttClient_SendIdRelease(client, packet_id);
-            #ifndef WOLFMQTT_NO_SESSION_REPLAY
-                MqttClient_Replay_RemoveSafe(client, packet_id);
-            #endif
+                MqttClient_SendIdRelease(client, packet_id,
+                    MQTT_PACKET_TYPE_RESERVED);
                 return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PUBLISH_REJECTED);
             }
         #endif
@@ -2845,7 +2889,8 @@ static int MqttClient_ReplaySession(MqttClient* client,
                 }
                 /* Outside the client lock, which SendIdRelease takes. */
                 if (dropped_id != 0) {
-                    MqttClient_SendIdRelease(client, dropped_id);
+                    MqttClient_SendIdRelease(client, dropped_id,
+                        MQTT_PACKET_TYPE_RESERVED);
                 }
                 client->replayIdx++; /* nothing to send from this slot */
                 continue;
@@ -2883,23 +2928,30 @@ static int MqttClient_ReplaySession(MqttClient* client,
  * being reported as "no flags set", and so the NULL branch inside that helper
  * does not leave GCC a path where client is NULL after the caller checked it
  * (which produced a false -Warray-bounds under partial inlining). */
-static int MqttClient_CheckConnectSent(MqttClient *client)
+static int MqttClient_ReadFlags(MqttClient *client, word32 *flags)
 {
-    word32 flags;
 #ifdef WOLFMQTT_MULTITHREAD
-    int rc;
-#endif
-
-#ifdef WOLFMQTT_MULTITHREAD
-    rc = wm_SemLock(&client->lockClient);
+    int rc = wm_SemLock(&client->lockClient);
     if (rc != 0) {
         return rc;
     }
 #endif
-    flags = client->flags;
+    *flags = client->flags;
 #ifdef WOLFMQTT_MULTITHREAD
     wm_SemUnlock(&client->lockClient);
 #endif
+    return MQTT_CODE_SUCCESS;
+}
+
+static int MqttClient_CheckConnectSent(MqttClient *client)
+{
+    word32 flags = 0;
+    int rc;
+
+    rc = MqttClient_ReadFlags(client, &flags);
+    if (rc != MQTT_CODE_SUCCESS) {
+        return rc;
+    }
 
     if ((flags & MQTT_CLIENT_FLAG_CONNECT_SENT) == 0) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
@@ -2939,6 +2991,8 @@ static void MqttClient_ConnectKeepAlive(MqttClient* client,
 int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
+    word32 connect_flags = 0;
+    int session_id_matched = 0;
 #if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
     MqttProp recv_max_prop;
     MqttProp* app_props = NULL;
@@ -2986,8 +3040,15 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
          * only a new handshake attempt on the same transport is refused. The
          * application must close the Network Connection with
          * MqttClient_NetDisconnect before connecting again. */
-        if ((MqttClient_Flags(client, 0, 0) &
-                MQTT_CLIENT_FLAG_CONNECT_SENT) != 0) {
+        /* Read the flag under lockClient rather than through
+         * MqttClient_Flags, which reports "no flags set" when the lock cannot
+         * be taken - that would let a second CONNECT through the guard
+         * instead of failing closed. */
+        rc = MqttClient_ReadFlags(client, &connect_flags);
+        if (rc != MQTT_CODE_SUCCESS) {
+            return rc;
+        }
+        if ((connect_flags & MQTT_CLIENT_FLAG_CONNECT_SENT) != 0) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
         }
 
@@ -3353,6 +3414,17 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
     }
 
+    /* [MQTT-3.1.3-2] The ClientId identifies the Client and its Session, so
+     * session state carries over only when the ClientId is the same one that
+     * created it. Recorded here, before the per-table decisions below, because
+     * the stored hash is updated as part of them. */
+    if (rc == MQTT_CODE_SUCCESS) {
+        word32 id_hash = MqttClient_ClientIdHash(mc_connect->client_id);
+
+        session_id_matched = (id_hash == client->session_client_id_hash);
+        client->session_client_id_hash = id_hash;
+    }
+
 #if WOLFMQTT_MAX_QOS >= 2
     /* The server's Session Present flag, not the client's request, decides
      * whether inbound QoS 2 dedup state carries over. Keep it only when the
@@ -3362,23 +3434,22 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
      * that reuses one [MQTT-4.3.3-10]. Packet ids also restart per connection,
      * so a fresh session must start with an empty table. */
     if (rc == MQTT_CODE_SUCCESS) {
-        word32 id_hash = MqttClient_ClientIdHash(mc_connect->client_id);
-
-        /* [MQTT-3.1.3-2] the ClientId identifies the Session state, so a
-         * Session Present answer for a different ClientId is a different
-         * Session and must not inherit the previous one's pending ids. */
         if (!(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT) ||
-                id_hash != client->session_client_id_hash) {
+                !session_id_matched) {
             XMEMSET(client->recv_qos2_pending, 0,
                 sizeof(client->recv_qos2_pending));
         }
-        client->session_client_id_hash = id_hash;
     }
 #endif
 
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
     if (rc == MQTT_CODE_SUCCESS) {
-        if (!(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT)) {
+        /* [MQTT-3.1.3-2] The ClientId identifies the Session, so outbound
+         * state belongs to the ClientId that created it. A Session Present
+         * answer for a different ClientId is a different Session: replaying
+         * into it would inject one Session's messages into another. */
+        if (!(mc_connect->ack.flags & MQTT_CONNECT_ACK_FLAG_SESSION_PRESENT) ||
+                !session_id_matched) {
             /* A fresh Session starts with no outbound state to re-send. */
             MqttClient_Replay_Reset(client);
         }
@@ -3390,10 +3461,25 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
              * reserved (MqttClient_Connect cleared the table above) and
              * re-send them [MQTT-4.4.0-1]. */
             for (i = 0; i < MQTT_MAX_REPLAY_MSGS; i++) {
-                if (client->replay[i].packet_id != 0) {
-                    (void)MqttClient_SendIdReserve(client,
-                        client->replay[i].packet_id, &client->replay[i], 1);
+                if (client->replay[i].packet_id == 0) {
+                    continue;
                 }
+                if (!client->replay[i].pubrelSent &&
+                        !client->replay[i].haveCopy) {
+                    /* Nothing to re-send: the payload was never retained, so
+                     * [MQTT-4.4.0-1] cannot be honoured for this one. Drop it
+                     * instead of reserving an identifier that no
+                     * acknowledgement will ever release [MQTT-2.3.1-3]. */
+                    MqttClient_Replay_FreeSlot(&client->replay[i]);
+                    continue;
+                }
+                (void)MqttClient_SendIdReserve(client,
+                    client->replay[i].packet_id, &client->replay[i], 1,
+                    client->replay[i].pubrelSent ?
+                        MQTT_PACKET_TYPE_PUBLISH_COMP :
+                        ((client->replay[i].qos == MQTT_QOS_2) ?
+                            MQTT_PACKET_TYPE_PUBLISH_COMP :
+                            MQTT_PACKET_TYPE_PUBLISH_ACK));
             }
             client->replayIdx = 0;
             mc_connect->stat.write = MQTT_MSG_PAYLOAD;
@@ -3826,7 +3912,10 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                  * required to keep its original identifier [MQTT-2.3.1-3] and
                  * carries DUP=1 [MQTT-3.3.1-1], so it is allowed through. */
                 rc = MqttClient_SendIdReserve(client, publish->packet_id,
-                        publish, publish->duplicate);
+                        publish, publish->duplicate,
+                        (publish->qos == MQTT_QOS_2) ?
+                            MQTT_PACKET_TYPE_PUBLISH_COMP :
+                            MQTT_PACKET_TYPE_PUBLISH_ACK);
                 if (rc != MQTT_CODE_SUCCESS) {
                     MqttWriteStop(client, &publish->stat);
                 #ifdef WOLFMQTT_V5
@@ -3865,6 +3954,17 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                 #endif
                     return rc; /* Error locking client */
                 }
+            }
+        #endif
+
+        #ifndef WOLFMQTT_NO_SESSION_REPLAY
+            /* Record the Session state before the packet reaches the wire.
+             * Once it is out, a reader thread can process the acknowledgement
+             * at any moment; adding the entry afterwards would let that
+             * removal run first and leave an acknowledged message retained,
+             * to be replayed after the next reconnect [MQTT-4.4.0-1]. */
+            if (publish->qos > MQTT_QOS_0) {
+                MqttClient_Replay_AddSafe(client, publish);
             }
         #endif
 
@@ -3909,10 +4009,21 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                     /* Part of the PUBLISH reached the server, so it may have
                      * seen the Packet Identifier. Reclaim the reservation the
                      * cancel just dropped so a new message cannot take it
-                     * [MQTT-2.3.1-3]. */
+                     * [MQTT-2.3.1-3]. The replay entry recorded above stays:
+                     * the message is in flight as far as the server may be
+                     * concerned. */
                     (void)MqttClient_SendIdReserve(client, publish->packet_id,
-                            publish, 1);
+                            publish, 1, (publish->qos == MQTT_QOS_2) ?
+                                MQTT_PACKET_TYPE_PUBLISH_COMP :
+                                MQTT_PACKET_TYPE_PUBLISH_ACK);
                 }
+            #ifndef WOLFMQTT_NO_SESSION_REPLAY
+                else {
+                    /* Nothing reached the wire, so this never became Session
+                     * state. Drop the entry recorded before the write. */
+                    MqttClient_Replay_RemoveSafe(client, publish->packet_id);
+                }
+            #endif
                 return rc;
             }
 
@@ -3945,7 +4056,9 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
                  * the Packet Identifier - is already on the wire, so keep the
                  * reservation the cancel dropped [MQTT-2.3.1-3]. */
                 (void)MqttClient_SendIdReserve(client, publish->packet_id,
-                        publish, 1);
+                        publish, 1, (publish->qos == MQTT_QOS_2) ?
+                            MQTT_PACKET_TYPE_PUBLISH_COMP :
+                            MQTT_PACKET_TYPE_PUBLISH_ACK);
                 break;
             }
 
@@ -3953,13 +4066,6 @@ static int MqttPublishMsg(MqttClient *client, MqttPublish *publish,
             if (publish->qos == MQTT_QOS_0) {
                 break;
             }
-
-        #ifndef WOLFMQTT_NO_SESSION_REPLAY
-            /* The PUBLISH is on the wire and unacknowledged, so it is now
-             * Session state the client must be able to re-send after a
-             * CleanSession 0 reconnect [MQTT-4.4.0-1]. */
-            MqttClient_Replay_AddSafe(client, publish);
-        #endif
 
             publish->stat.write = MQTT_MSG_WAIT;
         }
@@ -4150,7 +4256,7 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
          * has no DUP bit, so a repeat while one is unacknowledged cannot be
          * told apart from a new subscription and is refused. */
         rc = MqttClient_SendIdReserve(client, subscribe->packet_id,
-                subscribe, 0);
+                subscribe, 0, MQTT_PACKET_TYPE_SUBSCRIBE_ACK);
         if (rc != MQTT_CODE_SUCCESS) {
             MqttWriteStop(client, &subscribe->stat);
             return rc;
@@ -4200,7 +4306,7 @@ int MqttClient_Subscribe(MqttClient *client, MqttSubscribe *subscribe)
                  * seen the Packet Identifier. Reclaim the reservation the
                  * cancel just dropped [MQTT-2.3.1-3]. */
                 (void)MqttClient_SendIdReserve(client, subscribe->packet_id,
-                        subscribe, 1);
+                        subscribe, 1, MQTT_PACKET_TYPE_SUBSCRIBE_ACK);
             }
             return rc;
         }
@@ -4304,7 +4410,7 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
          * UNSUBSCRIBE has no DUP bit, so a repeat while one is unacknowledged
          * cannot be told apart from a new request and is refused. */
         rc = MqttClient_SendIdReserve(client, unsubscribe->packet_id,
-                unsubscribe, 0);
+                unsubscribe, 0, MQTT_PACKET_TYPE_UNSUBSCRIBE_ACK);
         if (rc != MQTT_CODE_SUCCESS) {
             MqttWriteStop(client, &unsubscribe->stat);
             return rc;
@@ -4355,7 +4461,7 @@ int MqttClient_Unsubscribe(MqttClient *client, MqttUnsubscribe *unsubscribe)
                  * seen the Packet Identifier. Reclaim the reservation the
                  * cancel just dropped [MQTT-2.3.1-3]. */
                 (void)MqttClient_SendIdReserve(client, unsubscribe->packet_id,
-                        unsubscribe, 1);
+                        unsubscribe, 1, MQTT_PACKET_TYPE_UNSUBSCRIBE_ACK);
             }
             return rc;
         }
@@ -4655,6 +4761,11 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *p_disconnect)
     MqttWriteStop(client, &disconnect->stat);
     if (rc == xfer) {
         rc = MQTT_CODE_SUCCESS;
+        /* [MQTT-3.14.4-1] "After sending a DISCONNECT Packet the Client MUST
+         * NOT send any more Control Packets on that Network Connection."
+         * Clearing the handshake flag makes the send APIs refuse them, the
+         * same way they do before CONNECT [MQTT-3.1.0-1]. */
+        (void)MqttClient_Flags(client, MQTT_CLIENT_FLAG_CONNECT_SENT, 0);
     }
 
 #if defined(WOLFMQTT_DISCONNECT_CB) && defined(WOLFMQTT_USE_CB_ON_DISCONNECT)

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -500,27 +500,48 @@ static void MqttClient_RecvQuotaRelease(MqttClient* client, MqttMsgStat* stat)
 }
 #endif /* WOLFMQTT_V5 */
 
-#ifdef WOLFMQTT_SESSION_ID_HASH
-/* Fingerprint the ClientId so the Session state can tell whether a resumed
- * Session belongs to the same one. A collision leaves stale entries in
- * place, which is exactly the behaviour before this check existed, so the
- * cheap hash only ever improves on it. Never returns 0; that value marks
- * "no Session recorded". */
-static word32 MqttClient_ClientIdHash(const char* client_id)
+#ifdef WOLFMQTT_SESSION_ID_TRACK
+/* Does client_id name the Session whose state this client is holding? An
+ * exact comparison: the ClientId identifies the Session [MQTT-3.1.3-2], and a
+ * digest of it would let two different ClientIds that happen to share one
+ * inherit each other's replay entries and QoS 2 pending ids. Returns 0 when no
+ * Session is recorded, so a first connect never matches. */
+static int MqttClient_SessionIdMatches(const MqttClient* client,
+    const char* client_id)
 {
-    word32 hash = 2166136261U; /* FNV-1a 32-bit offset basis */
-    const byte* p;
+    size_t len;
 
-    if (client_id == NULL) {
-        return 1;
+    if (client->session_client_id_len == 0 || client_id == NULL) {
+        return 0;
     }
-    for (p = (const byte*)client_id; *p != '\0'; p++) {
-        hash ^= (word32)*p;
-        hash *= 16777619U; /* FNV-1a 32-bit prime */
+    len = XSTRLEN(client_id);
+    if (len != (size_t)client->session_client_id_len) {
+        return 0;
     }
-    return (hash == 0) ? 1 : hash;
+    return (XMEMCMP(client->session_client_id, client_id, len) == 0) ? 1 : 0;
 }
-#endif /* WOLFMQTT_SESSION_ID_HASH */
+
+/* Record client_id as the Session this client now holds state for. A ClientId
+ * too long for the buffer is not recorded, so the next Session Present is
+ * treated as a different Session and the state is dropped rather than
+ * inherited on a partial match. */
+static void MqttClient_SessionIdRecord(MqttClient* client,
+    const char* client_id)
+{
+    size_t len;
+
+    client->session_client_id_len = 0;
+    if (client_id == NULL) {
+        return;
+    }
+    len = XSTRLEN(client_id);
+    if (len == 0 || len > (size_t)MQTT_MAX_SESSION_CLIENT_ID) {
+        return;
+    }
+    XMEMCPY(client->session_client_id, client_id, len);
+    client->session_client_id_len = (word16)len;
+}
+#endif /* WOLFMQTT_SESSION_ID_TRACK */
 
 #if WOLFMQTT_MAX_QOS >= 2
 /* Inbound QoS 2 de-duplication. A subscribing client that has delivered a
@@ -601,13 +622,19 @@ static MqttReplayMsg* MqttClient_Replay_Find(MqttClient* client,
     return NULL;
 }
 
+/* The retained copies hold application data - a payload may carry credentials
+ * or key material - so they are wiped before going back to the allocator, the
+ * same way the client scrubs tx_buf and rx_buf. The static-memory build has no
+ * separate buffers; the XMEMSET below covers its in-struct copies. */
 static void MqttClient_Replay_FreeSlot(MqttReplayMsg* slot)
 {
 #ifndef WOLFMQTT_STATIC_MEMORY
     if (slot->topic != NULL) {
+        CLIENT_FORCE_ZERO(slot->topic, XSTRLEN(slot->topic) + 1);
         WOLFMQTT_FREE(slot->topic);
     }
     if (slot->payload != NULL) {
+        CLIENT_FORCE_ZERO(slot->payload, slot->payload_len);
         WOLFMQTT_FREE(slot->payload);
     }
 #endif
@@ -682,6 +709,7 @@ static void MqttClient_Replay_Add(MqttClient* client, MqttPublish* publish)
     if (publish->total_len > 0) {
         slot->payload = (byte*)WOLFMQTT_MALLOC(publish->total_len);
         if (slot->payload == NULL) {
+            CLIENT_FORCE_ZERO(slot->topic, topic_len + 1);
             WOLFMQTT_FREE(slot->topic);
             slot->topic = NULL;
             return;
@@ -942,6 +970,34 @@ static void MqttClient_SendIdReleaseOwner(MqttClient* client, const void* owner)
             client->send_inflight[i].owner = NULL;
             client->send_inflight[i].ack_type =
                 (byte)MQTT_PACKET_TYPE_RESERVED;
+        }
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    wm_SemUnlock(&client->lockClient);
+#endif
+}
+
+/* Detach owner from its reservation without releasing the Packet Identifier.
+ * Used when a message object is being reset for reuse but its packet is
+ * already on the wire: the identifier stays claimed until the peer's
+ * acknowledgement [MQTT-2.3.1-3], while the object must stop owning it so a
+ * later cancel through the reused object cannot give the old one back. */
+static void MqttClient_SendIdDisown(MqttClient* client, const void* owner)
+{
+    int i;
+
+    if (owner == NULL) {
+        return;
+    }
+#ifdef WOLFMQTT_MULTITHREAD
+    if (wm_SemLock(&client->lockClient) != MQTT_CODE_SUCCESS) {
+        return;
+    }
+#endif
+    for (i = 0; i < MQTT_MAX_SEND_INFLIGHT; i++) {
+        if (client->send_inflight[i].packet_id != 0 &&
+                client->send_inflight[i].owner == owner) {
+            client->send_inflight[i].owner = NULL;
         }
     }
 #ifdef WOLFMQTT_MULTITHREAD
@@ -2958,6 +3014,10 @@ static int MqttClient_CheckConnectSent(MqttClient *client)
     if ((flags & MQTT_CLIENT_FLAG_CONNECT_SENT) == 0) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
     }
+    /* [MQTT-3.14.4-1] Nothing may follow a DISCONNECT on this connection. */
+    if ((flags & MQTT_CLIENT_FLAG_DISCONNECT_SENT) != 0) {
+        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_STAT);
+    }
     return MQTT_CODE_SUCCESS;
 }
 
@@ -2994,7 +3054,7 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
 {
     int rc;
     word32 connect_flags = 0;
-#ifdef WOLFMQTT_SESSION_ID_HASH
+#ifdef WOLFMQTT_SESSION_ID_TRACK
     int session_id_matched = 0;
 #endif
 #if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
@@ -3418,16 +3478,15 @@ int MqttClient_Connect(MqttClient *client, MqttConnect *mc_connect)
         rc = MQTT_TRACE_ERROR(MQTT_CODE_ERROR_SERVER_PROP);
     }
 
-#ifdef WOLFMQTT_SESSION_ID_HASH
+#ifdef WOLFMQTT_SESSION_ID_TRACK
     /* [MQTT-3.1.3-2] The ClientId identifies the Client and its Session, so
      * session state carries over only when the ClientId is the same one that
-     * created it. Recorded here, before the per-table decisions below, because
-     * the stored hash is updated as part of them. */
+     * created it. Compared here, before the per-table decisions below, because
+     * the recorded ClientId is updated as part of them. */
     if (rc == MQTT_CODE_SUCCESS) {
-        word32 id_hash = MqttClient_ClientIdHash(mc_connect->client_id);
-
-        session_id_matched = (id_hash == client->session_client_id_hash);
-        client->session_client_id_hash = id_hash;
+        session_id_matched =
+            MqttClient_SessionIdMatches(client, mc_connect->client_id);
+        MqttClient_SessionIdRecord(client, mc_connect->client_id);
     }
 #endif
 
@@ -4769,9 +4828,11 @@ int MqttClient_Disconnect_ex(MqttClient *client, MqttDisconnect *p_disconnect)
         rc = MQTT_CODE_SUCCESS;
         /* [MQTT-3.14.4-1] "After sending a DISCONNECT Packet the Client MUST
          * NOT send any more Control Packets on that Network Connection."
-         * Clearing the handshake flag makes the send APIs refuse them, the
-         * same way they do before CONNECT [MQTT-3.1.0-1]. */
-        (void)MqttClient_Flags(client, MQTT_CLIENT_FLAG_CONNECT_SENT, 0);
+         * Recorded separately from MQTT_CLIENT_FLAG_CONNECT_SENT: this call
+         * does not close the transport, so clearing CONNECT_SENT would reopen
+         * the [MQTT-3.1.0-2] duplicate-CONNECT guard and allow a second
+         * CONNECT on the still-open Network Connection. */
+        (void)MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_DISCONNECT_SENT);
     }
 
 #if defined(WOLFMQTT_DISCONNECT_CB) && defined(WOLFMQTT_USE_CB_ON_DISCONNECT)
@@ -5117,6 +5178,7 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
 {
     int rc = MQTT_CODE_SUCCESS;
     MqttMsgStat* mms_stat;
+    int onWire;
 #ifdef WOLFMQTT_MULTITHREAD
     MqttPendResp* tmpResp;
 #endif
@@ -5132,17 +5194,29 @@ int MqttClient_CancelMessage(MqttClient *client, MqttObject* msg)
     PRINTF("Cancel Msg: %p", msg);
 #endif
 
+    /* Whether this message's packet finished going out. MQTT_MSG_WAIT is only
+     * reached once the whole Control Packet has been written. */
+    onWire = (mms_stat->write == MQTT_MSG_WAIT) ? 1 : 0;
+
     /* reset states */
     mms_stat->write = MQTT_MSG_BEGIN;
     mms_stat->read = MQTT_MSG_BEGIN;
 
-    /* Give back any outbound Packet Identifier this object reserved. Cancel is
-     * the application saying it is done with the exchange and is reusing the
-     * object, so the identifier must not stay claimed for the rest of the
-     * connection - unlike the Receive Maximum unit below, a reused identifier
-     * is the application's own call rather than a flow-control promise made to
-     * the server. */
-    MqttClient_SendIdReleaseOwner(client, msg);
+    /* A packet that never fully reached the transport carries no identifier
+     * the peer can act on, so cancelling it gives the identifier straight
+     * back. One that did is a different matter: the peer may still process it
+     * and answer, and that acknowledgement would complete whatever new
+     * exchange had taken the identifier over. [MQTT-2.3.1-3] makes it reusable
+     * only once the acknowledgement is processed, so the reservation outlives
+     * the cancel - the same reasoning as the Receive Maximum unit below - and
+     * only the object's ownership of it is dropped. The partial-write paths in
+     * MqttPublishMsg re-reserve explicitly after cancelling. */
+    if (onWire) {
+        MqttClient_SendIdDisown(client, msg);
+    }
+    else {
+        MqttClient_SendIdReleaseOwner(client, msg);
+    }
 
     /* Do not credit the reserved Receive Maximum unit here. Cancelling an
      * abandoned QoS>0 publish that already reached the wire must retain the

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -2087,6 +2087,22 @@ wait_again:
             #endif
             #endif
 
+                /* Stage the acknowledgement on this wait object as well.
+                 * client->packetAck above is shared by every reader, so a
+                 * thread finishing its own PUBLISH read can overwrite it in
+                 * the window between this read lock being dropped and the
+                 * send lock being taken below, sending the later ack twice
+                 * and never the earlier one. [MQTT-4.6.0-2] requires PUBACKs
+                 * to be sent in the order their PUBLISHes were received, so
+                 * the encode reads these per-object fields instead. */
+                mms_stat->ackPacketType = resp.packet_type;
+                mms_stat->ackPacketId = resp.packet_id;
+            #ifdef WOLFMQTT_V5
+                mms_stat->ackReasonCode = resp.reason_code;
+                mms_stat->ackProps = resp.props;
+                mms_stat->ackProtocolLevel = client->protocol_level;
+            #endif
+
                 /* if we get here, then we are sending an ACK */
                 mms_stat->read = MQTT_MSG_ACK;
                 mms_stat->ack = MQTT_MSG_WAIT;
@@ -2146,13 +2162,27 @@ wait_again:
 
         case MQTT_MSG_ACK:
         {
+            /* Rebuild the response from this wait object's staged fields, not
+             * from the shared client->packetAck another reader may have
+             * replaced since [MQTT-4.6.0-2]. */
+            MqttPublishResp ackResp;
+
+            XMEMSET(&ackResp, 0, sizeof(ackResp));
+            ackResp.packet_type = mms_stat->ackPacketType;
+            ackResp.packet_id = mms_stat->ackPacketId;
+        #ifdef WOLFMQTT_V5
+            ackResp.reason_code = mms_stat->ackReasonCode;
+            ackResp.props = mms_stat->ackProps;
+            ackResp.protocol_level = mms_stat->ackProtocolLevel;
+        #endif
+
             /* send ack */
             rc = MqttEncode_PublishResp(client->tx_buf, client->tx_buf_len,
-                client->packetAck.packet_type, &client->packetAck);
+                ackResp.packet_type, &ackResp);
         #ifdef WOLFMQTT_DEBUG_CLIENT
             PRINTF("MqttEncode_PublishResp: Len %d, Type %s (%d), ID %d",
-                rc, MqttPacket_TypeDesc(client->packetAck.packet_type),
-                    client->packetAck.packet_type, client->packetAck.packet_id);
+                rc, MqttPacket_TypeDesc(ackResp.packet_type),
+                    ackResp.packet_type, ackResp.packet_id);
         #endif
             if (rc < 0) {
                 MqttWriteStop(client, mms_stat);
@@ -2187,6 +2217,8 @@ wait_again:
                 rc = MQTT_CODE_SUCCESS; /* success */
             }
 
+            /* The staged acknowledgement is spent. */
+            mms_stat->ackPacketType = MQTT_PACKET_TYPE_RESERVED;
             mms_stat->ack = MQTT_MSG_BEGIN; /* reset write state */
             break;
         }

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -2057,9 +2057,27 @@ int MqttDecode_ConnectAck(byte *rx_buf, int rx_buf_len,
         return header_len;
     }
 
-    /* Validate remain_len */
-    if (remain_len < 2) {
-        return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+    /* Validate remain_len. MQTT 3.1.1 section 3.2.1 fixes the CONNACK
+     * Remaining Length at 2 - the Connect Acknowledge Flags and the Connect
+     * Return Code - and section 3.2.3 states the packet has no payload, so a
+     * larger value is a protocol violation the receiver must reject. MQTT 5.0
+     * section 3.2.2.1 appends a Properties block, so the longer form is only
+     * valid once the caller has identified the connection as v5. A NULL
+     * connect_ack takes the strict path: with no struct to carry properties,
+     * anything past the two fixed bytes cannot be consumed. */
+#ifdef WOLFMQTT_V5
+    if (connect_ack != NULL &&
+        connect_ack->protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
+        if (remain_len < 2) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
+    }
+    else
+#endif
+    {
+        if (remain_len != 2) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
+        }
     }
     if (rx_buf_len < header_len + remain_len) {
         return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_OUT_OF_BUFFER);
@@ -2785,6 +2803,16 @@ int MqttDecode_PublishResp(byte* rx_buf, int rx_buf_len, byte type,
             return tmp;
         }
         rx_payload += tmp;
+
+        /* A publish response echoes the Packet Identifier of the PUBLISH it
+         * acknowledges, and [MQTT-2.3.1-1] requires that identifier to be
+         * non-zero. Zero can never name an in-flight exchange, so treat it as
+         * the protocol violation it is and let the caller close the Network
+         * Connection per [MQTT-4.8.0-1], rather than silently discarding the
+         * packet as spurious. */
+        if (publish_resp->packet_id == 0) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_PACKET_ID);
+        }
 
 #ifdef WOLFMQTT_V5
         publish_resp->props = NULL;

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1494,6 +1494,17 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_MALFORMED_DATA);
         }
     #endif
+        /* [MQTT-3.1.3-7] A Client that supplies a zero-byte ClientId MUST
+         * also set CleanSession to 1. There is no ClientId for a Server to
+         * key a persistent session on, so [MQTT-3.1.3-8] requires a
+         * conforming Server to answer the pairing with Identifier Rejected.
+         * Refuse to put the packet on the wire instead. MQTT 5.0 section
+         * 3.1.3.1 drops the coupling - a zero-length ClientId asks the
+         * Server to assign one - so the combination stays legal there. */
+        if (str_len == 0 && mc_connect->clean_session == 0 &&
+                mc_connect->protocol_level == MQTT_CONNECT_PROTOCOL_LEVEL_4) {
+            return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
+        }
         remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
     }
     if (mc_connect->enable_lwt) {

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1428,6 +1428,7 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
 #endif
     MqttConnectPacket packet = MQTT_CONNECT_INIT;
     byte *tx_payload;
+    word16 password_len = 0;
 
     /* Validate required arguments */
     if (tx_buf == NULL || mc_connect == NULL || mc_connect->client_id == NULL) {
@@ -1593,13 +1594,16 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
     if (mc_connect->password) {
         /* [MQTT-3.1.3.5] Password is Binary Data. An explicit password_len
          * carries bytes that XSTRLEN would truncate at an embedded 0x00; 0
-         * keeps the original NUL-terminated behaviour. */
+         * keeps the original NUL-terminated behaviour. Computed once here and
+         * reused by the payload pass below, which must agree with what
+         * remain_len reserved. */
         size_t str_len = (mc_connect->password_len > 0) ?
             (size_t)mc_connect->password_len :
             XSTRLEN(mc_connect->password);
         if (str_len > (size_t)0xFFFF) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
         }
+        password_len = (word16)str_len;
         remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
     }
 
@@ -1700,9 +1704,7 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
          * and matches the decode path, which reads it as raw bytes. The length
          * bound was already enforced above. */
         tx_payload += MqttEncode_Data(tx_payload,
-            (const byte*)mc_connect->password,
-            (mc_connect->password_len > 0) ? mc_connect->password_len :
-                (word16)XSTRLEN(mc_connect->password));
+            (const byte*)mc_connect->password, password_len);
     }
     (void)tx_payload;
 
@@ -1774,6 +1776,7 @@ int MqttDecode_Connect(byte *rx_buf, int rx_buf_len, MqttConnect *mc_connect)
         (packet.flags & MQTT_CONNECT_FLAG_WILL_FLAG) ? 1 : 0;
     mc_connect->username = NULL;
     mc_connect->password = NULL;
+    mc_connect->password_len = 0;
 #ifdef WOLFMQTT_V5
     mc_connect->props = NULL;
     if (mc_connect->enable_lwt && mc_connect->lwt_msg != NULL) {
@@ -2016,6 +2019,11 @@ int MqttDecode_Connect(byte *rx_buf, int rx_buf_len, MqttConnect *mc_connect)
             goto cleanup;
         }
         mc_connect->password = (char*)(rx_payload + tmp);
+        /* [MQTT-3.1.3.5] The Password is Binary Data and the decoded pointer
+         * is into rx_buf, which is not NUL terminated. Report the wire length
+         * so a caller re-encoding this CONNECT does not fall back to XSTRLEN
+         * and truncate at an embedded 0x00 or read past the buffer. */
+        mc_connect->password_len = plen;
         rx_payload += tmp + plen;
     }
 

--- a/src/mqtt_packet.c
+++ b/src/mqtt_packet.c
@@ -1591,7 +1591,12 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
         remain_len += (int)str_len + MQTT_DATA_LEN_SIZE;
     }
     if (mc_connect->password) {
-        size_t str_len = XSTRLEN(mc_connect->password);
+        /* [MQTT-3.1.3.5] Password is Binary Data. An explicit password_len
+         * carries bytes that XSTRLEN would truncate at an embedded 0x00; 0
+         * keeps the original NUL-terminated behaviour. */
+        size_t str_len = (mc_connect->password_len > 0) ?
+            (size_t)mc_connect->password_len :
+            XSTRLEN(mc_connect->password);
         if (str_len > (size_t)0xFFFF) {
             return MQTT_TRACE_ERROR(MQTT_CODE_ERROR_BAD_ARG);
         }
@@ -1696,7 +1701,8 @@ int MqttEncode_Connect(byte *tx_buf, int tx_buf_len, MqttConnect *mc_connect)
          * bound was already enforced above. */
         tx_payload += MqttEncode_Data(tx_payload,
             (const byte*)mc_connect->password,
-            (word16)XSTRLEN(mc_connect->password));
+            (mc_connect->password_len > 0) ? mc_connect->password_len :
+                (word16)XSTRLEN(mc_connect->password));
     }
     (void)tx_payload;
 

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -408,7 +408,13 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
         if (rc != MQTT_CODE_SUCCESS) {
             return rc;
         }
-        MqttClient_Flags(client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+        /* A fresh Network Connection has sent no CONNECT yet, so the
+         * [MQTT-3.1.0-2] once-per-connection guard starts over here. Clearing
+         * on connect as well as on disconnect keeps the handshake state
+         * correct for an application that reconnects without routing through
+         * MqttClient_NetDisconnect. */
+        MqttClient_Flags(client, MQTT_CLIENT_FLAG_CONNECT_SENT,
+            MQTT_CLIENT_FLAG_IS_CONNECTED);
     }
 
 #if defined(ENABLE_MQTT_TLS) && !defined(ENABLE_MQTT_CURL)
@@ -581,7 +587,10 @@ int MqttSocket_Disconnect(MqttClient *client)
         if (client->net && client->net->disconnect) {
             rc = client->net->disconnect(client->net->context);
         }
-        MqttClient_Flags(client, MQTT_CLIENT_FLAG_IS_CONNECTED, 0);
+        /* The MQTT handshake belongs to the Network Connection being closed;
+         * the next one must start with its own CONNECT [MQTT-3.1.0-1]. */
+        MqttClient_Flags(client,
+            (MQTT_CLIENT_FLAG_IS_CONNECTED | MQTT_CLIENT_FLAG_CONNECT_SENT), 0);
 
     #ifdef ENABLE_MQTT_CURL
         if (client->curl_initialized) {

--- a/src/mqtt_socket.c
+++ b/src/mqtt_socket.c
@@ -413,7 +413,9 @@ int MqttSocket_Connect(MqttClient *client, const char* host, word16 port,
          * on connect as well as on disconnect keeps the handshake state
          * correct for an application that reconnects without routing through
          * MqttClient_NetDisconnect. */
-        MqttClient_Flags(client, MQTT_CLIENT_FLAG_CONNECT_SENT,
+        MqttClient_Flags(client,
+            (MQTT_CLIENT_FLAG_CONNECT_SENT |
+             MQTT_CLIENT_FLAG_DISCONNECT_SENT),
             MQTT_CLIENT_FLAG_IS_CONNECTED);
     }
 
@@ -590,7 +592,8 @@ int MqttSocket_Disconnect(MqttClient *client)
         /* The MQTT handshake belongs to the Network Connection being closed;
          * the next one must start with its own CONNECT [MQTT-3.1.0-1]. */
         MqttClient_Flags(client,
-            (MQTT_CLIENT_FLAG_IS_CONNECTED | MQTT_CLIENT_FLAG_CONNECT_SENT), 0);
+            (MQTT_CLIENT_FLAG_IS_CONNECTED | MQTT_CLIENT_FLAG_CONNECT_SENT |
+             MQTT_CLIENT_FLAG_DISCONNECT_SENT), 0);
 
     #ifdef ENABLE_MQTT_CURL
         if (client->curl_initialized) {

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -157,6 +157,12 @@ typedef struct MockClient {
     int    write_err; /* when set, mock_write returns a network error */
     int    write_continue; /* when set, mock_write reports would-block */
     int    write_limit_once; /* positive: short-write the next callback */
+    /* positive: short-write the next callback to this many bytes and arm
+     * write_err_pending, so the callback after it fails. Models a blocking
+     * transport that gets part of a packet out before the socket errors -
+     * a sequence the one-shot knobs above cannot express on their own. */
+    int    write_limit_then_err;
+    int    write_err_pending; /* next mock_write call returns a network error */
 } MockClient;
 
 static MockClient g_clients[MOCK_MAX_CLIENTS];
@@ -257,8 +263,19 @@ static int mock_write(void* ctx, BROKER_SOCKET_T sock,
         return MQTT_CODE_ERROR_NETWORK;
     }
     mc = &g_clients[idx];
+    if (mc->write_err_pending) {
+        mc->write_err_pending = 0;
+        return MQTT_CODE_ERROR_NETWORK;
+    }
     if (mc->write_continue) {
         return MQTT_CODE_CONTINUE;
+    }
+    if (mc->write_limit_then_err > 0) {
+        if (write_len > mc->write_limit_then_err) {
+            write_len = mc->write_limit_then_err;
+        }
+        mc->write_limit_then_err = 0;
+        mc->write_err_pending = 1;
     }
     if (mc->write_limit_once > 0) {
         if (write_len > mc->write_limit_once) {
@@ -2983,6 +3000,149 @@ TEST(self_publish_waits_for_partial_puback)
     MqttBroker_Free(&broker);
 }
 
+/* MQTT 3.1.1 section 3.1.4: when a CONNECT check fails the Server "SHOULD send
+ * an appropriate CONNACK response with a non-zero return code ... and it MUST
+ * close the Network Connection". Closing the moment the write returns leaves a
+ * short write truncated, so the client sees only part of the CONNACK and never
+ * learns why it was refused. The refusal must be delivered in full first.
+ *
+ * Refusal used: [MQTT-3.1.3-8], zero-length ClientId with CleanSession=0,
+ * answered with return code 0x02 (Identifier rejected). */
+TEST(refused_connack_short_write_delivers_return_code_before_close)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    byte connect[64];
+    size_t connect_len;
+    /* v3.1.1 CONNACK: type 0x20, Remaining Length 2, Session Present 0
+     * ([MQTT-3.2.2-4] on a refusal), return code 0x02. */
+    static const byte expected[] = {
+        0x20, 0x02, 0x00, MQTT_CONNECT_ACK_CODE_REFUSED_ID
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    connect_len = build_v311_connect_emptyid(connect, 0x00);
+    reset_mock_state(connect, connect_len);
+
+    /* Accept only the first byte of the refused CONNACK. */
+    g_clients[0].write_limit_once = 1;
+    run_broker_one_connect(&broker);
+
+    /* Only 0x20 is out so far, and the socket is still open - closing here is
+     * what used to strand the return code. */
+    ASSERT_EQ((size_t)1, g_out_len);
+    ASSERT_EQ(0x20, g_out_buf[0]);
+    ASSERT_FALSE(g_client_closed);
+
+    /* A later broker step finishes the write and only then closes. */
+    (void)MqttBroker_Step(&broker);
+    ASSERT_EQ(sizeof(expected), g_out_len);
+    ASSERT_MEM_EQ(expected, g_out_buf, sizeof(expected));
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* The refused client must never count as connected while its CONNACK drains,
+ * and must leave no BrokerClient behind once it does. */
+TEST(refused_connack_short_write_leaves_no_client)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    byte connect[64];
+    size_t connect_len;
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    connect_len = build_v311_connect_emptyid(connect, 0x00);
+    reset_mock_state(connect, connect_len);
+
+    g_clients[0].write_limit_once = 1;
+    run_broker_one_connect(&broker);
+    ASSERT_NOT_NULL(broker.clients);
+    ASSERT_EQ(0, (int)broker.clients->connected);
+    ASSERT_EQ(1, (int)broker.clients->connack_refused);
+
+    (void)MqttBroker_Step(&broker);
+    ASSERT_NULL(broker.clients);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* MQTT 3.1.1 section 3.1.4 lists "Start message delivery and keep alive
+ * monitoring" as the step after acknowledging the CONNECT. An accepted CONNACK
+ * that is still only partly written must therefore not be cut short by its own
+ * client's keepalive deadline - the broker withholds reads until that write
+ * finishes, so last_rx cannot advance and the deadline would always win.
+ *
+ * Keep Alive is 2, so the 1.5x deadline [MQTT-3.1.2-24] falls at t=3. */
+TEST(accepted_connack_pending_survives_keepalive_deadline)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* bc;
+    /* v3.1.1 CONNECT: CleanSession=1, Keep Alive 2, ClientId "id". */
+    static const byte connect[] = {
+        0x10, 14,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02,
+        0x00, 0x02,
+        0x00, 0x02, 'i', 'd'
+    };
+    static const byte expected[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_state(connect, sizeof(connect));
+    g_clients[0].write_limit_once = 1;
+    run_broker_one_connect(&broker);
+
+    bc = find_broker_client(&broker, "id");
+    ASSERT_NOT_NULL(bc);
+    ASSERT_EQ(4, bc->connack_pending_len);
+    ASSERT_EQ((size_t)1, g_out_len);
+
+    /* Past the keepalive deadline with the CONNACK still pending: the client
+     * must survive, since keep alive monitoring has not started yet. */
+    g_broker_time_s = 3;
+    g_clients[0].write_continue = 1;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_FALSE(g_client_closed);
+    ASSERT_NOT_NULL(find_broker_client(&broker, "id"));
+
+    /* Once the CONNACK completes the deadline is re-baselined off that
+     * moment, so the client is still live at the same clock reading. */
+    g_clients[0].write_continue = 0;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_EQ(sizeof(expected), g_out_len);
+    ASSERT_MEM_EQ(expected, g_out_buf, sizeof(expected));
+    ASSERT_FALSE(g_client_closed);
+    bc = find_broker_client(&broker, "id");
+    ASSERT_NOT_NULL(bc);
+    ASSERT_EQ(0, bc->connack_pending_len);
+
+    /* Keep alive monitoring is running now: 1.5x past the new baseline
+     * closes the client as usual. */
+    g_broker_time_s = 6;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_TRUE(g_client_closed);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
 TEST(pending_write_does_not_bypass_keepalive)
 {
     MqttBroker broker;
@@ -4166,6 +4326,94 @@ TEST(outbound_zero_progress_retry_keeps_dup_clear)
     MqttBroker_Free(&broker);
 }
 
+/* MQTT 3.1.1 section 4.3.1: at QoS 0 "no retry is performed by the sender" and
+ * the message "arrives at the receiver either once or not at all". A QoS 0
+ * fan-out whose write starts and then fails has been attempted, so it must not
+ * follow the persistent Session into an orphan and be delivered a second time
+ * on reconnect. Section 4.1 makes only QoS 0 messages *pending transmission*
+ * optional Session state. */
+TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* CleanSession=0 so the Session survives the failed write. */
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x00, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* Granted QoS 0, so the fan-out to this subscriber is QoS 0. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x00
+    };
+    /* Hand-built MQTT v3.1.1 QoS 0 PUBLISH: topic "x", payload "ABC". */
+    static const byte publish_x[] = {
+        0x30, 0x06,
+        0x00, 0x01, 'x',
+        'A', 'B', 'C'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* One byte of the QoS 0 delivery goes out, then the socket errors. */
+    g_clients[1].write_limit_once = 1;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    (void)MqttBroker_Step(&broker);
+    ASSERT_NOT_NULL(sub_bc->out_q_head);
+    ASSERT_EQ(MQTT_QOS_0, sub_bc->out_q_head->qos);
+    ASSERT_TRUE(sub_bc->client.write.pos > 0);
+
+    g_clients[1].write_err = 1;
+    (void)MqttBroker_Step(&broker);
+    /* The attempted QoS 0 message is gone rather than queued for replay. */
+    ASSERT_NULL(sub_bc->out_q_head);
+    ASSERT_EQ(0, sub_bc->out_q_count);
+
+    for (i = 0; i < 4; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_TRUE(g_clients[1].closed);
+    ASSERT_EQ(1, broker.orphan_session_count);
+
+    /* Reconnect the same persistent Session: only the CONNACK comes back,
+     * with no second copy of the QoS 0 PUBLISH. */
+    mock_client_input_append(2, connect_sub, sizeof(connect_sub));
+    g_clients_active = 3;
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_EQ(0, count_packets_of_type(g_clients[2].out_buf,
+        g_clients[2].out_len, MQTT_PACKET_TYPE_PUBLISH));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
 /* A QoS 1 PUBLISH whose transport write starts but fails before completion has
  * still been attempted. If the persistent Session reconnects, the broker must
  * re-deliver it with DUP=1 and the same Packet Identifier [MQTT-3.3.1-1]. */
@@ -4249,6 +4497,98 @@ TEST(outbound_partial_failure_reconnect_sets_dup)
     MqttBroker_Free(&broker);
 }
 #endif /* WOLFMQTT_NONBLOCK && !WOLFMQTT_STATIC_MEMORY */
+
+#if !defined(WOLFMQTT_NONBLOCK) && !defined(WOLFMQTT_STATIC_MEMORY)
+/* Blocking-transport counterpart of outbound_partial_failure_reconnect_sets_dup.
+ * MqttSocket_Write loops until the packet is out or the transport errors, so a
+ * transport that accepts some bytes and then fails does both inside one
+ * MqttPacket_Write call - there is no MQTT_CODE_CONTINUE step to mark the
+ * entry with. Those bytes still reached the subscriber, so the replay after
+ * session recovery is a re-delivery and [MQTT-3.3.1-1] requires DUP=1. */
+TEST(outbound_blocking_partial_failure_reconnect_sets_dup)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    PublishInfo info;
+    word16 packet_id;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* CleanSession=0 so the Session survives the failed write. */
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x00, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x01
+    };
+    /* Hand-built MQTT v3.1.1 QoS 1 PUBLISH: Packet Identifier 7, topic "x",
+     * payload "ABC"; this is independent of the encoder under test. */
+    static const byte publish_x[] = {
+        0x32, 0x08,
+        0x00, 0x01, 'x',
+        0x00, 0x07,
+        'A', 'B', 'C'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* One byte of the queued delivery goes out, then the socket errors -
+     * both within the single blocking write. */
+    g_clients[1].write_limit_then_err = 1;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    (void)MqttBroker_Step(&broker);
+    ASSERT_NOT_NULL(sub_bc->out_q_head);
+    ASSERT_TRUE(sub_bc->client.write.pos > 0);
+    ASSERT_EQ(1, sub_bc->out_q_head->retransmit_dup);
+    packet_id = sub_bc->out_q_head->packet_id;
+    ASSERT_TRUE(packet_id != 0);
+
+    g_clients[1].write_err = 1;
+    for (i = 0; i < 4; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_TRUE(g_clients[1].closed);
+    ASSERT_EQ(1, broker.orphan_session_count);
+
+    /* Reconnect the same persistent Session and inspect its replayed PUBLISH. */
+    mock_client_input_append(2, connect_sub, sizeof(connect_sub));
+    g_clients_active = 3;
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    info = first_publish_info(g_clients[2].out_buf, g_clients[2].out_len);
+    ASSERT_TRUE(info.found);
+    ASSERT_EQ(0x3A, info.first_byte); /* PUBLISH | DUP | QoS 1 */
+    ASSERT_EQ(packet_id, info.packet_id);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* !WOLFMQTT_NONBLOCK && !WOLFMQTT_STATIC_MEMORY */
 
 /* [MQTT-3.2.2-2] When a CleanSession=0 connection is accepted and the
  * broker has stored session state for the supplied Client Identifier,
@@ -7909,9 +8249,16 @@ int main(int argc, char** argv)
     RUN_TEST(retained_publish_waits_for_partial_suback);
 #endif
     RUN_TEST(self_publish_waits_for_partial_puback);
+    RUN_TEST(refused_connack_short_write_delivers_return_code_before_close);
+    RUN_TEST(refused_connack_short_write_leaves_no_client);
+    RUN_TEST(accepted_connack_pending_survives_keepalive_deadline);
     RUN_TEST(pending_write_does_not_bypass_keepalive);
     RUN_TEST(outbound_zero_progress_retry_keeps_dup_clear);
+    RUN_TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect);
     RUN_TEST(outbound_partial_failure_reconnect_sets_dup);
+#endif
+#if !defined(WOLFMQTT_NONBLOCK) && !defined(WOLFMQTT_STATIC_MEMORY)
+    RUN_TEST(outbound_blocking_partial_failure_reconnect_sets_dup);
 #endif
 #endif /* !WOLFMQTT_STATIC_MEMORY */
 #ifdef WOLFMQTT_V5

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -4341,7 +4341,7 @@ static int static_out_id_in_use(const BrokerClient* bc, word16 packet_id)
     int i;
 
     for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
-        if (bc->out_inflight[i] == packet_id) {
+        if (bc->out_inflight[i].packet_id == packet_id) {
             return 1;
         }
     }
@@ -4470,6 +4470,25 @@ TEST(static_fanout_does_not_reuse_unacked_packet_id)
 
 #endif /* WOLFMQTT_STATIC_MEMORY */
 
+#ifndef WOLFMQTT_STATIC_MEMORY
+/* Find the orphan session carrying a disconnected client's Session state. The
+ * BrokerClient itself is freed by the close, so anything a test wants to check
+ * about the preserved queue must be read from here. */
+static BrokerOrphanSession* find_orphan_session(MqttBroker* broker,
+    const char* id)
+{
+    BrokerOrphanSession* o = broker->orphan_sessions;
+
+    while (o != NULL) {
+        if (o->client_id != NULL && XSTRCMP(o->client_id, id) == 0) {
+            return o;
+        }
+        o = o->next;
+    }
+    return NULL;
+}
+#endif /* !WOLFMQTT_STATIC_MEMORY */
+
 #if defined(WOLFMQTT_NONBLOCK) && !defined(WOLFMQTT_STATIC_MEMORY)
 /* A zero-progress would-block result means none of the first transmission has
  * reached the network, so its later retry must still carry DUP=0
@@ -4556,6 +4575,7 @@ TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect)
     MqttBroker broker;
     MqttBrokerNet net;
     BrokerClient* sub_bc;
+    BrokerOrphanSession* orphan;
     int i;
     static const byte connect_pub[] = {
         0x10, 0x0D,
@@ -4607,17 +4627,21 @@ TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect)
     ASSERT_EQ(MQTT_QOS_0, sub_bc->out_q_head->qos);
     ASSERT_TRUE(sub_bc->client.write.pos > 0);
 
+    /* The failing write closes the client, so sub_bc is freed from here on and
+     * the preserved queue must be inspected through the orphan session. */
     g_clients[1].write_err = 1;
-    (void)MqttBroker_Step(&broker);
-    /* The attempted QoS 0 message is gone rather than queued for replay. */
-    ASSERT_NULL(sub_bc->out_q_head);
-    ASSERT_EQ(0, sub_bc->out_q_count);
-
     for (i = 0; i < 4; i++) {
         (void)MqttBroker_Step(&broker);
     }
     ASSERT_TRUE(g_clients[1].closed);
     ASSERT_EQ(1, broker.orphan_session_count);
+
+    /* The attempted QoS 0 message did not follow the Session into the orphan;
+     * only QoS > 0 state is preserved for replay. */
+    orphan = find_orphan_session(&broker, "S");
+    ASSERT_NOT_NULL(orphan);
+    ASSERT_NULL(orphan->out_q_head);
+    ASSERT_EQ(0, orphan->out_q_count);
 
     /* Reconnect the same persistent Session: only the CONNACK comes back,
      * with no second copy of the QoS 0 PUBLISH. */
@@ -4729,6 +4753,7 @@ TEST(outbound_blocking_partial_failure_reconnect_sets_dup)
     MqttBroker broker;
     MqttBrokerNet net;
     BrokerClient* sub_bc;
+    BrokerOrphanSession* orphan;
     PublishInfo info;
     word16 packet_id;
     int i;
@@ -4776,22 +4801,27 @@ TEST(outbound_blocking_partial_failure_reconnect_sets_dup)
     ASSERT_NOT_NULL(sub_bc);
 
     /* One byte of the queued delivery goes out, then the socket errors -
-     * both within the single blocking write. */
+     * both within the single blocking write. That failure closes the client,
+     * so sub_bc is freed and the entry must be inspected via the orphan. */
     g_clients[1].write_limit_then_err = 1;
     mock_client_input_append(0, publish_x, sizeof(publish_x));
     (void)MqttBroker_Step(&broker);
-    ASSERT_NOT_NULL(sub_bc->out_q_head);
-    ASSERT_TRUE(sub_bc->client.write.pos > 0);
-    ASSERT_EQ(1, sub_bc->out_q_head->retransmit_dup);
-    packet_id = sub_bc->out_q_head->packet_id;
-    ASSERT_TRUE(packet_id != 0);
 
+    /* The fan-out drain discards its result, so the close lands on a later
+     * step. It frees sub_bc, hence the orphan lookup below. */
     g_clients[1].write_err = 1;
     for (i = 0; i < 4; i++) {
         (void)MqttBroker_Step(&broker);
     }
     ASSERT_TRUE(g_clients[1].closed);
     ASSERT_EQ(1, broker.orphan_session_count);
+
+    orphan = find_orphan_session(&broker, "S");
+    ASSERT_NOT_NULL(orphan);
+    ASSERT_NOT_NULL(orphan->out_q_head);
+    ASSERT_EQ(1, orphan->out_q_head->retransmit_dup);
+    packet_id = orphan->out_q_head->packet_id;
+    ASSERT_TRUE(packet_id != 0);
 
     /* Reconnect the same persistent Session and inspect its replayed PUBLISH. */
     mock_client_input_append(2, connect_sub, sizeof(connect_sub));
@@ -8408,9 +8438,11 @@ int main(int argc, char** argv)
 #if defined(WOLFMQTT_V5) && defined(WOLFMQTT_BROKER_WILL)
     RUN_TEST(connect_v5_oversize_will_payload_emits_connack);
     #ifdef WOLFMQTT_STATIC_MEMORY
-    RUN_TEST(static_fanout_does_not_reuse_unacked_packet_id);
     RUN_TEST(connect_v5_oversize_will_topic_emits_connack);
     #endif
+#endif
+#ifdef WOLFMQTT_STATIC_MEMORY
+    RUN_TEST(static_fanout_does_not_reuse_unacked_packet_id);
 #endif
     RUN_TEST(connect_v311_explicit_auto_prefix_refused);
     RUN_TEST(connect_unsupported_level_3_refused);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -163,6 +163,12 @@ typedef struct MockClient {
      * a sequence the one-shot knobs above cannot express on their own. */
     int    write_limit_then_err;
     int    write_err_pending; /* next mock_write call returns a network error */
+    /* When set, the next PUBLISH frame (and only that) fails. Lets a test aim
+     * at a delivery without also failing the SUBACK that precedes it. */
+    int    write_err_on_publish;
+    /* Next mock_write call reports a transient timeout: the socket is alive,
+     * select() just did not report it writable in time. */
+    int    write_timeout_pending;
 } MockClient;
 
 static MockClient g_clients[MOCK_MAX_CLIENTS];
@@ -265,6 +271,15 @@ static int mock_write(void* ctx, BROKER_SOCKET_T sock,
     mc = &g_clients[idx];
     if (mc->write_err_pending) {
         mc->write_err_pending = 0;
+        return MQTT_CODE_ERROR_NETWORK;
+    }
+    if (mc->write_timeout_pending) {
+        mc->write_timeout_pending = 0;
+        return MQTT_CODE_ERROR_TIMEOUT;
+    }
+    if (mc->write_err_on_publish && buf != NULL && buf_len > 0 &&
+            ((buf[0] & 0xF0) >> 4) == MQTT_PACKET_TYPE_PUBLISH) {
+        mc->write_err_on_publish = 0;
         return MQTT_CODE_ERROR_NETWORK;
     }
     if (mc->write_continue) {
@@ -4468,6 +4483,275 @@ TEST(static_fanout_does_not_reuse_unacked_packet_id)
     MqttBroker_Free(&broker);
 }
 
+/* Bring up a publisher on slot 0 and a QoS-`sub_qos` subscriber "S" on slot 1,
+ * both subscribed to topic "x". Returns the subscriber's BrokerClient. */
+static BrokerClient* static_setup_pub_sub(MqttBroker* broker,
+    MqttBrokerNet* net, byte proto_level, byte sub_qos)
+{
+    int i;
+    /* v3.1.1 CONNECT: remain 13 = 6 name + 1 level + 1 flags + 2 keepalive
+     * + 2+1 ClientId. */
+    byte connect_v4[15] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* v5 CONNECT: the variable header gains a Properties Length byte, so
+     * remain is 14 [MQTT-3.1.2.11]. */
+    byte connect_v5[16] = {
+        0x10, 0x0E,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x05, 0x02, 0x00, 0x3C,
+        0x00,
+        0x00, 0x01, 'P'
+    };
+    /* v3.1.1 SUBSCRIBE: packet id + one filter "x" + options. */
+    byte subscribe_v4[8] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x00
+    };
+    /* v5 SUBSCRIBE adds a Properties Length byte [MQTT-3.8.2.1]. */
+    byte subscribe_v5[9] = {
+        0x82, 0x07,
+        0x00, 0x01,
+        0x00,
+        0x00, 0x01, 'x',
+        0x00
+    };
+    byte* connect_pub;
+    byte* connect_sub;
+    byte* subscribe_x;
+    int connect_len;
+    int subscribe_len;
+
+    if (proto_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
+        connect_pub = connect_v5;
+        connect_len = (int)sizeof(connect_v5);
+        subscribe_x = subscribe_v5;
+        subscribe_len = (int)sizeof(subscribe_v5);
+    }
+    else {
+        connect_pub = connect_v4;
+        connect_len = (int)sizeof(connect_v4);
+        subscribe_x = subscribe_v4;
+        subscribe_len = (int)sizeof(subscribe_v4);
+    }
+    subscribe_x[subscribe_len - 1] = sub_qos;
+
+    install_mock_net(net);
+    XMEMSET(broker, 0, sizeof(*broker));
+    if (MqttBroker_Init(broker, net) != MQTT_CODE_SUCCESS) {
+        return NULL;
+    }
+    if (MqttBroker_Start(broker) != MQTT_CODE_SUCCESS) {
+        return NULL;
+    }
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_pub, (size_t)connect_len);
+    /* Same packet with ClientId "S" for the subscriber. */
+    connect_sub = connect_pub;
+    connect_sub[connect_len - 1] = 'S';
+    mock_client_input_append(1, connect_sub, (size_t)connect_len);
+    connect_sub[connect_len - 1] = 'P';
+    mock_client_input_append(1, subscribe_x, (size_t)subscribe_len);
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(broker);
+    }
+    return find_static_broker_client(broker, "S");
+}
+
+/* Count the identifiers the subscriber is currently waiting on. */
+static int static_out_id_count(const BrokerClient* bc)
+{
+    int i;
+    int n = 0;
+
+    for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
+        if (bc->out_inflight[i].packet_id != 0) {
+            n++;
+        }
+    }
+    return n;
+}
+
+/* A retained PUBLISH the broker encoded but could not write is over: no PUBACK
+ * will ever arrive for it, and unlike the live fan-out this path leaves the
+ * subscriber connected, so the identifier must be given back rather than held
+ * for the life of the connection [MQTT-2.3.1-3]. */
+TEST(static_retained_releases_packet_id_on_write_failure)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* Retained QoS 1 PUBLISH (RETAIN bit set), packet id 7, topic "x". */
+    static const byte publish_retained[] = {
+        0x33, 0x06,
+        0x00, 0x01, 'x',
+        0x00, 0x07,
+        'A'
+    };
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x01
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    /* Store the retained message before anyone subscribes, so it is delivered
+     * from the retained store rather than by live fan-out. */
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(0, publish_retained, sizeof(publish_retained));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+
+    /* Now subscribe, failing only the retained delivery itself: the SUBACK
+     * that precedes it still goes out. */
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    g_clients[1].write_err_on_publish = 1;
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+
+    sub_bc = find_static_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+    /* The write failed, so nothing can acknowledge it: no slot may be held. */
+    ASSERT_EQ(0, static_out_id_count(sub_bc));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* [MQTT-2.3.1-4] With every identifier outstanding the broker has none left
+ * to assign, so the delivery is skipped rather than reusing one the subscriber
+ * has not acknowledged. */
+TEST(static_fanout_drops_delivery_when_ids_exhausted)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    int n;
+    size_t before;
+    PublishInfo info;
+    static const byte publish_x[] = {
+        0x32, 0x06,
+        0x00, 0x01, 'x',
+        0x00, 0x07,
+        'A'
+    };
+
+    sub_bc = static_setup_pub_sub(&broker, &net,
+        MQTT_CONNECT_PROTOCOL_LEVEL_4, 0x01);
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* Fill every slot, acknowledging none. */
+    for (n = 0; n < BROKER_MAX_INFLIGHT_PER_SUB; n++) {
+        mock_client_input_append(0, publish_x, sizeof(publish_x));
+        for (i = 0; i < 8; i++) {
+            (void)MqttBroker_Step(&broker);
+        }
+    }
+    ASSERT_EQ(BROKER_MAX_INFLIGHT_PER_SUB, static_out_id_count(sub_bc));
+
+    /* One more: nothing may reach the subscriber. */
+    before = g_clients[1].out_len;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    info = first_publish_info(g_clients[1].out_buf + before,
+        g_clients[1].out_len - before);
+    ASSERT_FALSE(info.found);
+    ASSERT_EQ(BROKER_MAX_INFLIGHT_PER_SUB, static_out_id_count(sub_bc));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+#if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
+/* [MQTT-4.3.3] A v5 subscriber rejecting a QoS 2 delivery at the PUBREC stage
+ * ends the exchange: no PUBREL, no PUBCOMP. Nothing else will release the
+ * identifier, so the broker must release it there or the subscriber runs out
+ * of them for the life of the connection. */
+TEST(static_fanout_releases_packet_id_on_v5_pubrec_reject)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    int i;
+    word16 id;
+    size_t before;
+    PublishInfo info;
+    byte pubrec[6];
+    /* v5 QoS 2 PUBLISH, packet id 9, topic "x", payload "A". The variable
+     * header carries a Properties Length byte [MQTT-3.3.2.2]. */
+    static const byte publish_x[] = {
+        0x34, 0x07,
+        0x00, 0x01, 'x',
+        0x00, 0x09,
+        0x00,
+        'A'
+    };
+
+    sub_bc = static_setup_pub_sub(&broker, &net,
+        MQTT_CONNECT_PROTOCOL_LEVEL_5, 0x02);
+    ASSERT_NOT_NULL(sub_bc);
+
+    before = g_clients[1].out_len;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    info = first_publish_info(g_clients[1].out_buf + before,
+        g_clients[1].out_len - before);
+    ASSERT_TRUE(info.found);
+    id = info.packet_id;
+    ASSERT_TRUE(id != 0);
+    ASSERT_TRUE(static_out_id_in_use(sub_bc, id));
+
+    /* v5 PUBREC with reason 0x87 (Not authorized). */
+    pubrec[0] = 0x50;
+    pubrec[1] = 0x03;
+    pubrec[2] = (byte)(id >> 8);
+    pubrec[3] = (byte)(id & 0xFF);
+    pubrec[4] = 0x87;
+    mock_client_input_append(1, pubrec, 5);
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+
+    ASSERT_FALSE(static_out_id_in_use(sub_bc, id));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+#endif /* WOLFMQTT_V5 && WOLFMQTT_MAX_QOS >= 2 */
+
 #endif /* WOLFMQTT_STATIC_MEMORY */
 
 #ifndef WOLFMQTT_STATIC_MEMORY
@@ -4652,6 +4936,210 @@ TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect)
     }
     ASSERT_EQ(0, count_packets_of_type(g_clients[2].out_buf,
         g_clients[2].out_len, MQTT_PACKET_TYPE_PUBLISH));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* MQTT_CODE_ERROR_TIMEOUT is not a dead socket: BrokerPosix_Write returns it
+ * when select() merely times out, so the drain must not treat it as a reason
+ * to discard a partially written QoS 0 entry - that would clear
+ * client.write.pos and let the next queued PUBLISH go out behind the truncated
+ * prefix. The entry stays queued, and MQTT 3.1.1 section 4.3.1 ("no retry is
+ * performed by the sender") is honoured at the orphan hand-off instead: bytes
+ * of it are already on the wire, so it must not follow the Session and be
+ * delivered a second time after reconnect. */
+TEST(outbound_qos0_transient_timeout_not_replayed_on_reconnect)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    BrokerOrphanSession* orphan;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* CleanSession=0 so the Session survives the close. */
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x00, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* Granted QoS 0, so the fan-out to this subscriber is QoS 0. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x00
+    };
+    /* Hand-built MQTT v3.1.1 QoS 0 PUBLISH: topic "x", payload "ABC". */
+    static const byte publish_x[] = {
+        0x30, 0x06,
+        0x00, 0x01, 'x',
+        'A', 'B', 'C'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(3);
+    g_clients_active = 2;
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* One byte of the QoS 0 delivery goes out, then the write would block. */
+    g_clients[1].write_limit_once = 1;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    (void)MqttBroker_Step(&broker);
+    ASSERT_NOT_NULL(sub_bc->out_q_head);
+    ASSERT_EQ(MQTT_QOS_0, sub_bc->out_q_head->qos);
+    ASSERT_TRUE(sub_bc->client.write.pos > 0);
+
+    /* The resume reports a transient timeout. The broker's main loop still
+     * tears the connection down on a negative drain result, so the Session
+     * becomes an orphan; sub_bc is freed from here on. */
+    g_clients[1].write_timeout_pending = 1;
+    for (i = 0; i < 4; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_TRUE(g_clients[1].closed);
+    ASSERT_EQ(1, broker.orphan_session_count);
+
+    /* The half-sent QoS 0 message did not follow the Session. */
+    orphan = find_orphan_session(&broker, "S");
+    ASSERT_NOT_NULL(orphan);
+    ASSERT_NULL(orphan->out_q_head);
+    ASSERT_EQ(0, orphan->out_q_count);
+
+    /* Reconnect the same persistent Session: no second copy of the PUBLISH. */
+    mock_client_input_append(2, connect_sub, sizeof(connect_sub));
+    g_clients_active = 3;
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_EQ(0, count_packets_of_type(g_clients[2].out_buf,
+        g_clients[2].out_len, MQTT_PACKET_TYPE_PUBLISH));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* BrokerClient_DrainOutQueue walks past entries awaiting an acknowledgement, so
+ * the partially written entry is the first one still QUEUED - not necessarily
+ * out_q_head. With a sent-but-unacked QoS 1 entry ahead of it, a half-written
+ * QoS 0 message must still be dropped at the orphan hand-off rather than
+ * follow the Session and be delivered a second time (section 4.3.1). */
+TEST(outbound_qos0_partial_behind_unacked_qos1_not_replayed)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    BrokerOrphanSession* orphan;
+    BrokerOutPub* e;
+    int queued = 0;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    /* CleanSession=0 so the Session survives the close. */
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x00, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* Two filters: "q" granted QoS 1, "x" granted QoS 0. */
+    static const byte subscribe_q[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'q',
+        0x01
+    };
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x02,
+        0x00, 0x01, 'x',
+        0x00
+    };
+    static const byte publish_q[] = {
+        0x32, 0x06,
+        0x00, 0x01, 'q',
+        0x00, 0x21,
+        'Q'
+    };
+    static const byte publish_x[] = {
+        0x30, 0x06,
+        0x00, 0x01, 'x',
+        'A', 'B', 'C'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(3);
+    g_clients_active = 2;
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_q, sizeof(subscribe_q));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    sub_bc = find_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* QoS 1 delivery goes out in full and stays queued awaiting its PUBACK. */
+    mock_client_input_append(0, publish_q, sizeof(publish_q));
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_NOT_NULL(sub_bc->out_q_head);
+    ASSERT_TRUE(sub_bc->out_q_head->state != BROKER_OUTQ_QUEUED);
+
+    /* QoS 0 delivery behind it gets one byte out, then would block. */
+    g_clients[1].write_limit_once = 1;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    (void)MqttBroker_Step(&broker);
+    ASSERT_TRUE(sub_bc->client.write.pos > 0);
+    /* The unacked QoS 1 entry is still ahead of the partial QoS 0 one. */
+    ASSERT_EQ(MQTT_QOS_1, sub_bc->out_q_head->qos);
+
+    /* Tear the connection down through a transient timeout: the drain keeps
+     * the entry (a timeout is not a dead socket), so the orphan hand-off is
+     * what has to drop it. A hard error would take the drain's own QoS 0 drop
+     * branch instead and never exercise this path. */
+    g_clients[1].write_timeout_pending = 1;
+    for (i = 0; i < 6; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_TRUE(g_clients[1].closed);
+
+    orphan = find_orphan_session(&broker, "S");
+    ASSERT_NOT_NULL(orphan);
+    /* The QoS 1 entry is Session state and stays; the half-sent QoS 0 one
+     * must not be there. */
+    for (e = orphan->out_q_head; e != NULL; e = e->next) {
+        queued++;
+        ASSERT_TRUE(e->qos != MQTT_QOS_0);
+    }
+    ASSERT_EQ(1, queued);
 
     MqttBroker_Stop(&broker);
     MqttBroker_Free(&broker);
@@ -8443,6 +8931,11 @@ int main(int argc, char** argv)
 #endif
 #ifdef WOLFMQTT_STATIC_MEMORY
     RUN_TEST(static_fanout_does_not_reuse_unacked_packet_id);
+    RUN_TEST(static_retained_releases_packet_id_on_write_failure);
+    RUN_TEST(static_fanout_drops_delivery_when_ids_exhausted);
+#if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 2
+    RUN_TEST(static_fanout_releases_packet_id_on_v5_pubrec_reject);
+#endif
 #endif
     RUN_TEST(connect_v311_explicit_auto_prefix_refused);
     RUN_TEST(connect_unsupported_level_3_refused);
@@ -8509,6 +9002,8 @@ int main(int argc, char** argv)
     RUN_TEST(pending_write_does_not_bypass_keepalive);
     RUN_TEST(outbound_zero_progress_retry_keeps_dup_clear);
     RUN_TEST(outbound_qos0_partial_failure_not_replayed_on_reconnect);
+    RUN_TEST(outbound_qos0_transient_timeout_not_replayed_on_reconnect);
+    RUN_TEST(outbound_qos0_partial_behind_unacked_qos1_not_replayed);
     RUN_TEST(outbound_partial_failure_reconnect_sets_dup);
 #endif
 #if !defined(WOLFMQTT_NONBLOCK) && !defined(WOLFMQTT_STATIC_MEMORY)

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -3078,6 +3078,88 @@ TEST(refused_connack_short_write_leaves_no_client)
     MqttBroker_Free(&broker);
 }
 
+/* If the resumed write of a refused CONNACK itself fails, the client is torn
+ * down without publishing a Will: a CONNECT refused before the Will was stored
+ * established no Session at all. */
+TEST(refused_connack_resume_write_failure_drops_client)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    byte connect[64];
+    size_t connect_len;
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    connect_len = build_v311_connect_emptyid(connect, 0x00);
+    reset_mock_state(connect, connect_len);
+
+    g_clients[0].write_limit_once = 1;
+    run_broker_one_connect(&broker);
+    ASSERT_NOT_NULL(broker.clients);
+    ASSERT_EQ(1, (int)broker.clients->connack_refused);
+
+    /* The rest of the refusal never makes it out. */
+    g_clients[0].write_err = 1;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_NULL(broker.clients);
+    ASSERT_EQ(0, broker.orphan_session_count);
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+/* A peer that never drains its socket must not hold a client slot forever
+ * while its accepted CONNACK is pending. Keep alive monitoring is held off
+ * for that window, so the handshake is bounded by BROKER_CONNECT_TIMEOUT_SEC
+ * measured from the CONNECT that produced the CONNACK. */
+TEST(accepted_connack_pending_times_out_and_closes)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* bc;
+    /* v3.1.1 CONNECT: CleanSession=1, Keep Alive 0 (no keepalive at all, so
+     * only the handshake bound can close this client), ClientId "id". */
+    static const byte connect[] = {
+        0x10, 14,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02,
+        0x00, 0x00,
+        0x00, 0x02, 'i', 'd'
+    };
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_state(connect, sizeof(connect));
+    g_clients[0].write_limit_once = 1;
+    run_broker_one_connect(&broker);
+
+    bc = find_broker_client(&broker, "id");
+    ASSERT_NOT_NULL(bc);
+    ASSERT_EQ(4, bc->connack_pending_len);
+
+    /* Still pending but inside the bound: the client survives. */
+    g_clients[0].write_continue = 1;
+    g_broker_time_s = BROKER_CONNECT_TIMEOUT_SEC;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_FALSE(g_client_closed);
+    ASSERT_NOT_NULL(find_broker_client(&broker, "id"));
+
+    /* Past the bound with the CONNACK still unwritten: the slot is reclaimed. */
+    g_broker_time_s = BROKER_CONNECT_TIMEOUT_SEC + 1;
+    (void)MqttBroker_Step(&broker);
+    ASSERT_TRUE(g_client_closed);
+    ASSERT_NULL(find_broker_client(&broker, "id"));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
 /* MQTT 3.1.1 section 3.1.4 lists "Start message delivery and keep alive
  * monitoring" as the step after acknowledging the CONNECT. An accepted CONNACK
  * that is still only partly written must therefore not be cut short by its own
@@ -8251,6 +8333,8 @@ int main(int argc, char** argv)
     RUN_TEST(self_publish_waits_for_partial_puback);
     RUN_TEST(refused_connack_short_write_delivers_return_code_before_close);
     RUN_TEST(refused_connack_short_write_leaves_no_client);
+    RUN_TEST(refused_connack_resume_write_failure_drops_client);
+    RUN_TEST(accepted_connack_pending_times_out_and_closes);
     RUN_TEST(accepted_connack_pending_survives_keepalive_deadline);
     RUN_TEST(pending_write_does_not_bypass_keepalive);
     RUN_TEST(outbound_zero_progress_retry_keeps_dup_clear);

--- a/tests/test_broker_connect.c
+++ b/tests/test_broker_connect.c
@@ -4333,6 +4333,143 @@ static PublishInfo first_publish_info(const byte* buf, size_t len)
     return info;
 }
 
+#ifdef WOLFMQTT_STATIC_MEMORY
+/* Reads the broker's outbound in-flight table directly; the library helper
+ * has internal linkage. */
+static int static_out_id_in_use(const BrokerClient* bc, word16 packet_id)
+{
+    int i;
+
+    for (i = 0; i < BROKER_MAX_INFLIGHT_PER_SUB; i++) {
+        if (bc->out_inflight[i] == packet_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Static-memory counterpart of find_broker_client: clients live in a fixed
+ * array rather than a list. */
+static BrokerClient* find_static_broker_client(MqttBroker* broker,
+    const char* id)
+{
+    int i;
+
+    for (i = 0; i < BROKER_MAX_CLIENTS; i++) {
+        if (broker->clients[i].in_use &&
+                XSTRCMP(broker->clients[i].client_id, id) == 0) {
+            return &broker->clients[i];
+        }
+    }
+    return NULL;
+}
+
+/* [MQTT-2.3.1-4] holds a Server sending a QoS > 0 PUBLISH to the same
+ * identifier rule as a Client: the value stays in use until the matching
+ * PUBACK is processed [MQTT-2.3.1-3]. The static-memory fan-out has no
+ * per-subscriber queue to derive that from, so it keeps its own in-flight
+ * table. Two deliveries with no PUBACK in between must not share an id, and
+ * the id must come back once the subscriber acknowledges it. */
+TEST(static_fanout_does_not_reuse_unacked_packet_id)
+{
+    MqttBroker broker;
+    MqttBrokerNet net;
+    BrokerClient* sub_bc;
+    word16 first_id;
+    word16 second_id;
+    size_t before;
+    int i;
+    static const byte connect_pub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'P'
+    };
+    static const byte connect_sub[] = {
+        0x10, 0x0D,
+        0x00, 0x04, 'M', 'Q', 'T', 'T',
+        0x04, 0x02, 0x00, 0x3C,
+        0x00, 0x01, 'S'
+    };
+    /* Subscribe to "x" at QoS 1 so the fan-out carries a Packet Identifier. */
+    static const byte subscribe_x[] = {
+        0x82, 0x06,
+        0x00, 0x01,
+        0x00, 0x01, 'x',
+        0x01
+    };
+    /* Hand-built MQTT v3.1.1 QoS 1 PUBLISH: Packet Identifier 7, topic "x",
+     * payload "A"; built from section 3.3, independent of the encoder. */
+    static const byte publish_x[] = {
+        0x32, 0x06,
+        0x00, 0x01, 'x',
+        0x00, 0x07,
+        'A'
+    };
+    PublishInfo info;
+
+    install_mock_net(&net);
+    XMEMSET(&broker, 0, sizeof(broker));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Init(&broker, &net));
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttBroker_Start(&broker));
+
+    reset_mock_clients(2);
+    mock_client_input_append(0, connect_pub, sizeof(connect_pub));
+    mock_client_input_append(1, connect_sub, sizeof(connect_sub));
+    mock_client_input_append(1, subscribe_x, sizeof(subscribe_x));
+    for (i = 0; i < 16; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    sub_bc = find_static_broker_client(&broker, "S");
+    ASSERT_NOT_NULL(sub_bc);
+
+    /* First delivery, left unacknowledged. */
+    before = g_clients[1].out_len;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    info = first_publish_info(g_clients[1].out_buf + before,
+        g_clients[1].out_len - before);
+    ASSERT_TRUE(info.found);
+    first_id = info.packet_id;
+    ASSERT_TRUE(first_id != 0);
+    ASSERT_TRUE(static_out_id_in_use(sub_bc, first_id));
+
+    /* Second delivery while the first is still outstanding. */
+    before = g_clients[1].out_len;
+    mock_client_input_append(0, publish_x, sizeof(publish_x));
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    info = first_publish_info(g_clients[1].out_buf + before,
+        g_clients[1].out_len - before);
+    ASSERT_TRUE(info.found);
+    second_id = info.packet_id;
+    ASSERT_TRUE(second_id != 0);
+    ASSERT_TRUE(second_id != first_id);
+
+    /* The subscriber acknowledges the first: that id becomes reusable. */
+    {
+        byte puback[4];
+        puback[0] = 0x40;
+        puback[1] = 0x02;
+        puback[2] = (byte)(first_id >> 8);
+        puback[3] = (byte)(first_id & 0xFF);
+        mock_client_input_append(1, puback, sizeof(puback));
+    }
+    for (i = 0; i < 8; i++) {
+        (void)MqttBroker_Step(&broker);
+    }
+    ASSERT_FALSE(static_out_id_in_use(sub_bc, first_id));
+    ASSERT_TRUE(static_out_id_in_use(sub_bc, second_id));
+
+    MqttBroker_Stop(&broker);
+    MqttBroker_Free(&broker);
+}
+
+#endif /* WOLFMQTT_STATIC_MEMORY */
+
 #if defined(WOLFMQTT_NONBLOCK) && !defined(WOLFMQTT_STATIC_MEMORY)
 /* A zero-progress would-block result means none of the first transmission has
  * reached the network, so its later retry must still carry DUP=0
@@ -8271,6 +8408,7 @@ int main(int argc, char** argv)
 #if defined(WOLFMQTT_V5) && defined(WOLFMQTT_BROKER_WILL)
     RUN_TEST(connect_v5_oversize_will_payload_emits_connack);
     #ifdef WOLFMQTT_STATIC_MEMORY
+    RUN_TEST(static_fanout_does_not_reuse_unacked_packet_id);
     RUN_TEST(connect_v5_oversize_will_topic_emits_connack);
     #endif
 #endif

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -3501,6 +3501,37 @@ TEST(publish_qos2_v5_pubrec_reject_restores_receive_max)
  * Session Present = 1) keeps its inbound QoS 2 dedup state across reconnect, so
  * a server retransmit still awaiting PUBREL is not delivered to the application
  * a second time. */
+/* Drive one CONNECT to completion against a canned CONNACK carrying the given
+ * Session Present bit, so a test can establish which ClientId owns the
+ * client's Session state before manipulating it. */
+static int run_connect_client_id(MqttConnect* connect, const char* client_id,
+    int session_present)
+{
+    int rc;
+    int i;
+    byte connack[4];
+
+    connack[0] = 0x20;
+    connack[1] = 0x02;
+    connack[2] = (byte)(session_present ? 0x01 : 0x00);
+    connack[3] = 0x00;
+
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(connect, 0, sizeof(*connect));
+    connect->keep_alive_sec = 60;
+    connect->clean_session = (byte)(session_present ? 0 : 1);
+    connect->client_id = client_id;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, connect);
+    }
+    return rc;
+}
+
 TEST(connect_clean0_preserves_qos2_dedup)
 {
     int rc;
@@ -3512,11 +3543,20 @@ TEST(connect_clean0_preserves_qos2_dedup)
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
-    /* A prior connection left an inbound QoS 2 id awaiting PUBREL. */
-    test_client.recv_qos2_pending[0] = 9;
 
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+
+    /* First connection under this ClientId, so the dedup table below belongs
+     * to the Session the reconnect resumes [MQTT-3.1.3-2]. */
+    rc = run_connect_client_id(&connect, "test_client", 0);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* That connection left an inbound QoS 2 id awaiting PUBREL. */
+    test_client.recv_qos2_pending[0] = 9;
+
     XMEMCPY(g_canned_buf, connack, sizeof(connack));
     g_canned_len = (int)sizeof(connack);
     g_canned_pos = 0;
@@ -3532,6 +3572,50 @@ TEST(connect_clean0_preserves_qos2_dedup)
     }
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(9, test_client.recv_qos2_pending[0]);
+}
+
+/* [MQTT-3.1.3-2] the ClientId identifies the Session state. Reusing one
+ * MqttClient object under a new ClientId must not let the previous Session's
+ * pending QoS 2 ids suppress delivery for the new one, even when the server
+ * answers Session Present = 1 for the new ClientId. */
+TEST(connect_clientid_change_clears_qos2_dedup)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* v3.1.1 CONNACK: Session Present = 1 (resume), accepted. */
+    static const byte connack[] = { 0x20, 0x02, 0x01, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+
+    rc = run_connect_client_id(&connect, "client_A", 0);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* Session state left behind by ClientId "client_A". */
+    test_client.recv_qos2_pending[0] = 9;
+
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "client_B";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(0, test_client.recv_qos2_pending[0]);
 }
 
 /* Clean Start = 1 clears the inbound QoS 2 dedup state, since packet ids
@@ -5796,6 +5880,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_pubrec_reject_restores_receive_max);
     RUN_TEST(connect_clean0_preserves_qos2_dedup);
+    RUN_TEST(connect_clientid_change_clears_qos2_dedup);
     RUN_TEST(connect_clean1_clears_qos2_dedup);
     RUN_TEST(connect_resume_declined_clears_qos2_dedup);
     RUN_TEST(connect_v5_advertises_receive_max);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2698,6 +2698,210 @@ TEST(wait_message_puback_survives_shared_ack_overwrite)
 #endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK && WOLFMQTT_MAX_QOS >= 1 */
 
 /* ============================================================================
+ * Outbound Session state replay [MQTT-4.4.0-1]
+ *
+ * MQTT 3.1.1 section 4.1 keeps unacknowledged QoS > 0 messages as Client
+ * Session state, and section 4.4 requires them re-sent with their original
+ * Packet Identifiers when the Client reconnects with CleanSession 0.
+ * ============================================================================ */
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+/* Reconnect against a CONNACK carrying the given Session Present bit and
+ * return the result, so a test can observe what the replay put on the wire. */
+static int run_reconnect(MqttConnect* connect, int session_present)
+{
+    int rc;
+    int i;
+    byte connack[4];
+
+    connack[0] = 0x20;
+    connack[1] = 0x02;
+    connack[2] = (byte)(session_present ? 0x01 : 0x00);
+    connack[3] = 0x00;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(connect, 0, sizeof(*connect));
+    connect->keep_alive_sec = 60;
+    connect->clean_session = 0;
+    connect->client_id = "replay_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, connect);
+    }
+    return rc;
+}
+
+/* An unacknowledged QoS 1 PUBLISH is re-sent after a resumed Session, with the
+ * original Packet Identifier and DUP set [MQTT-4.4.0-1], [MQTT-3.3.1-1]. */
+TEST(reconnect_replays_unacked_qos1_publish)
+{
+    int rc;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    /* Publish, no PUBACK: it stays unacknowledged Session state. */
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    g_frames_written = 0;
+    rc = run_reconnect(&connect, 1);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* CONNECT plus the replayed PUBLISH. connect_mock_sent holds the last
+     * frame written, which is the replay. */
+    ASSERT_EQ(2, g_frames_written);
+    /* 0x3A = PUBLISH | DUP | QoS 1. */
+    ASSERT_EQ(0x3A, (int)connect_mock_sent[0]);
+    /* topic "sensor/temp" is 11 bytes, so the packet id follows at offset
+     * 2 (fixed header) + 2 (topic length) + 11. */
+    ASSERT_EQ(0x12, (int)connect_mock_sent[15]);
+    ASSERT_EQ(0x34, (int)connect_mock_sent[16]);
+}
+
+/* Session Present = 0 means the server has no Session, so nothing is
+ * replayed: section 4.1 state belongs to the Session that ended. */
+TEST(reconnect_without_session_present_replays_nothing)
+{
+    int rc;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    g_frames_written = 0;
+    rc = run_reconnect(&connect, 0);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_frames_written); /* the CONNECT only */
+}
+
+/* A completed exchange leaves Session state, so an acknowledged PUBLISH is
+ * not replayed [MQTT-4.4.0-1] covers unacknowledged messages only. */
+TEST(reconnect_does_not_replay_acked_publish)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v3.1.1 PUBACK for packet id 0x1234. */
+    static const byte puback[] = { 0x40, 0x02, 0x12, 0x34 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    g_frames_written = 0;
+    rc = run_reconnect(&connect, 1);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_frames_written); /* the CONNECT only */
+}
+
+#if WOLFMQTT_MAX_QOS >= 2
+/* Once QoS 2 has passed PUBREC the client owes a PUBREL, so that is what is
+ * re-sent, not the PUBLISH [MQTT-4.4.0-1]. */
+TEST(reconnect_replays_unacked_pubrel)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v3.1.1 PUBREC for packet id 0x2233: the client answers with PUBREL and
+     * then waits for a PUBCOMP that never arrives. */
+    static const byte pubrec[] = { 0x50, 0x02, 0x22, 0x33 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
+    g_canned_len = (int)sizeof(pubrec);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_2, 0x2233, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    /* No PUBCOMP, so the publish does not complete. */
+    ASSERT_TRUE(rc != MQTT_CODE_SUCCESS);
+    ASSERT_TRUE(g_pubrel_written);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    g_frames_written = 0;
+    rc = run_reconnect(&connect, 1);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* CONNECT plus the replayed PUBREL: type 6 with the [MQTT-3.6.1-1]
+     * reserved flags 0010, then the original Packet Identifier. */
+    ASSERT_EQ(2, g_frames_written);
+    ASSERT_EQ(0x62, (int)connect_mock_sent[0]);
+    ASSERT_EQ(0x02, (int)connect_mock_sent[1]);
+    ASSERT_EQ(0x22, (int)connect_mock_sent[2]);
+    ASSERT_EQ(0x33, (int)connect_mock_sent[3]);
+}
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
+
+
+/* ============================================================================
  * MqttClient_Disconnect Tests
  * ============================================================================ */
 
@@ -5923,6 +6127,14 @@ void run_mqtt_client_tests(void)
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
     WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(wait_message_puback_survives_shared_ack_overwrite);
+#endif
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    RUN_TEST(reconnect_replays_unacked_qos1_publish);
+    RUN_TEST(reconnect_without_session_present_replays_nothing);
+    RUN_TEST(reconnect_does_not_replay_acked_publish);
+#if WOLFMQTT_MAX_QOS >= 2
+    RUN_TEST(reconnect_replays_unacked_pubrel);
+#endif
 #endif
     RUN_TEST(disconnect_null_client);
 

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -145,6 +145,18 @@ static int test_init_client(void)
     return rc;
 }
 
+/* Declare the precondition the MQTT send APIs require: a CONNECT has already
+ * been written on this Network Connection. [MQTT-3.1.0-1] makes CONNECT the
+ * first packet a Client sends, so MqttClient_Publish, _Subscribe,
+ * _Unsubscribe, _Ping and _Disconnect refuse to put anything on the wire
+ * before it. Tests that exercise those APIs in isolation - without driving a
+ * full handshake through MqttClient_Connect - state that precondition here
+ * rather than relying on the send path not checking it. */
+static void test_client_connect_sent(void)
+{
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
+}
+
 /* ============================================================================
  * MqttClient_Init Tests
  * ============================================================================ */
@@ -512,6 +524,252 @@ static int mock_net_read_canned(void *context, byte* buf, int buf_len,
     XMEMCPY(buf, g_canned_buf + g_canned_pos, n);
     g_canned_pos += n;
     return n;
+}
+
+/* [MQTT-3.1.0-1] "After a Network Connection is established by a Client to a
+ * Server, the first Packet sent from the Client to the Server MUST be a
+ * CONNECT Packet." MQTT_CLIENT_FLAG_IS_CONNECTED tracks only the transport, so
+ * an application that calls MqttClient_NetConnect and then publishes used to
+ * put a PUBLISH on the wire as the first MQTT packet. Nothing may reach the
+ * network before CONNECT. */
+TEST(publish_before_connect_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* Transport up, MQTT handshake not started - what NetConnect leaves. */
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_0;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MqttClient_Publish(&test_client, &publish);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+/* Same rule for the other client-to-server Control Packets. */
+TEST(subscribe_before_connect_rejected)
+{
+    int rc;
+    MqttSubscribe subscribe;
+    MqttTopic topic;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&subscribe, 0, sizeof(subscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "test/topic";
+    topic.qos = MQTT_QOS_0;
+    subscribe.packet_id = 1;
+    subscribe.topic_count = 1;
+    subscribe.topics = &topic;
+
+    rc = MqttClient_Subscribe(&test_client, &subscribe);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+TEST(unsubscribe_before_connect_rejected)
+{
+    int rc;
+    MqttUnsubscribe unsubscribe;
+    MqttTopic topic;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    XMEMSET(&unsubscribe, 0, sizeof(unsubscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "test/topic";
+    unsubscribe.packet_id = 1;
+    unsubscribe.topic_count = 1;
+    unsubscribe.topics = &topic;
+
+    rc = MqttClient_Unsubscribe(&test_client, &unsubscribe);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+TEST(ping_before_connect_rejected)
+{
+    int rc;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Ping(&test_client);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+TEST(disconnect_before_connect_rejected)
+{
+    int rc;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read;
+
+    rc = MqttClient_Disconnect(&test_client);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
+/* Positive control for the whole guard: after a real CONNECT the same publish
+ * reaches the wire, so the check gates on handshake state and not on the
+ * publish itself. */
+TEST(publish_after_connect_allowed)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* CONNACK v3.1.1: type=0x20, remain=2, flags=0x00, return_code=0x00. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    g_frames_written = 0;
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_0;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MqttClient_Publish(&test_client, &publish);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_frames_written);
+}
+
+/* [MQTT-3.1.0-2] "A Client can only send the CONNECT Packet once over a
+ * Network Connection. The Server MUST process a second CONNECT Packet sent
+ * from a Client as a protocol violation and disconnect the Client." A second
+ * MqttClient_Connect on the same transport must be refused before anything is
+ * encoded, and closing the Network Connection must make a new one legal again.
+ */
+TEST(second_connect_on_same_network_connection_rejected)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    g_frames_written = 0;
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* Second handshake attempt on the same transport, fresh CONNECT object. */
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MqttClient_Connect(&test_client, &connect);
+
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(1, g_frames_written); /* nothing new reached the wire */
+
+    /* Closing the Network Connection starts a new one, where CONNECT is legal
+     * again - the sequence a reconnecting application must follow. */
+    rc = MqttClient_NetDisconnect(&test_client);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    g_canned_pos = 0;
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(2, g_frames_written);
 }
 
 /* A broker that accepts the connection returns a CONNACK whose return code is
@@ -887,7 +1145,11 @@ TEST(auth_with_connect_method_allowed)
     MqttClient_PropsFree(auth.props);
 
     /* Reconnect without the property: the negotiation does not carry over, so
-     * the same AUTH must now be refused before anything reaches the wire. */
+     * the same AUTH must now be refused before anything reaches the wire.
+     * [MQTT-3.1.0-2] allows only one CONNECT per Network Connection, so the
+     * old one is closed first - the same sequence an application must use. */
+    rc = MqttClient_NetDisconnect(&test_client);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     XMEMSET(&auth, 0, sizeof(auth));
     rc = run_connect_v5_with_auth_method(0);
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
@@ -1045,6 +1307,7 @@ TEST(publish_qos1_v5_receive_max_quota_exhausted_rejects_before_send)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 0; /* quota exhausted */
 
@@ -1079,6 +1342,7 @@ TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 5;
 
@@ -1171,6 +1435,7 @@ TEST(cancel_message_reuse_does_not_bypass_recv_quota)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max_negotiated = 1;
     test_client.server_recv_max = 0; /* the one unit is on the wire */
@@ -1246,6 +1511,7 @@ TEST(publish_qos1_v5_write_failure_restores_recv_quota)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max_negotiated = 5;
     test_client.server_recv_max = 5;
@@ -1479,6 +1745,7 @@ TEST(publish_v5_topic_alias_exceeds_max_rejected)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.topic_alias_max = 5; /* server accepts alias values 1..5 */
 
@@ -1517,6 +1784,7 @@ TEST(publish_v5_topic_alias_zero_rejected)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.topic_alias_max = 5;
 
@@ -1557,6 +1825,7 @@ TEST(publish_v5_subscription_id_rejected)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
 
     XMEMSET(&publish, 0, sizeof(publish));
@@ -1597,6 +1866,7 @@ TEST(publish_v5_oversized_packet_rejected_before_write)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     /* Larger than any single tx_buf-sized fragment (<=256), smaller than the
      * whole PUBLISH (~417 bytes). */
@@ -1635,6 +1905,7 @@ TEST(publish_v5_within_max_packet_size_allowed)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.packet_sz_max = 1000; /* comfortably above the ~417-byte packet */
 
@@ -1758,6 +2029,7 @@ TEST(subscribe_broker_rejection_returns_subscribe_rejected)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
@@ -1802,6 +2074,7 @@ TEST(unsubscribe_broker_rejection_returns_unsubscribe_rejected)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
 
     test_net.write = mock_net_write_accept;
@@ -1841,6 +2114,7 @@ TEST(unsubscribe_too_few_reason_codes_is_malformed)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     (void)MqttClient_Flags(&test_client, 0,
         MQTT_CLIENT_FLAG_IS_CONNECTED);
@@ -1884,6 +2158,7 @@ TEST(unsubscribe_too_many_reason_codes_is_malformed)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     (void)MqttClient_Flags(&test_client, 0,
         MQTT_CLIENT_FLAG_IS_CONNECTED);
@@ -1993,6 +2268,7 @@ TEST(ping_response_timeout_disconnects_network)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     (void)MqttClient_Flags(&test_client, 0, MQTT_CLIENT_FLAG_IS_CONNECTED);
     g_disconnect_calls = 0;
@@ -2143,6 +2419,7 @@ TEST(ping_timeout_waits_for_concurrent_writer)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     XMEMSET(&race, 0, sizeof(race));
     ASSERT_EQ(0, pthread_mutex_init(&race.mutex, NULL));
     ASSERT_EQ(0, pthread_cond_init(&race.cond, NULL));
@@ -2329,6 +2606,7 @@ TEST(publish_stream_cb_final_chunk_no_overrun)
 
     rc = test_init_client(); /* tx_buf_len = TEST_TX_BUF_SIZE (256) */
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     pub_stream_wire_len = 0;
     XMEMSET(pub_stream_wire, 0, sizeof(pub_stream_wire));
@@ -2374,6 +2652,7 @@ TEST(publish_stream_cb_multifill_full_payload)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     pub_stream_wire_len = 0;
     pub_stream_hdr_len = 0;
@@ -2413,6 +2692,7 @@ TEST(publish_stream_cb_overreturn_clamped_to_total)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     pub_stream_wire_len = 0;
     pub_stream_hdr_len = 0;
@@ -2475,6 +2755,7 @@ TEST(publish_stream_cb_nonblock_resume_no_tail_drop)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     pub_stream_wire_len = 0;
     pub_stream_hdr_len = 0;
@@ -2521,6 +2802,7 @@ static int run_publish_with_canned_resp(MqttPublish* publish,
     if (rc != MQTT_CODE_SUCCESS) {
         return rc;
     }
+    test_client_connect_sent();
     test_client.protocol_level = proto_level;
 
     g_pubrel_written = 0;
@@ -2764,6 +3046,7 @@ TEST(publish_qos2_v5_pubrec_reject_restores_receive_max)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3106,6 +3389,7 @@ TEST(publish_qos2_v5_pubrec_rejection_multithread_reader)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
 
     g_pubrel_written = 0;
@@ -3160,6 +3444,7 @@ TEST(publish_qos2_v5_pubrec_state_multithread_reader)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_canned;
@@ -3227,6 +3512,7 @@ TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 0; /* quota exhausted */
 
@@ -3263,6 +3549,7 @@ TEST(publish_writeonly_v5_receive_max_released_on_puback)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3319,6 +3606,7 @@ TEST(publish_writeonly_v5_receive_max_released_on_pubrec_reject)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3393,6 +3681,7 @@ TEST(publish_writeonly_v5_no_dangling_pendresp_on_success)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3434,6 +3723,7 @@ TEST(publish_writeonly_v5_cancel_holds_receive_max)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3483,6 +3773,7 @@ TEST(disconnect_clears_recv_quota_ownership)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
@@ -3511,7 +3802,10 @@ TEST(disconnect_clears_recv_quota_ownership)
     ASSERT_EQ(0, (int)publish.stat.recvQuotaHeld);
 
     /* Stand in for the reconnect that re-negotiates the quota, then reuse the
-     * same object: it must reserve again rather than ride the stale flag. */
+     * same object: it must reserve again rather than ride the stale flag. The
+     * NetDisconnect above ended the Network Connection, so the new one needs
+     * its own CONNECT before any publish [MQTT-3.1.0-1]. */
+    test_client_connect_sent();
     test_client.server_recv_max = 1;
     test_client.server_recv_max_negotiated = 1;
     publish.stat.write = MQTT_MSG_BEGIN;
@@ -3549,6 +3843,7 @@ TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     /* Mock writes accept everything so the publish state machine reaches
      * MQTT_MSG_WAIT and returns MQTT_CODE_CONTINUE while the pendResp is
@@ -3638,6 +3933,7 @@ TEST(subscribe_in_flight_blocks_publish_with_same_packet_id)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_continue;
@@ -4361,6 +4657,10 @@ TEST(wait_message_auto_pings_on_keepalive_deadline)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4397,6 +4697,10 @@ TEST(wait_message_no_autoping_when_keepalive_zero)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4417,6 +4721,10 @@ TEST(wait_message_no_autoping_when_flag_disables)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4450,6 +4758,10 @@ TEST(wait_message_auto_pings_before_full_interval_with_margin)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4475,6 +4787,10 @@ TEST(wait_message_no_autoping_when_link_recently_active)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4498,6 +4814,7 @@ TEST(packet_write_refreshes_last_tx_time)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4526,6 +4843,7 @@ TEST(packet_write_skips_last_tx_time_when_keepalive_zero)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4550,6 +4868,10 @@ TEST(wait_message_no_autoping_during_partial_read)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4577,6 +4899,10 @@ TEST(wait_message_no_autoping_during_partial_payload)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4607,6 +4933,10 @@ TEST(wait_message_no_autoping_when_read_active)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4639,6 +4969,10 @@ TEST(wait_message_resumes_inflight_ping)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4670,6 +5004,10 @@ TEST(wait_message_nonblock_returns_continue_for_deferred_ping)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The keep-alive PINGREQ the wait path injects is a Control Packet
+     * like any other, so it needs the post-CONNECT state [MQTT-3.1.0-1].
+     * In practice keep_alive_sec is only armed by an accepted CONNACK. */
+    test_client_connect_sent();
 
     g_pingreq_writes = 0;
     test_net.write = mock_net_write_count_ping;
@@ -4954,6 +5292,13 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_null_connect);
     RUN_TEST(connect_both_null);
     RUN_TEST(connect_with_mock_network);
+    RUN_TEST(publish_before_connect_rejected);
+    RUN_TEST(subscribe_before_connect_rejected);
+    RUN_TEST(unsubscribe_before_connect_rejected);
+    RUN_TEST(ping_before_connect_rejected);
+    RUN_TEST(disconnect_before_connect_rejected);
+    RUN_TEST(publish_after_connect_allowed);
+    RUN_TEST(second_connect_on_same_network_connection_rejected);
     RUN_TEST(connect_clears_tx_buf_credentials);
     RUN_TEST(connect_accepted_connack_returns_success);
     RUN_TEST(connect_clean_session_present_mismatch_refused);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2477,6 +2477,106 @@ TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected)
     ASSERT_EQ(1, g_frames_written);
 }
 
+/* A new handshake starts a fresh identifier space, so reservations left over
+ * from a dead connection must not refuse a reuse on the new one. This covers
+ * the reconnect path an application takes when the previous connection died
+ * without MqttClient_NetDisconnect: MqttClient_WaitType clears
+ * MQTT_CLIENT_FLAG_IS_CONNECTED on a fatal error, the application calls
+ * MqttClient_NetConnect (which clears MQTT_CLIENT_FLAG_CONNECT_SENT) and then
+ * MqttClient_Connect. Guards the reset against being compiled out. */
+TEST(connect_frees_in_flight_packet_ids)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* CONNACK v3.1.1: type=0x20, remain=2, flags=0x00, return_code=0x00. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* Stand in for the transport being re-established without a
+     * MqttClient_NetDisconnect: only the handshake flag is cleared. */
+    (void)MqttClient_Flags(&test_client, MQTT_CLIENT_FLAG_CONNECT_SENT, 0);
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "test_client";
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* The identifier belonged to the previous connection, so it is free. */
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+}
+
+/* Past MQTT_MAX_SEND_INFLIGHT the table cannot record any more identifiers, so
+ * the collision check is best effort by design: the send is allowed rather
+ * than refused, since an application may legitimately keep more than that many
+ * packets in flight. Pins that contract so a later change to fail closed is a
+ * deliberate one. */
+TEST(send_inflight_table_full_still_allows_new_packet_id)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    /* Receive Maximum would otherwise cap in-flight publishes first. */
+    test_client.server_recv_max = 65535;
+    test_client.server_recv_max_negotiated = 65535;
+#endif
+
+    /* Fill every slot with a distinct unacknowledged identifier. */
+    for (i = 0; i < MQTT_MAX_SEND_INFLIGHT; i++) {
+        init_qos_publish(&publish, MQTT_QOS_1, (word16)(i + 1), "sensor/temp",
+            payload, (word32)(sizeof(payload) - 1));
+        rc = run_publish_unacked(&publish);
+        ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    }
+
+    /* One more distinct identifier goes untracked but is still sent. */
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1,
+        (word16)(MQTT_MAX_SEND_INFLIGHT + 1), "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+}
+
 /* The identifiers were in use on one Network Connection only; closing it
  * clears them, since the client keeps no outbound session state across one. */
 TEST(net_disconnect_frees_in_flight_packet_ids)
@@ -5646,6 +5746,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos1_packet_id_reusable_after_puback);
     RUN_TEST(subscribe_reuse_packet_id_before_suback_rejected);
     RUN_TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected);
+    RUN_TEST(connect_frees_in_flight_packet_ids);
+    RUN_TEST(send_inflight_table_full_still_allows_new_packet_id);
     RUN_TEST(net_disconnect_frees_in_flight_packet_ids);
     RUN_TEST(disconnect_null_client);
 

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -57,6 +57,14 @@ static int mock_net_connect(void *context, const char* host, word16 port,
     return MQTT_CODE_ERROR_NETWORK;
 }
 
+/* Succeeds, so MqttClient_NetConnect reaches the flag update. */
+static int mock_net_connect_ok(void *context, const char* host, word16 port,
+    int timeout_ms)
+{
+    (void)context; (void)host; (void)port; (void)timeout_ms;
+    return MQTT_CODE_SUCCESS;
+}
+
 static int mock_net_read(void *context, byte* buf, int buf_len, int timeout_ms)
 {
     (void)context; (void)buf; (void)buf_len; (void)timeout_ms;
@@ -2697,6 +2705,89 @@ TEST(wait_message_puback_survives_shared_ack_overwrite)
 }
 #endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK && WOLFMQTT_MAX_QOS >= 1 */
 
+/* MqttClient_WaitType dispatches on the stat of the object it is handed, which
+ * for the CONNACK wait is mc_connect->ack. Left at MQTT_MSG_PAYLOAD after a
+ * completed handshake, a second MqttClient_Connect on the same MqttConnect
+ * skips the read entirely and hands whatever is still in rx_buf to the PUBLISH
+ * payload handler instead of waiting for the new CONNACK. The bundled examples
+ * reuse one MqttConnect across reconnects, so this is the ordinary path. */
+TEST(reconnect_on_reused_connect_object_waits_for_connack)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    /* v3.1.1 CONNACK, Session Present = 0, Accepted. */
+    static const byte connack[] = { 0x20, 0x02, 0x00, 0x00 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "reuse_client";
+    /* Pin v3.1.1 so the canned CONNACK shape is right in every build; a v5
+     * CONNACK would need a Property Length byte. The decoder reads the level
+     * from the client, which MqttClient_Init sets from the build default and
+     * MqttClient_Connect does not sync from mc_connect, so set both. */
+    connect.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    for (i = 0; i < 2; i++) {
+        XMEMCPY(g_canned_buf, connack, sizeof(connack));
+        g_canned_len = (int)sizeof(connack);
+        g_canned_pos = 0;
+        g_frames_written = 0;
+
+        rc = MQTT_CODE_CONTINUE;
+        while (rc == MQTT_CODE_CONTINUE) {
+            rc = MqttClient_Connect(&test_client, &connect);
+        }
+        /* Both handshakes must complete, and each must consume its own
+         * CONNACK rather than reusing the bytes left in rx_buf. */
+        ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+        ASSERT_EQ((int)sizeof(connack), g_canned_pos);
+        ASSERT_EQ(1, g_frames_written);
+
+        ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+    }
+}
+
+/* [MQTT-3.1.0-1] A new Network Connection starts with no MQTT packet sent, so
+ * MqttClient_NetConnect must clear MQTT_CLIENT_FLAG_CONNECT_SENT as it sets
+ * MQTT_CLIENT_FLAG_IS_CONNECTED. Otherwise a client reconnecting after a
+ * successful handshake would still look like it had sent CONNECT, and the
+ * CONNECT-once guard [MQTT-3.1.0-2] would refuse the new handshake. */
+TEST(net_connect_clears_connect_sent_flag)
+{
+    int rc;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* Look like a client that already completed a handshake. */
+    test_client_connect_sent();
+    ASSERT_TRUE((MqttClient_Flags(&test_client, 0, 0) &
+        MQTT_CLIENT_FLAG_CONNECT_SENT) != 0);
+
+    test_net.connect = mock_net_connect_ok;
+    rc = MqttClient_NetConnect(&test_client, "host", 1883, 100, 0, NULL);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    ASSERT_TRUE((MqttClient_Flags(&test_client, 0, 0) &
+        MQTT_CLIENT_FLAG_IS_CONNECTED) != 0);
+    ASSERT_EQ(0, (int)(MqttClient_Flags(&test_client, 0, 0) &
+        MQTT_CLIENT_FLAG_CONNECT_SENT));
+
+    test_net.connect = mock_net_connect;
+}
+
 /* ============================================================================
  * Outbound Session state replay [MQTT-4.4.0-1]
  *
@@ -2707,22 +2798,34 @@ TEST(wait_message_puback_survives_shared_ack_overwrite)
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
 /* Reconnect against a CONNACK carrying the given Session Present bit and
  * return the result, so a test can observe what the replay put on the wire. */
-static int run_reconnect(MqttConnect* connect, int session_present)
+static int run_reconnect_with(MqttConnect* connect, int session_present,
+    MqttNetWriteCb write_cb)
 {
     int rc;
     int i;
-    byte connack[4];
+    int connack_len;
+    byte connack[5];
 
     connack[0] = 0x20;
     connack[1] = 0x02;
     connack[2] = (byte)(session_present ? 0x01 : 0x00);
     connack[3] = 0x00;
+    connack_len = 4;
+#ifdef WOLFMQTT_V5
+    if (test_client.protocol_level >= MQTT_CONNECT_PROTOCOL_LEVEL_5) {
+        /* A v5 CONNACK carries a Property Length, which the decoder now
+         * requires to be present [MQTT-3.2.2.1]. */
+        connack[1] = 0x03;
+        connack[4] = 0x00; /* zero-length property set */
+        connack_len = 5;
+    }
+#endif
 
-    test_net.write = mock_net_write_accept;
+    test_net.write = write_cb;
     test_net.read = mock_net_read_canned;
     test_net.disconnect = mock_net_disconnect;
-    XMEMCPY(g_canned_buf, connack, sizeof(connack));
-    g_canned_len = (int)sizeof(connack);
+    XMEMCPY(g_canned_buf, connack, (size_t)connack_len);
+    g_canned_len = connack_len;
     g_canned_pos = 0;
 
     XMEMSET(connect, 0, sizeof(*connect));
@@ -2735,6 +2838,11 @@ static int run_reconnect(MqttConnect* connect, int session_present)
         rc = MqttClient_Connect(&test_client, connect);
     }
     return rc;
+}
+
+static int run_reconnect(MqttConnect* connect, int session_present)
+{
+    return run_reconnect_with(connect, session_present, mock_net_write_accept);
 }
 
 /* An unacknowledged QoS 1 PUBLISH is re-sent after a resumed Session, with the
@@ -2898,6 +3006,361 @@ TEST(reconnect_replays_unacked_pubrel)
     ASSERT_EQ(0x33, (int)connect_mock_sent[3]);
 }
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
+
+/* Payload larger than the 256-byte tx_buf, so the single-buffer replay encode
+ * cannot carry it. */
+#define REPLAY_BIG_PAYLOAD_LEN 300
+static byte g_replay_big_payload[REPLAY_BIG_PAYLOAD_LEN];
+
+/* Accepts every frame but records the fixed-header type and the declared
+ * Remaining Length of each one, so a test can prove the bytes written match
+ * what the header promised. */
+#define REPLAY_MAX_FRAMES 8
+static int g_replay_types[REPLAY_MAX_FRAMES];
+static int g_replay_declared[REPLAY_MAX_FRAMES];
+static int g_replay_written[REPLAY_MAX_FRAMES];
+static int g_replay_frames;
+static int g_replay_fail_at;   /* 1-based frame index to fail, 0 = never */
+static int g_replay_cont_at;   /* 1-based frame index to defer once */
+static int g_replay_cont_done;
+
+/* Streaming-publish staging buffer: smaller than total_len, so the payload
+ * arrives one callback chunk at a time and the client never holds all of
+ * it. */
+#define REPLAY_STREAM_CHUNK 64
+static byte g_replay_stream_buf[REPLAY_STREAM_CHUNK];
+
+static int replay_stream_cb(MqttPublish* publish)
+{
+    XMEMSET(publish->buffer, 0x5A, REPLAY_STREAM_CHUNK);
+    (void)publish;
+    return REPLAY_STREAM_CHUNK;
+}
+
+static void replay_mock_reset(void)
+{
+    XMEMSET(g_replay_types, 0, sizeof(g_replay_types));
+    XMEMSET(g_replay_declared, 0, sizeof(g_replay_declared));
+    XMEMSET(g_replay_written, 0, sizeof(g_replay_written));
+    g_replay_frames = 0;
+    g_replay_fail_at = 0;
+    g_replay_cont_at = 0;
+    g_replay_cont_done = 0;
+}
+
+static int replay_mock_write(void *context, const byte* buf, int buf_len,
+    int timeout_ms)
+{
+    int remain = 0;
+    int i;
+    (void)context; (void)timeout_ms;
+
+    if (buf == NULL || buf_len <= 0) {
+        return 0;
+    }
+    if (g_replay_cont_at != 0 && !g_replay_cont_done &&
+            g_replay_frames + 1 == g_replay_cont_at) {
+        /* Defer this frame once so the caller has to resume it. */
+        g_replay_cont_done = 1;
+        return MQTT_CODE_CONTINUE;
+    }
+    if (g_replay_fail_at != 0 && g_replay_frames + 1 == g_replay_fail_at) {
+        return MQTT_CODE_ERROR_NETWORK;
+    }
+    if (g_replay_frames < REPLAY_MAX_FRAMES) {
+        /* Decode the Remaining Length VBI that follows the first byte. */
+        for (i = 1; i < buf_len && i <= 4; i++) {
+            remain |= (int)(buf[i] & 0x7F) << (7 * (i - 1));
+            if ((buf[i] & 0x80) == 0) {
+                break;
+            }
+        }
+        g_replay_types[g_replay_frames] = (buf[0] & 0xF0) >> 4;
+        g_replay_declared[g_replay_frames] = (i + 1) + remain;
+        g_replay_written[g_replay_frames] = buf_len;
+        g_replay_frames++;
+    }
+    return buf_len;
+}
+
+/* MqttEncode_Publish declares the full Remaining Length in the fixed header
+ * but clamps the payload it copies to what tx_buf holds, leaving the rest for
+ * MqttClient_Publish_WritePayload. The replay writes exactly one buffer, so a
+ * clamped payload would put a short packet on the wire behind a longer
+ * declared length and desynchronize the stream. Such an entry is dropped. */
+TEST(reconnect_drops_replay_larger_than_tx_buf)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+
+    rc = test_init_client(); /* tx_buf_len = TEST_TX_BUF_SIZE (256) */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    XMEMSET(g_replay_big_payload, 0x5A, sizeof(g_replay_big_payload));
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        g_replay_big_payload, (word32)REPLAY_BIG_PAYLOAD_LEN);
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* The CONNECT only: the oversize entry is dropped, not truncated. */
+    ASSERT_EQ(1, g_replay_frames);
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+    /* Whatever did go out was complete. */
+    for (i = 0; i < g_replay_frames; i++) {
+        ASSERT_EQ(g_replay_declared[i], g_replay_written[i]);
+    }
+}
+
+/* A retained entry the client cannot rebuild is dropped, so the pool bounds
+ * how many messages survive a reconnect. Publishing more than
+ * MQTT_MAX_REPLAY_MSGS leaves the extras unretained; they are still sent, they
+ * just cannot be replayed. */
+TEST(reconnect_replays_at_most_pool_size)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    for (i = 0; i < MQTT_MAX_REPLAY_MSGS + 1; i++) {
+        init_qos_publish(&publish, MQTT_QOS_1, (word16)(0x100 + i),
+            "sensor/temp", payload, (word32)(sizeof(payload) - 1));
+        rc = run_publish_unacked(&publish);
+        ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    }
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* CONNECT plus one replay per pool slot, and every frame complete. */
+    ASSERT_EQ(MQTT_MAX_REPLAY_MSGS + 1, g_replay_frames);
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+    for (i = 1; i < g_replay_frames; i++) {
+        ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH, g_replay_types[i]);
+    }
+    for (i = 0; i < g_replay_frames; i++) {
+        ASSERT_EQ(g_replay_declared[i], g_replay_written[i]);
+    }
+}
+
+/* A streamed publish delivers its payload through the application callback, so
+ * the client holds no copy to rebuild from. The slot still tracks the Packet
+ * Identifier for a QoS 2 PUBREL, but the PUBLISH itself must not be replayed
+ * from a stale chunk buffer. */
+TEST(reconnect_does_not_replay_streamed_publish)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    XMEMSET(g_replay_stream_buf, 0, sizeof(g_replay_stream_buf));
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* network error: no PUBACK */
+
+    /* buffer_len is the staging chunk, total_len the whole message: the
+     * client only ever sees one chunk at a time. */
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 0x4321;
+    publish.topic_name = "sensor/temp";
+    publish.buffer = g_replay_stream_buf;
+    publish.buffer_len = (word32)REPLAY_STREAM_CHUNK;
+    publish.total_len = (word32)REPLAY_BIG_PAYLOAD_LEN;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_ex(&test_client, &publish, replay_stream_cb);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_replay_frames); /* the CONNECT only */
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+}
+
+/* An entry the replay cannot rebuild is dropped from the Session, so nothing
+ * will ever acknowledge it and the Packet Identifier the reconnect reserved for
+ * it must be given back [MQTT-2.3.1-3]. Left reserved, the next legitimate
+ * PUBLISH reusing that identifier is refused with MQTT_CODE_ERROR_PACKET_ID
+ * for the rest of the connection. */
+TEST(reconnect_dropped_replay_frees_packet_id)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    /* v3.1.1 PUBACK for packet id 0x1234, for the reuse attempt below. */
+    static const byte puback[] = { 0x40, 0x02, 0x12, 0x34 };
+    static byte small[] = "hi";
+
+    rc = test_init_client(); /* tx_buf_len = TEST_TX_BUF_SIZE (256) */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    /* Retained, but too large to rebuild in one tx_buf pass: the replay drops
+     * it rather than putting a truncated packet on the wire. */
+    XMEMSET(g_replay_big_payload, 0x5A, sizeof(g_replay_big_payload));
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        g_replay_big_payload, (word32)REPLAY_BIG_PAYLOAD_LEN);
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_replay_frames); /* the CONNECT only: the entry was dropped */
+
+    /* The identifier is free again, so a new PUBLISH may take it. */
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        small, (word32)(sizeof(small) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
+/* A replay that fails on the transport must not leave the MqttConnect looking
+ * like a resume. The bundled examples reuse one MqttConnect across reconnects,
+ * so a leftover resume marker would make the replay the first packet of the
+ * next Network Connection instead of a CONNECT [MQTT-3.1.0-1]. */
+TEST(failed_replay_does_not_skip_next_connect)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* Frame 1 is the CONNECT, frame 2 the replayed PUBLISH: fail that one. */
+    replay_mock_reset();
+    g_replay_fail_at = 2;
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_replay_frames);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* Reconnect on the same MqttConnect object, as the examples do. The first
+     * packet on the new connection must be the CONNECT. */
+    replay_mock_reset();
+    test_net.write = replay_mock_write;
+    test_net.read = mock_net_read_canned;
+    g_canned_pos = 0;
+    /* No test_client_connect_sent() here: MqttClient_NetDisconnect cleared
+     * MQTT_CLIENT_FLAG_CONNECT_SENT, which is what a real reconnect looks
+     * like, and what the CONNECT-once guard [MQTT-3.1.0-2] requires. */
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_TRUE(g_replay_frames >= 1);
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+}
+
+#ifdef WOLFMQTT_NONBLOCK
+/* A replay that has to be resumed returns to the caller before the tail of
+ * MqttClient_Connect, so the auto keep-alive scheduler has to be armed on that
+ * path too. Otherwise the application is told the connect succeeded, no
+ * PINGREQ is ever sent, and the broker drops the client at 1.5x the keep-alive
+ * interval [MQTT-3.1.2-24]. */
+TEST(replay_resume_arms_keep_alive)
+{
+    int rc;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    test_client.keep_alive_sec = 0;
+
+    /* Defer frame 2 (the replayed PUBLISH) once so the connect returns
+     * MQTT_CODE_CONTINUE and the application has to call it again. */
+    replay_mock_reset();
+    g_replay_cont_at = 2;
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_replay_cont_done); /* the resume path really ran */
+    ASSERT_EQ(2, g_replay_frames);
+
+    /* Armed from the CONNECT the application asked for. */
+    ASSERT_EQ(60, (int)test_client.keep_alive_sec);
+}
+#endif /* WOLFMQTT_NONBLOCK */
 #endif /* !WOLFMQTT_NO_SESSION_REPLAY */
 
 
@@ -3743,6 +4206,89 @@ TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected)
      * client must NOT emit a PUBREL. Directly pin that no PUBREL was written. */
     ASSERT_FALSE(g_pubrel_written);
 }
+
+/* [MQTT-2.3.1-3] A Packet Identifier is available for reuse once the exchange
+ * it belongs to is complete. A rejecting PUBREC completes the QoS 2 exchange
+ * ([MQTT-4.3.3]: no PUBREL, no PUBCOMP), so the identifier must be released
+ * there. Left reserved, the next legitimate PUBLISH reusing it is refused with
+ * MQTT_CODE_ERROR_PACKET_ID. */
+TEST(publish_qos2_v5_pubrec_reject_frees_packet_id)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v5 PUBREC: type=0x50, remain=3, packet_id=11, reason=0x87. */
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x0B, 0x87 };
+    /* v5 PUBACK for the second (QoS 1) publish reusing the same id. */
+    static const byte puback[] = { 0x40, 0x03, 0x00, 0x0B, 0x00 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 11;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, pubrec, (int)sizeof(pubrec),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+
+    /* Same identifier, new message: the rejected exchange is over, so this
+     * must be accepted rather than refused as still in flight. */
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 11;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+/* The server explicitly rejected the message, so it is no longer Session state
+ * [MQTT-4.4.0-1] asks to be re-sent. Replaying it would push a PUBLISH with
+ * DUP=1 that the broker already refused. */
+TEST(publish_qos2_v5_pubrec_reject_not_replayed_on_reconnect)
+{
+    int rc;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    static const byte pubrec[] = { 0x50, 0x03, 0x00, 0x0B, 0x87 };
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_2;
+    publish.packet_id = 11;
+    publish.topic_name = "test/topic";
+    publish.buffer = payload;
+    publish.total_len = (word32)(sizeof(payload) - 1);
+    publish.buffer_len = publish.total_len;
+
+    rc = run_publish_with_canned_resp(&publish, pubrec, (int)sizeof(pubrec),
+        MQTT_CONNECT_PROTOCOL_LEVEL_5);
+    ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_replay_frames); /* the CONNECT only */
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+}
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
 
 /* [MQTT-4.9] A PUBREC rejection (reason >= 0x80) ends the QoS 2 exchange and
  * frees the reserved Receive Maximum unit. MqttPublishMsg must credit it back
@@ -6128,12 +6674,22 @@ void run_mqtt_client_tests(void)
     WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(wait_message_puback_survives_shared_ack_overwrite);
 #endif
+    RUN_TEST(net_connect_clears_connect_sent_flag);
+    RUN_TEST(reconnect_on_reused_connect_object_waits_for_connack);
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
     RUN_TEST(reconnect_replays_unacked_qos1_publish);
     RUN_TEST(reconnect_without_session_present_replays_nothing);
     RUN_TEST(reconnect_does_not_replay_acked_publish);
 #if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(reconnect_replays_unacked_pubrel);
+#endif
+    RUN_TEST(reconnect_drops_replay_larger_than_tx_buf);
+    RUN_TEST(reconnect_replays_at_most_pool_size);
+    RUN_TEST(reconnect_does_not_replay_streamed_publish);
+    RUN_TEST(reconnect_dropped_replay_frees_packet_id);
+    RUN_TEST(failed_replay_does_not_skip_next_connect);
+#ifdef WOLFMQTT_NONBLOCK
+    RUN_TEST(replay_resume_arms_keep_alive);
 #endif
 #endif
     RUN_TEST(disconnect_null_client);
@@ -6181,6 +6737,10 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_success_returns_success);
     RUN_TEST(publish_qos2_v5_pubrec_rejection_returns_publish_rejected);
+    RUN_TEST(publish_qos2_v5_pubrec_reject_frees_packet_id);
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    RUN_TEST(publish_qos2_v5_pubrec_reject_not_replayed_on_reconnect);
+#endif
     RUN_TEST(publish_qos2_v5_pubrec_reject_restores_receive_max);
     RUN_TEST(connect_clean0_preserves_qos2_dedup);
     RUN_TEST(connect_clientid_change_clears_qos2_dedup);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2189,6 +2189,328 @@ TEST(unsubscribe_too_many_reason_codes_is_malformed)
 #endif /* WOLFMQTT_V5 */
 
 /* ============================================================================
+ * Outbound Packet Identifier occupancy
+ *
+ * [MQTT-2.3.1-2] "Each time a Client sends a new packet of one of these types
+ * it MUST assign it a currently unused Packet Identifier", and [MQTT-2.3.1-3]
+ * makes it reusable only "after the Client has processed the corresponding
+ * acknowledgement packet". These run in every build: the pending-response list
+ * that used to be the only guard is WOLFMQTT_MULTITHREAD-only, and it drops
+ * its entry as soon as the call returns even when no acknowledgement arrived.
+ * ============================================================================ */
+
+/* Drive one QoS>0 publish whose acknowledgement never arrives: the mock read
+ * fails, so the PUBLISH is on the wire and unacknowledged when the call
+ * returns. Works in both blocking and nonblocking builds because the read
+ * error is reported immediately either way. */
+static int run_publish_unacked(MqttPublish* publish)
+{
+    int rc;
+    int i;
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* network error */
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, publish);
+    }
+    return rc;
+}
+
+static void init_qos_publish(MqttPublish* publish, MqttQoS qos,
+    word16 packet_id, const char* topic, byte* payload, word32 len)
+{
+    XMEMSET(publish, 0, sizeof(*publish));
+    publish->qos = qos;
+    publish->packet_id = packet_id;
+    publish->topic_name = topic;
+    publish->buffer = payload;
+    publish->total_len = len;
+    publish->buffer_len = len;
+}
+
+TEST(publish_qos1_reuse_packet_id_before_puback_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* A second, different message reusing the still-unacknowledged Packet
+     * Identifier must be refused before anything reaches the wire. */
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/humidity",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MqttClient_Publish(&test_client, &publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* Positive control: a currently unused identifier is still accepted while
+     * 0x1234 is in flight, so the guard is not refusing every publish. */
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1235, "sensor/humidity",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(2, g_frames_written);
+}
+
+/* [MQTT-3.3.1-1] A re-delivery attempt of the same PUBLISH carries DUP=1 and
+ * [MQTT-2.3.1-3] requires it to keep its original Packet Identifier, so the
+ * guard must let a retransmission through. */
+TEST(publish_qos1_retransmit_reuses_packet_id)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    publish.duplicate = 1;
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(2, g_frames_written);
+}
+
+/* [MQTT-2.3.1-3] For QoS 2 the identifier is released by PUBCOMP, so it is
+ * still in use after the PUBLISH has gone out unacknowledged. */
+TEST(publish_qos2_reuse_packet_id_before_pubcomp_rejected)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_2, 0x2233, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    init_qos_publish(&publish, MQTT_QOS_2, 0x2233, "sensor/humidity",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MqttClient_Publish(&test_client, &publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+    ASSERT_EQ(1, g_frames_written);
+}
+
+/* Processing the PUBACK releases the identifier [MQTT-2.3.1-3], so the same
+ * value is legal on the next message. Pins the release side of the guard. */
+TEST(publish_qos1_packet_id_reusable_after_puback)
+{
+    int rc;
+    int i;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* v3.1.1 PUBACK: type 0x40, Remaining Length 2, Packet Identifier 0x1234. */
+    static const byte puback[] = { 0x40, 0x02, 0x12, 0x34 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    g_canned_pos = 0; /* replay the same PUBACK for the second publish */
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/humidity",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(2, g_frames_written);
+}
+
+/* [MQTT-2.3.1-2] applies to SUBSCRIBE as well; SUBACK releases the
+ * identifier. SUBSCRIBE has no DUP bit, so a repeat cannot be told apart from
+ * a new subscription and is refused. */
+TEST(subscribe_reuse_packet_id_before_suback_rejected)
+{
+    int rc;
+    int i;
+    MqttSubscribe subscribe;
+    MqttTopic topic;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* no SUBACK ever arrives */
+
+    XMEMSET(&subscribe, 0, sizeof(subscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "sensor/temp";
+    topic.qos = MQTT_QOS_0;
+    subscribe.packet_id = 0x1234;
+    subscribe.topic_count = 1;
+    subscribe.topics = &topic;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Subscribe(&test_client, &subscribe);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* A second, different SUBSCRIBE on the same identifier is refused. */
+    XMEMSET(&subscribe, 0, sizeof(subscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "sensor/humidity";
+    topic.qos = MQTT_QOS_0;
+    subscribe.packet_id = 0x1234;
+    subscribe.topic_count = 1;
+    subscribe.topics = &topic;
+
+    rc = MqttClient_Subscribe(&test_client, &subscribe);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    /* Positive control: another identifier still goes out. */
+    subscribe.packet_id = 0x1235;
+    subscribe.stat.write = MQTT_MSG_BEGIN;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Subscribe(&test_client, &subscribe);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(2, g_frames_written);
+}
+
+/* Same rule for UNSUBSCRIBE, released by UNSUBACK. */
+TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected)
+{
+    int rc;
+    int i;
+    MqttUnsubscribe unsubscribe;
+    MqttTopic topic;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* no UNSUBACK ever arrives */
+
+    XMEMSET(&unsubscribe, 0, sizeof(unsubscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "sensor/temp";
+    unsubscribe.packet_id = 0x1234;
+    unsubscribe.topic_count = 1;
+    unsubscribe.topics = &topic;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Unsubscribe(&test_client, &unsubscribe);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(1, g_frames_written);
+
+    XMEMSET(&unsubscribe, 0, sizeof(unsubscribe));
+    XMEMSET(&topic, 0, sizeof(topic));
+    topic.topic_filter = "sensor/humidity";
+    unsubscribe.packet_id = 0x1234;
+    unsubscribe.topic_count = 1;
+    unsubscribe.topics = &topic;
+
+    rc = MqttClient_Unsubscribe(&test_client, &unsubscribe);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+    ASSERT_EQ(1, g_frames_written);
+}
+
+/* The identifiers were in use on one Network Connection only; closing it
+ * clears them, since the client keeps no outbound session state across one. */
+TEST(net_disconnect_frees_in_flight_packet_ids)
+{
+    int rc;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    g_frames_written = 0;
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    test_net.disconnect = mock_net_disconnect;
+    rc = MqttClient_NetDisconnect(&test_client);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    test_client_connect_sent();
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+    ASSERT_EQ(2, g_frames_written);
+}
+
+/* ============================================================================
  * MqttClient_Disconnect Tests
  * ============================================================================ */
 
@@ -5318,6 +5640,13 @@ void run_mqtt_client_tests(void)
 #endif
 
     /* MqttClient_Disconnect tests */
+    RUN_TEST(publish_qos1_reuse_packet_id_before_puback_rejected);
+    RUN_TEST(publish_qos1_retransmit_reuses_packet_id);
+    RUN_TEST(publish_qos2_reuse_packet_id_before_pubcomp_rejected);
+    RUN_TEST(publish_qos1_packet_id_reusable_after_puback);
+    RUN_TEST(subscribe_reuse_packet_id_before_suback_rejected);
+    RUN_TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected);
+    RUN_TEST(net_disconnect_frees_in_flight_packet_ids);
     RUN_TEST(disconnect_null_client);
 
     /* MqttClient_GetProtocolVersion tests */

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2759,6 +2759,37 @@ TEST(reconnect_on_reused_connect_object_waits_for_connack)
     }
 }
 
+/* [MQTT-3.14.4-1] "After sending a DISCONNECT Packet the Client MUST NOT send
+ * any more Control Packets on that Network Connection." The send APIs enforce
+ * that the same way they refuse packets before CONNECT. */
+TEST(publish_after_disconnect_rejected)
+{
+    int rc;
+    MqttDisconnect disconnect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+
+    test_net.write = mock_net_write_accept;
+    XMEMSET(&disconnect, 0, sizeof(disconnect));
+    rc = MQTT_CODE_CONTINUE;
+    while (rc == MQTT_CODE_CONTINUE) {
+        rc = MqttClient_Disconnect_ex(&test_client, &disconnect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* The transport is still up, but the MQTT session is over. */
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    g_frames_written = 0;
+    rc = MqttClient_Publish(&test_client, &publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+}
+
 /* [MQTT-3.1.0-1] A new Network Connection starts with no MQTT packet sent, so
  * MqttClient_NetConnect must clear MQTT_CLIENT_FLAG_CONNECT_SENT as it sets
  * MQTT_CLIENT_FLAG_IS_CONNECTED. Otherwise a client reconnecting after a
@@ -2845,6 +2876,16 @@ static int run_reconnect(MqttConnect* connect, int session_present)
     return run_reconnect_with(connect, session_present, mock_net_write_accept);
 }
 
+/* Complete a first handshake with the ClientId the reconnect will use. The
+ * client binds outbound Session state to the ClientId that created it
+ * [MQTT-3.1.3-2], so a test that publishes before ever connecting has no
+ * Session to resume and nothing would be replayed. Session Present = 0: this
+ * is a new Session. */
+static int run_initial_connect(MqttConnect* connect)
+{
+    return run_reconnect_with(connect, 0, mock_net_write_accept);
+}
+
 /* An unacknowledged QoS 1 PUBLISH is re-sent after a resumed Session, with the
  * original Packet Identifier and DUP set [MQTT-4.4.0-1], [MQTT-3.3.1-1]. */
 TEST(reconnect_replays_unacked_qos1_publish)
@@ -2856,10 +2897,13 @@ TEST(reconnect_replays_unacked_qos1_publish)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     /* Publish, no PUBACK: it stays unacknowledged Session state. */
     init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
@@ -2895,10 +2939,13 @@ TEST(reconnect_without_session_present_replays_nothing)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
         payload, (word32)(sizeof(payload) - 1));
@@ -2927,10 +2974,13 @@ TEST(reconnect_does_not_replay_acked_publish)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_canned;
@@ -2970,10 +3020,13 @@ TEST(reconnect_replays_unacked_pubrel)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     test_net.write = mock_net_write_accept;
     test_net.read = mock_net_read_canned;
@@ -3097,10 +3150,13 @@ TEST(reconnect_drops_replay_larger_than_tx_buf)
 
     rc = test_init_client(); /* tx_buf_len = TEST_TX_BUF_SIZE (256) */
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     XMEMSET(g_replay_big_payload, 0x5A, sizeof(g_replay_big_payload));
     init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
@@ -3137,10 +3193,13 @@ TEST(reconnect_replays_at_most_pool_size)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     for (i = 0; i < MQTT_MAX_REPLAY_MSGS + 1; i++) {
         init_qos_publish(&publish, MQTT_QOS_1, (word16)(0x100 + i),
@@ -3179,10 +3238,13 @@ TEST(reconnect_does_not_replay_streamed_publish)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     XMEMSET(g_replay_stream_buf, 0, sizeof(g_replay_stream_buf));
     test_net.write = mock_net_write_accept;
@@ -3230,10 +3292,13 @@ TEST(reconnect_dropped_replay_frees_packet_id)
 
     rc = test_init_client(); /* tx_buf_len = TEST_TX_BUF_SIZE (256) */
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     /* Retained, but too large to rebuild in one tx_buf pass: the replay drops
      * it rather than putting a truncated packet on the wire. */
@@ -3266,6 +3331,230 @@ TEST(reconnect_dropped_replay_frees_packet_id)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
 }
 
+/* [MQTT-3.1.3-2] The ClientId identifies the Client and its Session, so
+ * outbound Session state belongs to the ClientId that created it. A Session
+ * Present answer for a different ClientId is a different Session: replaying
+ * into it would inject one Session's messages into another. */
+TEST(reconnect_with_new_client_id_does_not_replay)
+{
+    int rc;
+    int i;
+    byte connack[4];
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* Same client object, different ClientId, server says Session Present. */
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(2, g_replay_frames); /* CONNECT + the replay for this ClientId */
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "a_different_client";
+
+    connack[0] = 0x20;
+    connack[1] = 0x02;
+    connack[2] = 0x01; /* Session Present */
+    connack[3] = 0x00;
+    test_net.write = replay_mock_write;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    /* The CONNECT only: the previous ClientId's message is not this Session's
+     * state and must not be injected into it. */
+    ASSERT_EQ(1, g_replay_frames);
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+}
+
+/* Section 3.3.3 allows a zero-byte PUBLISH payload, and [MQTT-4.4.0-1] asks
+ * for an unacknowledged one back like any other. It must be retained rather
+ * than treated as a payload the client could not copy. */
+TEST(reconnect_replays_unacked_zero_length_payload)
+{
+    int rc;
+    MqttConnect connect;
+    MqttPublish publish;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp", NULL, 0);
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* CONNECT plus the replayed empty PUBLISH, complete on the wire. */
+    ASSERT_EQ(2, g_replay_frames);
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH, g_replay_types[1]);
+    ASSERT_EQ(g_replay_declared[1], g_replay_written[1]);
+}
+
+/* An entry the replay can never re-send must not keep its Packet Identifier
+ * reserved for the life of the connection: nothing will ever acknowledge it
+ * [MQTT-2.3.1-3]. */
+TEST(reconnect_unreplayable_entry_frees_packet_id)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static const byte puback[] = { 0x40, 0x02, 0x43, 0x21 };
+    static byte small[] = "hi";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
+
+    /* Streamed publish: the payload goes out through the callback, so the
+     * client keeps no copy and the message cannot be replayed. */
+    XMEMSET(g_replay_stream_buf, 0, sizeof(g_replay_stream_buf));
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read; /* network error: no PUBACK */
+
+    XMEMSET(&publish, 0, sizeof(publish));
+    publish.qos = MQTT_QOS_1;
+    publish.packet_id = 0x4321;
+    publish.topic_name = "sensor/temp";
+    publish.buffer = g_replay_stream_buf;
+    publish.buffer_len = (word32)REPLAY_STREAM_CHUNK;
+    publish.total_len = (word32)REPLAY_BIG_PAYLOAD_LEN;
+
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish_ex(&test_client, &publish, replay_stream_cb);
+    }
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    replay_mock_reset();
+    rc = run_reconnect_with(&connect, 1, replay_mock_write);
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    ASSERT_EQ(1, g_replay_frames); /* the CONNECT only */
+
+    /* The identifier is free again, so a new PUBLISH may take it. */
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x4321, "sensor/temp",
+        small, (word32)(sizeof(small) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
+#if WOLFMQTT_MAX_QOS >= 2
+/* Count how many in-flight slots hold packet_id. */
+static int send_id_reserved(word16 packet_id)
+{
+    int i;
+    int n = 0;
+
+    for (i = 0; i < MQTT_MAX_SEND_INFLIGHT; i++) {
+        if (test_client.send_inflight[i].packet_id == packet_id) {
+            n++;
+        }
+    }
+    return n;
+}
+
+/* [MQTT-2.3.1-3] A Packet Identifier is reusable only once the exchange it
+ * belongs to completes. A QoS 2 exchange completes on PUBCOMP, so a PUBACK
+ * naming that identifier is the wrong acknowledgement and must not end it
+ * early - the reservation has to survive it. */
+TEST(qos2_publish_id_not_released_by_stray_puback)
+{
+    int rc;
+    int i;
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+    /* PUBREC for 0x2233: the client answers PUBREL and waits for PUBCOMP. */
+    static const byte pubrec[] = { 0x50, 0x02, 0x22, 0x33 };
+    /* A PUBACK naming the same identifier, which belongs to no QoS 1
+     * exchange on this connection. */
+    static const byte puback[] = { 0x40, 0x02, 0x22, 0x33 };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, pubrec, sizeof(pubrec));
+    g_canned_len = (int)sizeof(pubrec);
+    g_canned_pos = 0;
+
+    init_qos_publish(&publish, MQTT_QOS_2, 0x2233, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Publish(&test_client, &publish);
+    }
+    /* No PUBCOMP, so the exchange is still open and the id still reserved. */
+    ASSERT_TRUE(rc != MQTT_CODE_SUCCESS);
+    ASSERT_EQ(1, send_id_reserved(0x2233));
+
+    /* Feed the stray PUBACK through the read path. */
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 5 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, 10);
+    }
+
+    /* The QoS 2 exchange completes on PUBCOMP, so it is still outstanding. */
+    ASSERT_EQ(1, send_id_reserved(0x2233));
+}
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
+
 /* A replay that fails on the transport must not leave the MqttConnect looking
  * like a resume. The bundled examples reuse one MqttConnect across reconnects,
  * so a leftover resume marker would make the replay the first packet of the
@@ -3280,10 +3569,13 @@ TEST(failed_replay_does_not_skip_next_connect)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
         payload, (word32)(sizeof(payload) - 1));
@@ -3334,10 +3626,13 @@ TEST(replay_resume_arms_keep_alive)
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
-    test_client_connect_sent();
 #ifdef WOLFMQTT_V5
     test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
 #endif
+    /* Establish the Session before publishing: outbound Session state is
+     * bound to the ClientId that created it [MQTT-3.1.3-2], so a client that
+     * never completed a handshake has nothing to resume. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, run_initial_connect(&connect));
 
     init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
         payload, (word32)(sizeof(payload) - 1));
@@ -6675,6 +6970,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(wait_message_puback_survives_shared_ack_overwrite);
 #endif
     RUN_TEST(net_connect_clears_connect_sent_flag);
+    RUN_TEST(publish_after_disconnect_rejected);
     RUN_TEST(reconnect_on_reused_connect_object_waits_for_connack);
 #ifndef WOLFMQTT_NO_SESSION_REPLAY
     RUN_TEST(reconnect_replays_unacked_qos1_publish);
@@ -6687,6 +6983,12 @@ void run_mqtt_client_tests(void)
     RUN_TEST(reconnect_replays_at_most_pool_size);
     RUN_TEST(reconnect_does_not_replay_streamed_publish);
     RUN_TEST(reconnect_dropped_replay_frees_packet_id);
+    RUN_TEST(reconnect_with_new_client_id_does_not_replay);
+    RUN_TEST(reconnect_replays_unacked_zero_length_payload);
+    RUN_TEST(reconnect_unreplayable_entry_frees_packet_id);
+#if WOLFMQTT_MAX_QOS >= 2
+    RUN_TEST(qos2_publish_id_not_released_by_stray_puback);
+#endif
     RUN_TEST(failed_replay_does_not_skip_next_connect);
 #ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(replay_resume_arms_keep_alive);

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -2809,6 +2809,67 @@ TEST(publish_after_disconnect_rejected)
     ASSERT_EQ(0, g_frames_written);
 }
 
+/* [MQTT-3.1.0-2] A Client may send only one CONNECT per Network Connection.
+ * MqttClient_Disconnect writes the DISCONNECT packet but does not close the
+ * transport, so the duplicate-CONNECT guard must stay shut afterwards - the
+ * application still has to call MqttClient_NetDisconnect before reconnecting. */
+TEST(connect_after_protocol_disconnect_rejected)
+{
+    int rc;
+    int i;
+    byte connack[4];
+    MqttConnect connect;
+    MqttDisconnect disconnect;
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+    connack[0] = 0x20; connack[1] = 0x02; connack[2] = 0x00; connack[3] = 0x00;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 1;
+    connect.client_id = "disc_client";
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    XMEMSET(&disconnect, 0, sizeof(disconnect));
+    rc = MQTT_CODE_CONTINUE;
+    while (rc == MQTT_CODE_CONTINUE) {
+        rc = MqttClient_Disconnect_ex(&test_client, &disconnect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* The transport is still open, so a second CONNECT on it is refused. */
+    g_frames_written = 0;
+    g_canned_pos = 0;
+    XMEMSET(&connect.stat, 0, sizeof(connect.stat));
+    rc = MqttClient_Connect(&test_client, &connect);
+    ASSERT_EQ(MQTT_CODE_ERROR_STAT, rc);
+    ASSERT_EQ(0, g_frames_written);
+
+    /* Closing the Network Connection is what permits a new handshake. */
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+}
+
 /* [MQTT-3.1.0-1] A new Network Connection starts with no MQTT packet sent, so
  * MqttClient_NetConnect must clear MQTT_CLIENT_FLAG_CONNECT_SENT as it sets
  * MQTT_CLIENT_FLAG_IS_CONNECTED. Otherwise a client reconnecting after a
@@ -3407,6 +3468,75 @@ TEST(reconnect_with_new_client_id_does_not_replay)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     /* The CONNECT only: the previous ClientId's message is not this Session's
      * state and must not be injected into it. */
+    ASSERT_EQ(1, g_replay_frames);
+    ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
+}
+
+/* [MQTT-3.1.3-2] The Session is identified by the ClientId itself, not by a
+ * digest of it. "OjQrQFStC" and "ly5wBaLsB" share a 32-bit FNV-1a value, so a
+ * client keyed on that hash would treat the second as a resumption of the
+ * first and replay one identity's messages into the other's Session. */
+TEST(reconnect_with_hash_colliding_client_id_does_not_replay)
+{
+    int rc;
+    int i;
+    byte connack[4];
+    MqttConnect connect;
+    MqttPublish publish;
+    static byte payload[] = "hello";
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+
+    /* Establish a Session as the first of the two colliding ClientIds. */
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    test_net.disconnect = mock_net_disconnect;
+    connack[0] = 0x20; connack[1] = 0x02; connack[2] = 0x00; connack[3] = 0x00;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "OjQrQFStC";
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    init_qos_publish(&publish, MQTT_QOS_1, 0x1234, "sensor/temp",
+        payload, (word32)(sizeof(payload) - 1));
+    rc = run_publish_unacked(&publish);
+    ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
+
+    ASSERT_EQ(MQTT_CODE_SUCCESS, MqttClient_NetDisconnect(&test_client));
+
+    /* Reconnect as the colliding ClientId, server reports Session Present. */
+    replay_mock_reset();
+    connack[2] = 0x01;
+    test_net.write = replay_mock_write;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, connack, sizeof(connack));
+    g_canned_len = (int)sizeof(connack);
+    g_canned_pos = 0;
+
+    XMEMSET(&connect, 0, sizeof(connect));
+    connect.keep_alive_sec = 60;
+    connect.clean_session = 0;
+    connect.client_id = "ly5wBaLsB";
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 20 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_Connect(&test_client, &connect);
+    }
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+
+    /* The CONNECT only: this is a different Session. */
     ASSERT_EQ(1, g_replay_frames);
     ASSERT_EQ(MQTT_PACKET_TYPE_CONNECT, g_replay_types[0]);
 }
@@ -5503,9 +5633,12 @@ TEST(disconnect_clears_recv_quota_ownership)
 TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
 {
     int rc;
+    int i;
     MqttPublish publish1, publish2;
     static byte payload1[] = "hello1";
     static byte payload2[] = "hello2";
+    /* v3.1.1 PUBACK for packet id 7. */
+    static const byte puback[] = { 0x40, 0x02, 0x00, 0x07 };
 
     rc = test_init_client();
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
@@ -5552,8 +5685,11 @@ TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
     rc = MqttClient_Publish_WriteOnly(&test_client, &publish2, NULL);
     ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
 
-    /* After the in-flight entry is released, the same Packet Identifier
-     * becomes reusable. */
+    /* Cancelling publish1 does NOT hand its Packet Identifier back: the
+     * PUBLISH is already on the wire, so the server may still answer it and
+     * that PUBACK would complete whatever new exchange had taken the
+     * identifier. [MQTT-2.3.1-3] makes it reusable only once the
+     * acknowledgement has been processed. */
     rc = MqttClient_CancelMessage(&test_client, (MqttObject*)&publish1);
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
 
@@ -5564,6 +5700,21 @@ TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
     publish1.buffer = payload1;
     publish1.total_len = (word32)(sizeof(payload1) - 1);
     publish1.buffer_len = publish1.total_len;
+    rc = MqttClient_Publish_WriteOnly(&test_client, &publish1, NULL);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+
+    /* Processing the acknowledgement is what releases it. */
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, puback, sizeof(puback));
+    g_canned_len = (int)sizeof(puback);
+    g_canned_pos = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 5 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, 10);
+    }
+
+    publish1.stat.write = MQTT_MSG_BEGIN;
+    publish1.buffer_pos = 0;
     rc = MqttClient_Publish_WriteOnly(&test_client, &publish1, NULL);
     ASSERT_EQ(MQTT_CODE_CONTINUE, rc);
 
@@ -7016,6 +7167,7 @@ void run_mqtt_client_tests(void)
 #endif
     RUN_TEST(net_connect_clears_connect_sent_flag);
     RUN_TEST(publish_after_disconnect_rejected);
+    RUN_TEST(connect_after_protocol_disconnect_rejected);
     RUN_TEST(reconnect_on_reused_connect_object_waits_for_connack);
 #if !defined(WOLFMQTT_NO_SESSION_REPLAY) && WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(reconnect_replays_unacked_qos1_publish);
@@ -7029,6 +7181,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(reconnect_does_not_replay_streamed_publish);
     RUN_TEST(reconnect_dropped_replay_frees_packet_id);
     RUN_TEST(reconnect_with_new_client_id_does_not_replay);
+    RUN_TEST(reconnect_with_hash_colliding_client_id_does_not_replay);
     RUN_TEST(reconnect_replays_unacked_zero_length_payload);
     RUN_TEST(reconnect_unreplayable_entry_frees_packet_id);
 #if WOLFMQTT_MAX_QOS >= 2

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -1350,6 +1350,7 @@ TEST(publish_qos1_v5_receive_max_quota_exhausted_rejects_before_send)
 
 #ifdef WOLFMQTT_NONBLOCK
 /* Quota decrements once per publish, not per non-blocking re-entry. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes)
 {
     int rc;
@@ -1397,6 +1398,7 @@ TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(5, test_client.server_recv_max);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 #endif /* WOLFMQTT_NONBLOCK */
 
 /* These two exercise MqttClient_CancelMessage, which is only a public API when
@@ -2221,6 +2223,7 @@ TEST(unsubscribe_too_many_reason_codes_is_malformed)
  * fails, so the PUBLISH is on the wire and unacknowledged when the call
  * returns. Works in both blocking and nonblocking builds because the read
  * error is reported immediately either way. */
+#if WOLFMQTT_MAX_QOS >= 1
 static int run_publish_unacked(MqttPublish* publish)
 {
     int rc;
@@ -2236,6 +2239,8 @@ static int run_publish_unacked(MqttPublish* publish)
     return rc;
 }
 
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
+
 static void init_qos_publish(MqttPublish* publish, MqttQoS qos,
     word16 packet_id, const char* topic, byte* payload, word32 len)
 {
@@ -2248,6 +2253,7 @@ static void init_qos_publish(MqttPublish* publish, MqttQoS qos,
     publish->buffer_len = len;
 }
 
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_reuse_packet_id_before_puback_rejected)
 {
     int rc;
@@ -2284,10 +2290,12 @@ TEST(publish_qos1_reuse_packet_id_before_puback_rejected)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(2, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* [MQTT-3.3.1-1] A re-delivery attempt of the same PUBLISH carries DUP=1 and
  * [MQTT-2.3.1-3] requires it to keep its original Packet Identifier, so the
  * guard must let a retransmission through. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_retransmit_reuses_packet_id)
 {
     int rc;
@@ -2315,7 +2323,9 @@ TEST(publish_qos1_retransmit_reuses_packet_id)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(2, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
+#if WOLFMQTT_MAX_QOS >= 2
 /* [MQTT-2.3.1-3] For QoS 2 the identifier is released by PUBCOMP, so it is
  * still in use after the PUBLISH has gone out unacknowledged. */
 TEST(publish_qos2_reuse_packet_id_before_pubcomp_rejected)
@@ -2344,9 +2354,11 @@ TEST(publish_qos2_reuse_packet_id_before_pubcomp_rejected)
     ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
     ASSERT_EQ(1, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 2 */
 
 /* Processing the PUBACK releases the identifier [MQTT-2.3.1-3], so the same
  * value is legal on the next message. Pins the release side of the guard. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_packet_id_reusable_after_puback)
 {
     int rc;
@@ -2389,6 +2401,7 @@ TEST(publish_qos1_packet_id_reusable_after_puback)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(2, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* [MQTT-2.3.1-2] applies to SUBSCRIBE as well; SUBACK releases the
  * identifier. SUBSCRIBE has no DUP bit, so a repeat cannot be told apart from
@@ -2502,6 +2515,7 @@ TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected)
  * MQTT_CLIENT_FLAG_IS_CONNECTED on a fatal error, the application calls
  * MqttClient_NetConnect (which clears MQTT_CLIENT_FLAG_CONNECT_SENT) and then
  * MqttClient_Connect. Guards the reset against being compiled out. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(connect_frees_in_flight_packet_ids)
 {
     int rc;
@@ -2554,12 +2568,14 @@ TEST(connect_frees_in_flight_packet_ids)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(1, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* Past MQTT_MAX_SEND_INFLIGHT the table cannot record any more identifiers, so
  * the collision check is best effort by design: the send is allowed rather
  * than refused, since an application may legitimately keep more than that many
  * packets in flight. Pins that contract so a later change to fail closed is a
  * deliberate one. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(send_inflight_table_full_still_allows_new_packet_id)
 {
     int rc;
@@ -2594,9 +2610,11 @@ TEST(send_inflight_table_full_still_allows_new_packet_id)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(1, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* The identifiers were in use on one Network Connection only; closing it
  * clears them, since the client keeps no outbound session state across one. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(net_disconnect_frees_in_flight_packet_ids)
 {
     int rc;
@@ -2627,6 +2645,7 @@ TEST(net_disconnect_frees_in_flight_packet_ids)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(2, g_frames_written);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* [MQTT-4.6.0-2] "It MUST send PUBACK packets in the order in which the
  * corresponding PUBLISH packets were received". The acknowledgement used to be
@@ -2826,7 +2845,7 @@ TEST(net_connect_clears_connect_sent_flag)
  * Session state, and section 4.4 requires them re-sent with their original
  * Packet Identifiers when the Client reconnects with CleanSession 0.
  * ============================================================================ */
-#ifndef WOLFMQTT_NO_SESSION_REPLAY
+#if !defined(WOLFMQTT_NO_SESSION_REPLAY) && WOLFMQTT_MAX_QOS >= 1
 /* Reconnect against a CONNACK carrying the given Session Present bit and
  * return the result, so a test can observe what the replay put on the wire. */
 static int run_reconnect_with(MqttConnect* connect, int session_present,
@@ -3656,7 +3675,7 @@ TEST(replay_resume_arms_keep_alive)
     ASSERT_EQ(60, (int)test_client.keep_alive_sec);
 }
 #endif /* WOLFMQTT_NONBLOCK */
-#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY && WOLFMQTT_MAX_QOS >= 1 */
 
 
 /* ============================================================================
@@ -4259,7 +4278,7 @@ TEST(publish_stream_cb_nonblock_resume_no_tail_drop)
 }
 #endif /* WOLFMQTT_NONBLOCK */
 
-#ifdef WOLFMQTT_V5
+#if defined(WOLFMQTT_V5) && WOLFMQTT_MAX_QOS >= 1
 /* Drives one QoS>0 publish to completion against the canned-response mock and
  * returns the final MqttClient_Publish result. The caller stages the broker's
  * PUBACK/PUBCOMP (plus any intermediate PUBREC for QoS 2) in g_canned_buf. */
@@ -4296,6 +4315,7 @@ static int run_publish_with_canned_resp(MqttPublish* publish,
  * MQTT_CODE_ERROR_PUBLISH_REJECTED rather than MQTT_CODE_SUCCESS, else the
  * application proceeds as if the message was delivered. This pins the
  * detection that the publish path previously lacked (known issue 3626). */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected)
 {
     int rc;
@@ -4318,10 +4338,12 @@ TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected)
     ASSERT_EQ(MQTT_CODE_ERROR_PUBLISH_REJECTED, rc);
     ASSERT_EQ(MQTT_REASON_NOT_AUTHORIZED, publish.resp.reason_code);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* A v5 PUBACK with reason code Success (0x00) means the broker accepted the
  * message; MqttClient_Publish must still return success and not false-trip the
  * new rejection check. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_v5_success_returns_success)
 {
     int rc;
@@ -4344,6 +4366,7 @@ TEST(publish_qos1_v5_success_returns_success)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(MQTT_REASON_SUCCESS, publish.resp.reason_code);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* Not every non-zero v5 reason code is a rejection: the high bit distinguishes
  * error (>= 0x80) from success-class codes. A broker legitimately returns
@@ -4351,6 +4374,7 @@ TEST(publish_qos1_v5_success_returns_success)
  * subscriptions, and the message WAS accepted. The check uses
  * (reason_code & 0x80) precisely so 0x10 stays a success; this pins that
  * boundary against a regression to e.g. (reason_code != 0). */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_qos1_v5_no_matching_subscribers_returns_success)
 {
     int rc;
@@ -4373,6 +4397,7 @@ TEST(publish_qos1_v5_no_matching_subscribers_returns_success)
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
     ASSERT_EQ(MQTT_REASON_NO_MATCH_SUB, publish.resp.reason_code);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 #if WOLFMQTT_MAX_QOS >= 2
 /* A QoS-capped build refuses a QoS 2 publish before it reaches the wire, so
@@ -4974,6 +4999,7 @@ TEST(connect_v5_app_receive_max_preserved)
  * for protocol level < 5. Pre-seed resp.reason_code with a failure byte to
  * prove the protocol_level guard prevents a stale value from being misread as
  * a broker rejection. */
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_v311_ack_not_misread_as_rejected)
 {
     int rc;
@@ -4997,6 +5023,7 @@ TEST(publish_v311_ack_not_misread_as_rejected)
 
     ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
     WOLFMQTT_MAX_QOS >= 2
@@ -5472,6 +5499,7 @@ TEST(disconnect_clears_recv_quota_ownership)
  * response list is in use) and NONBLOCK (so the write-only publish leaves
  * the pendResp in the list across the call boundary). */
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+#if WOLFMQTT_MAX_QOS >= 1
 TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
 {
     int rc;
@@ -5543,6 +5571,7 @@ TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
     (void)MqttClient_CancelMessage(&test_client, (MqttObject*)&publish1);
     (void)MqttClient_CancelMessage(&test_client, (MqttObject*)&publish2);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 
 /* Cross-packet-type collision: an in-flight SUBSCRIBE_ACK and a new QoS 1
  * publish must not share a Packet Identifier. The MQTT spec treats the
@@ -5551,6 +5580,7 @@ TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id)
  * collision regardless of whether the existing entry is a PUBLISH_ACK,
  * SUBSCRIBE_ACK, UNSUBSCRIBE_ACK, etc. This test guards against a future
  * narrowing of the check to a single packet_type family. */
+#if WOLFMQTT_MAX_QOS >= 1
 static int mock_net_read_continue(void *context, byte* buf, int buf_len,
     int timeout_ms)
 {
@@ -5607,6 +5637,7 @@ TEST(subscribe_in_flight_blocks_publish_with_same_packet_id)
     (void)MqttClient_CancelMessage(&test_client, (MqttObject*)&subscribe);
     (void)MqttClient_CancelMessage(&test_client, (MqttObject*)&publish);
 }
+#endif /* WOLFMQTT_MAX_QOS >= 1 */
 #endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK */
 
 
@@ -6956,15 +6987,29 @@ void run_mqtt_client_tests(void)
 #endif
 
     /* MqttClient_Disconnect tests */
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_reuse_packet_id_before_puback_rejected);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_retransmit_reuses_packet_id);
+#endif
+#if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(publish_qos2_reuse_packet_id_before_pubcomp_rejected);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_packet_id_reusable_after_puback);
+#endif
     RUN_TEST(subscribe_reuse_packet_id_before_suback_rejected);
     RUN_TEST(unsubscribe_reuse_packet_id_before_unsuback_rejected);
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(connect_frees_in_flight_packet_ids);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(send_inflight_table_full_still_allows_new_packet_id);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(net_disconnect_frees_in_flight_packet_ids);
+#endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
     WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(wait_message_puback_survives_shared_ack_overwrite);
@@ -6972,7 +7017,7 @@ void run_mqtt_client_tests(void)
     RUN_TEST(net_connect_clears_connect_sent_flag);
     RUN_TEST(publish_after_disconnect_rejected);
     RUN_TEST(reconnect_on_reused_connect_object_waits_for_connack);
-#ifndef WOLFMQTT_NO_SESSION_REPLAY
+#if !defined(WOLFMQTT_NO_SESSION_REPLAY) && WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(reconnect_replays_unacked_qos1_publish);
     RUN_TEST(reconnect_without_session_present_replays_nothing);
     RUN_TEST(reconnect_does_not_replay_acked_publish);
@@ -7032,9 +7077,15 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_stream_cb_nonblock_resume_no_tail_drop);
 #endif
 #ifdef WOLFMQTT_V5
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_v5_broker_rejection_returns_publish_rejected);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_v5_success_returns_success);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_v5_no_matching_subscribers_returns_success);
+#endif
 #if WOLFMQTT_MAX_QOS >= 2
     RUN_TEST(publish_qos2_v5_broker_rejection_returns_publish_rejected);
     RUN_TEST(publish_qos2_v5_success_returns_success);
@@ -7051,14 +7102,18 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_v5_advertises_receive_max);
     RUN_TEST(connect_v5_app_receive_max_preserved);
 #endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_v311_ack_not_misread_as_rejected);
+#endif
     RUN_TEST(publish_v5_topic_alias_zero_rejected);
     RUN_TEST(publish_v5_topic_alias_exceeds_max_rejected);
     RUN_TEST(publish_v5_subscription_id_rejected);
     RUN_TEST(publish_v5_oversized_packet_rejected_before_write);
     RUN_TEST(publish_v5_within_max_packet_size_allowed);
 #ifdef WOLFMQTT_NONBLOCK
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_qos1_v5_receive_max_quota_decrements_once_and_replenishes);
+#endif
 #endif
     RUN_TEST(publish_qos1_v5_receive_max_quota_exhausted_rejects_before_send);
 #if defined(WOLFMQTT_MULTITHREAD) || defined(WOLFMQTT_NONBLOCK)
@@ -7072,7 +7127,8 @@ void run_mqtt_client_tests(void)
     RUN_TEST(publish_qos2_v5_pubrec_rejection_multithread_reader);
     RUN_TEST(publish_qos2_v5_pubrec_state_multithread_reader);
 #endif
-#ifdef WOLFMQTT_MULTITHREAD
+/* Every write-only publish test drives a QoS > 0 message. */
+#if defined(WOLFMQTT_MULTITHREAD) && WOLFMQTT_MAX_QOS >= 1
 #ifdef WOLFMQTT_NONBLOCK
     RUN_TEST(publish_writeonly_v5_receive_max_quota_exhausted_rejects);
     RUN_TEST(publish_writeonly_v5_receive_max_released_on_puback);
@@ -7087,8 +7143,12 @@ void run_mqtt_client_tests(void)
 #endif
 #endif
 #if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK)
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(publish_writeonly_rejects_duplicate_in_flight_packet_id);
+#endif
+#if WOLFMQTT_MAX_QOS >= 1
     RUN_TEST(subscribe_in_flight_blocks_publish_with_same_packet_id);
+#endif
 #endif
 
     /* MqttClient_WaitMessage tests */

--- a/tests/test_mqtt_client.c
+++ b/tests/test_mqtt_client.c
@@ -385,6 +385,10 @@ static int g_last_ack_written;
  * the 4..7 range that g_last_ack_written tracks. */
 static int g_frames_written;
 
+/* Every PUBLISH-response packet id written to the wire, in order. */
+static int g_ack_ids[8];
+static int g_ack_id_count;
+
 /* Packet id carried by the most recent PUBLISH-response frame written to the
  * wire. For a v3.1.1 ack the two-byte id sits right after the fixed header, so a
  * test can confirm the client echoed the id of the PUBLISH it is acknowledging. */
@@ -423,6 +427,12 @@ static int mock_net_write_accept(void *context, const byte* buf, int buf_len,
             g_last_ack_written = ack_type;
             if (buf_len >= 4) {
                 g_last_ack_id = (buf[2] << 8) | buf[3];
+                /* Keep the full sequence so a test can check [MQTT-4.6.0-2]
+                 * ordering, not just the last value. */
+                if (g_ack_id_count <
+                        (int)(sizeof(g_ack_ids) / sizeof(g_ack_ids[0]))) {
+                    g_ack_ids[g_ack_id_count++] = g_last_ack_id;
+                }
             }
         }
     }
@@ -2609,6 +2619,83 @@ TEST(net_disconnect_frees_in_flight_packet_ids)
     ASSERT_EQ(MQTT_CODE_ERROR_NETWORK, rc);
     ASSERT_EQ(2, g_frames_written);
 }
+
+/* [MQTT-4.6.0-2] "It MUST send PUBACK packets in the order in which the
+ * corresponding PUBLISH packets were received". The acknowledgement used to be
+ * staged in client->packetAck, a field every reader shares. A second thread
+ * finishing its own PUBLISH read overwrites it in the window between the first
+ * thread dropping the read lock and taking the send lock, so the first ack
+ * went out carrying the second id and the first id was never acknowledged.
+ *
+ * The window is reproduced deterministically rather than raced: the ack write
+ * is deferred (as it is when another write holds the send lock), the shared
+ * field is then overwritten the way a second reader would, and the deferred
+ * ack is flushed. It must still carry the id it was staged with.
+ */
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
+    WOLFMQTT_MAX_QOS >= 1
+static int mock_msg_cb_accept(MqttClient* client, MqttMessage* msg,
+    byte msg_new, byte msg_done)
+{
+    (void)client; (void)msg; (void)msg_new; (void)msg_done;
+    return MQTT_CODE_SUCCESS;
+}
+
+TEST(wait_message_puback_survives_shared_ack_overwrite)
+{
+    int rc;
+    int i;
+    /* v3.1.1 QoS 1 PUBLISH: topic "a", packet id 1, payload "h". */
+    static const byte publish_id1[] = {
+        0x32, 0x06, 0x00, 0x01, 'a', 0x00, 0x01, 'h'
+    };
+
+    rc = test_init_client();
+    ASSERT_EQ(MQTT_CODE_SUCCESS, rc);
+    test_client_connect_sent();
+#ifdef WOLFMQTT_V5
+    test_client.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+#endif
+    test_client.msg_cb = mock_msg_cb_accept;
+
+    g_ack_id_count = 0;
+    g_last_ack_id = 0;
+    test_net.write = mock_net_write_accept;
+    test_net.read = mock_net_read_canned;
+    XMEMCPY(g_canned_buf, publish_id1, sizeof(publish_id1));
+    g_canned_len = (int)sizeof(publish_id1);
+    g_canned_pos = 0;
+
+    /* An in-progress write makes MqttWriteStart defer, so the PUBLISH is read
+     * and its ack staged but not yet encoded - exactly the window. */
+    test_client.write.isActive = 1;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+    ASSERT_EQ(MQTT_PACKET_TYPE_PUBLISH_ACK,
+        (int)test_client.msg.stat.ackPacketType);
+    ASSERT_EQ(1, (int)test_client.msg.stat.ackPacketId);
+    ASSERT_EQ(0, g_ack_id_count); /* nothing on the wire yet */
+
+    /* A second reader completing its own PUBLISH read replaces the shared
+     * field. Pre-fix this is the value the encoder would have used. */
+    XMEMSET(&test_client.packetAck, 0, sizeof(test_client.packetAck));
+    test_client.packetAck.packet_type = MQTT_PACKET_TYPE_PUBLISH_ACK;
+    test_client.packetAck.packet_id = 0x2222;
+
+    /* Release the write path and let the deferred ack go out. */
+    test_client.write.isActive = 0;
+    rc = MQTT_CODE_CONTINUE;
+    for (i = 0; i < 10 && rc == MQTT_CODE_CONTINUE; i++) {
+        rc = MqttClient_WaitMessage(&test_client, TEST_CMD_TIMEOUT_MS);
+    }
+
+    /* The ack carries the id it was staged with, not the overwritten one. */
+    ASSERT_TRUE(g_ack_id_count >= 1);
+    ASSERT_EQ(1, g_ack_ids[0]);
+}
+#endif /* WOLFMQTT_MULTITHREAD && WOLFMQTT_NONBLOCK && WOLFMQTT_MAX_QOS >= 1 */
 
 /* ============================================================================
  * MqttClient_Disconnect Tests
@@ -5833,6 +5920,10 @@ void run_mqtt_client_tests(void)
     RUN_TEST(connect_frees_in_flight_packet_ids);
     RUN_TEST(send_inflight_table_full_still_allows_new_packet_id);
     RUN_TEST(net_disconnect_frees_in_flight_packet_ids);
+#if defined(WOLFMQTT_MULTITHREAD) && defined(WOLFMQTT_NONBLOCK) && \
+    WOLFMQTT_MAX_QOS >= 1
+    RUN_TEST(wait_message_puback_survives_shared_ack_overwrite);
+#endif
     RUN_TEST(disconnect_null_client);
 
     /* MqttClient_GetProtocolVersion tests */

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -2717,6 +2717,78 @@ TEST(encode_connect_username_and_password)
  * (0xC0 0xAF is an overlong sequence Utf8WellFormed rejects). Locks in that
  * the Password field bypasses encode-side UTF-8 validation, unlike the
  * username/client_id/topic string fields. */
+/* [MQTT-3.1.3.5] the Password is "Binary Data", 0 to 65535 bytes with a
+ * two-byte length prefix, so an embedded 0x00 is legal. Without an explicit
+ * length the encoder measured it with XSTRLEN and truncated at that byte.
+ *
+ * Wire layout, hand-built from section 3.1:
+ *   10 18                  CONNECT, Remaining Length 24
+ *   00 04 4D 51 54 54      protocol name "MQTT"
+ *   04                     protocol level 4
+ *   C0                     flags: User Name + Password
+ *   00 00                  keep alive 0
+ *   00 03 63 69 64         ClientId "cid"
+ *   00 04 75 73 65 72      User Name "user"
+ *   00 03 41 00 42         Password 'A' 0x00 'B'  <- the three bytes at issue
+ */
+TEST(encode_connect_binary_password_with_len_not_truncated)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    static const char password[] = { 'A', '\0', 'B', '\0' };
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "cid";
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    conn.clean_session = 1;
+    conn.username = "user";
+    conn.password = password;
+    conn.password_len = 3;
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+
+    /* Password field sits last: after the 10-byte variable header, the
+     * ClientId (2+3) and the User Name (2+4). */
+    {
+        int off = 2 + 10 + 2 + 3 + 2 + 4;
+        ASSERT_EQ(0x00, (int)tx_buf[off]);
+        ASSERT_EQ(0x03, (int)tx_buf[off + 1]);
+        ASSERT_EQ('A',  (int)tx_buf[off + 2]);
+        ASSERT_EQ(0x00, (int)tx_buf[off + 3]);
+        ASSERT_EQ('B',  (int)tx_buf[off + 4]);
+        ASSERT_EQ(off + 5, rc);
+    }
+}
+
+/* password_len 0 keeps the original NUL-terminated behaviour, so existing
+ * callers that never set the field are unaffected. */
+TEST(encode_connect_password_len_zero_uses_strlen)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "cid";
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    conn.clean_session = 1;
+    conn.username = "user";
+    conn.password = "pw";
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+    {
+        int off = 2 + 10 + 2 + 3 + 2 + 4;
+        ASSERT_EQ(0x00, (int)tx_buf[off]);
+        ASSERT_EQ(0x02, (int)tx_buf[off + 1]);
+        ASSERT_EQ('p',  (int)tx_buf[off + 2]);
+        ASSERT_EQ('w',  (int)tx_buf[off + 3]);
+        ASSERT_EQ(off + 4, rc);
+    }
+}
+
 TEST(encode_connect_binary_password_accepted)
 {
     byte tx_buf[256];
@@ -6691,6 +6763,8 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(encode_connect_v5_unsupported);
 #endif
     RUN_TEST(encode_connect_username_and_password);
+    RUN_TEST(encode_connect_binary_password_with_len_not_truncated);
+    RUN_TEST(encode_connect_password_len_zero_uses_strlen);
     RUN_TEST(encode_connect_binary_password_accepted);
     RUN_TEST(encode_connect_invalid_utf8_clientid_rejected);
     RUN_TEST(encode_connect_invalid_utf8_username_rejected);

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -1836,6 +1836,64 @@ TEST(decode_connack_truncated_partial_var_header)
     ASSERT_EQ(MQTT_CODE_ERROR_OUT_OF_BUFFER, rc);
 }
 
+/* MQTT 3.1.1 section 3.2.1 fixes the CONNACK Remaining Length at 2 and
+ * section 3.2.3 states "The CONNACK Packet has no payload". A CONNACK
+ * carrying a third byte is a protocol violation the receiver must reject so
+ * it closes the Network Connection per [MQTT-4.8.0-1].
+ *
+ * Wire layout, hand-built from section 3.2:
+ *   0x20        fixed header, type 2 (CONNACK), reserved flags 0
+ *   0x03        Remaining Length = 3 (must be 2)
+ *   0x00        Connect Acknowledge Flags, Session Present = 0
+ *   0x00        Connect Return Code, 0 = Connection Accepted
+ *   0xFF        extra byte the spec does not allow
+ */
+TEST(decode_connack_v311_extra_payload_rejected)
+{
+    byte buf[] = { 0x20, 0x03, 0x00, 0x00, 0xFF };
+    MqttConnectAck ack;
+    int rc;
+
+    XMEMSET(&ack, 0, sizeof(ack));
+    rc = MqttDecode_ConnectAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+}
+
+/* Positive control for the same gate: the identical prefix with the correct
+ * Remaining Length of 2 must still decode. Pins the check to the length
+ * rather than to the presence of trailing bytes in the caller's buffer. */
+TEST(decode_connack_v311_exact_remain_len_accepted)
+{
+    byte buf[] = { 0x20, 0x02, 0x00, 0x00 };
+    MqttConnectAck ack;
+    int rc;
+
+    XMEMSET(&ack, 0, sizeof(ack));
+    rc = MqttDecode_ConnectAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(4, rc);
+    ASSERT_EQ(0, ack.flags);
+    ASSERT_EQ(MQTT_CONNECT_ACK_CODE_ACCEPTED, ack.return_code);
+}
+
+#ifdef WOLFMQTT_V5
+/* MQTT 5.0 section 3.2.2.1 appends a Properties block to the CONNACK variable
+ * header, so a v5 session must still accept Remaining Length > 2. Pins the v5
+ * arm of the gate so the v3.1.1 exact-length rule cannot regress onto v5 -
+ * the wire is remain_len = 3 = flags + reason code + props_len(0). */
+TEST(decode_connack_v5_longer_remain_len_accepted)
+{
+    byte buf[] = { 0x20, 0x03, 0x00, MQTT_REASON_SUCCESS, 0x00 };
+    MqttConnectAck ack;
+    int rc;
+
+    XMEMSET(&ack, 0, sizeof(ack));
+    ack.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttDecode_ConnectAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(5, rc);
+    MqttProps_Free(ack.props);
+}
+#endif /* WOLFMQTT_V5 */
+
 #ifdef WOLFMQTT_V5
 /* MQTT 5.0 section 3.2.2.3: the Property Length belongs to this CONNACK,
  * so bytes after its declared Remaining Length cannot satisfy the property
@@ -4953,6 +5011,85 @@ TEST(decode_pubcomp_v311_valid)
     ASSERT_EQ(7, resp.packet_id);
 }
 
+/* [MQTT-2.3.1-1] requires the Packet Identifier of a QoS > 0 PUBLISH to be
+ * non-zero, and a publish response echoes the identifier of the PUBLISH it
+ * acknowledges (sections 3.4.2, 3.5.2, 3.6.2, 3.7.2). A zero identifier can
+ * therefore never name an in-flight exchange: it is a protocol violation, and
+ * [MQTT-4.8.0-1] requires the receiver to close the Network Connection rather
+ * than discard the packet as spurious.
+ *
+ * Wire layout, hand-built from section 3.4:
+ *   0x40        fixed header, type 4 (PUBACK), reserved flags 0
+ *   0x02        Remaining Length = 2
+ *   0x00 0x00   Packet Identifier = 0, which the spec forbids
+ */
+TEST(decode_puback_packet_id_zero_rejected)
+{
+    byte buf[] = { 0x40, 0x02, 0x00, 0x00 };
+    MqttPublishResp resp;
+    int rc;
+
+    XMEMSET(&resp, 0, sizeof(resp));
+    rc = MqttDecode_PublishResp(buf, (int)sizeof(buf),
+        MQTT_PACKET_TYPE_PUBLISH_ACK, &resp);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+}
+
+/* PUBREC, section 3.5: type 5, reserved flags 0. */
+TEST(decode_pubrec_packet_id_zero_rejected)
+{
+    byte buf[] = { 0x50, 0x02, 0x00, 0x00 };
+    MqttPublishResp resp;
+    int rc;
+
+    XMEMSET(&resp, 0, sizeof(resp));
+    rc = MqttDecode_PublishResp(buf, (int)sizeof(buf),
+        MQTT_PACKET_TYPE_PUBLISH_REC, &resp);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+}
+
+/* PUBREL, section 3.6: type 6, and [MQTT-3.6.1-1] fixes its reserved flags
+ * at 0010, hence 0x62 rather than 0x60. */
+TEST(decode_pubrel_packet_id_zero_rejected)
+{
+    byte buf[] = { 0x62, 0x02, 0x00, 0x00 };
+    MqttPublishResp resp;
+    int rc;
+
+    XMEMSET(&resp, 0, sizeof(resp));
+    rc = MqttDecode_PublishResp(buf, (int)sizeof(buf),
+        MQTT_PACKET_TYPE_PUBLISH_REL, &resp);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+}
+
+/* PUBCOMP, section 3.7: type 7, reserved flags 0. */
+TEST(decode_pubcomp_packet_id_zero_rejected)
+{
+    byte buf[] = { 0x70, 0x02, 0x00, 0x00 };
+    MqttPublishResp resp;
+    int rc;
+
+    XMEMSET(&resp, 0, sizeof(resp));
+    rc = MqttDecode_PublishResp(buf, (int)sizeof(buf),
+        MQTT_PACKET_TYPE_PUBLISH_COMP, &resp);
+    ASSERT_EQ(MQTT_CODE_ERROR_PACKET_ID, rc);
+}
+
+/* Positive control: Packet Identifier 1 is the smallest legal value and must
+ * still decode, so the guard rejects only zero. */
+TEST(decode_puback_packet_id_one_accepted)
+{
+    byte buf[] = { 0x40, 0x02, 0x00, 0x01 };
+    MqttPublishResp resp;
+    int rc;
+
+    XMEMSET(&resp, 0, sizeof(resp));
+    rc = MqttDecode_PublishResp(buf, (int)sizeof(buf),
+        MQTT_PACKET_TYPE_PUBLISH_ACK, &resp);
+    ASSERT_EQ(4, rc);
+    ASSERT_EQ(1, resp.packet_id);
+}
+
 /* publish_resp == NULL takes the strict-length path even under
  * WOLFMQTT_V5: with no struct to consume reason_code/props, anything
  * beyond the Packet Identifier is unreachable extra payload. Pins the
@@ -6413,7 +6550,10 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_connack_truncated_one_byte_buffer);
     RUN_TEST(decode_connack_truncated_no_var_header);
     RUN_TEST(decode_connack_truncated_partial_var_header);
+    RUN_TEST(decode_connack_v311_extra_payload_rejected);
+    RUN_TEST(decode_connack_v311_exact_remain_len_accepted);
 #ifdef WOLFMQTT_V5
+    RUN_TEST(decode_connack_v5_longer_remain_len_accepted);
     RUN_TEST(decode_connack_v5_props_cannot_cross_packet_end);
     RUN_TEST(decode_connack_v5_rejects_bytes_after_property_block);
 #endif
@@ -6602,6 +6742,11 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_pubrel_v311_valid);
     RUN_TEST(decode_pubcomp_v311_valid);
     RUN_TEST(decode_puback_null_resp_extra_payload_rejected);
+    RUN_TEST(decode_puback_packet_id_zero_rejected);
+    RUN_TEST(decode_pubrec_packet_id_zero_rejected);
+    RUN_TEST(decode_pubrel_packet_id_zero_rejected);
+    RUN_TEST(decode_pubcomp_packet_id_zero_rejected);
+    RUN_TEST(decode_puback_packet_id_one_accepted);
 #ifdef WOLFMQTT_V5
     RUN_TEST(decode_puback_v5_with_reason_code_accepted);
     RUN_TEST(decode_puback_v5_reason_code_past_buf_rejected);

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -2553,6 +2553,85 @@ TEST(encode_connect_default_password_without_username)
 #endif
 }
 
+/* [MQTT-3.1.3-7] "If the Client supplies a zero-byte ClientId, the Client MUST
+ * also set CleanSession to 1." A conforming Server answers the pairing with
+ * Identifier Rejected [MQTT-3.1.3-8], so the encoder must refuse to build the
+ * packet rather than hand the caller a CONNECT it is not allowed to send. */
+TEST(encode_connect_v311_empty_client_id_without_clean_session_rejected)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "";
+    conn.clean_session = 0;
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_EQ(MQTT_CODE_ERROR_BAD_ARG, rc);
+}
+
+/* Positive control: the pairing the spec does allow. Section 3.1.3.1 notes a
+ * Server may assign a unique ClientId when the Client sends a zero-byte one,
+ * and the CleanSession bit is 0x02 in the Connect Flags byte (section 3.1.2.4),
+ * which sits at offset 9 of the CONNECT variable header. */
+TEST(encode_connect_v311_empty_client_id_with_clean_session_accepted)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "";
+    conn.clean_session = 1;
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+    /* 0x10 type, 0x0C remaining length, then the 10-byte variable header:
+     * 00 04 'M' 'Q' 'T' 'T' 04 <flags> <keepalive hi> <keepalive lo>. */
+    ASSERT_EQ(MQTT_CONNECT_FLAG_CLEAN_SESSION, (int)tx_buf[9]);
+    /* Followed by the zero-length ClientId: 00 00. */
+    ASSERT_EQ(0, (int)tx_buf[12]);
+    ASSERT_EQ(0, (int)tx_buf[13]);
+}
+
+/* Second positive control: a non-empty ClientId with CleanSession 0 is the
+ * ordinary persistent-session CONNECT and must stay legal, so the guard keys
+ * on the pairing rather than on CleanSession alone. */
+TEST(encode_connect_v311_client_id_without_clean_session_accepted)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "test_client";
+    conn.clean_session = 0;
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+    ASSERT_EQ(0, (int)tx_buf[9]);
+}
+
+#ifdef WOLFMQTT_V5
+/* MQTT 5.0 section 3.1.3.1 drops the coupling: a zero-length Client Identifier
+ * asks the Server to assign one and carries no Clean Start requirement, so the
+ * v3.1.1 guard must not reach a v5 CONNECT. */
+TEST(encode_connect_v5_empty_client_id_without_clean_session_accepted)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "";
+    conn.clean_session = 0;
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+}
+#endif /* WOLFMQTT_V5 */
+
 TEST(encode_connect_unsupported_protocol_level)
 {
     byte tx_buf[256];
@@ -6599,6 +6678,12 @@ void run_mqtt_packet_tests(void)
     /* MqttEncode_Connect */
     RUN_TEST(encode_connect_password_without_username);
     RUN_TEST(encode_connect_default_password_without_username);
+    RUN_TEST(encode_connect_v311_empty_client_id_without_clean_session_rejected);
+    RUN_TEST(encode_connect_v311_empty_client_id_with_clean_session_accepted);
+    RUN_TEST(encode_connect_v311_client_id_without_clean_session_accepted);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(encode_connect_v5_empty_client_id_without_clean_session_accepted);
+#endif
     RUN_TEST(encode_connect_unsupported_protocol_level);
 #ifdef WOLFMQTT_V5
     RUN_TEST(encode_connect_v5_password_without_username);

--- a/tests/test_mqtt_packet.c
+++ b/tests/test_mqtt_packet.c
@@ -1895,6 +1895,33 @@ TEST(decode_connack_v5_longer_remain_len_accepted)
 #endif /* WOLFMQTT_V5 */
 
 #ifdef WOLFMQTT_V5
+/* The strict v3.1.1 length rule keys off connect_ack->protocol_level, which
+ * MqttConnectAck otherwise only carries as output. A caller that hands in a
+ * zeroed struct is therefore treated as v3.1.1, so a v5-shaped CONNACK is
+ * rejected as malformed. Pin that contract: the in-tree client always sets
+ * protocol_level first (src/mqtt_client.c), and an external caller decoding a
+ * v5 CONNACK must do the same. */
+TEST(decode_connack_v5_shape_without_protocol_level_rejected)
+{
+    byte buf[] = { 0x20, 0x03, 0x00, MQTT_REASON_SUCCESS, 0x00 };
+    MqttConnectAck ack;
+    int rc;
+
+    XMEMSET(&ack, 0, sizeof(ack));
+    ASSERT_EQ(0, (int)ack.protocol_level);
+    rc = MqttDecode_ConnectAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(MQTT_CODE_ERROR_MALFORMED_DATA, rc);
+
+    /* Same bytes, protocol level supplied: accepted. */
+    XMEMSET(&ack, 0, sizeof(ack));
+    ack.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    rc = MqttDecode_ConnectAck(buf, (int)sizeof(buf), &ack);
+    ASSERT_EQ(5, rc);
+    MqttProps_Free(ack.props);
+}
+#endif /* WOLFMQTT_V5 */
+
+#ifdef WOLFMQTT_V5
 /* MQTT 5.0 section 3.2.2.3: the Property Length belongs to this CONNACK,
  * so bytes after its declared Remaining Length cannot satisfy the property
  * block. The trailing bytes form a valid Maximum QoS property deliberately. */
@@ -2788,6 +2815,133 @@ TEST(encode_connect_password_len_zero_uses_strlen)
         ASSERT_EQ(off + 4, rc);
     }
 }
+
+/* password_len is the Password length regardless of protocol level, so the
+ * v5 encoder must honour it too [MQTT-3.1.3.5]. Same payload shape as the
+ * v3.1.1 case plus the CONNECT Properties length byte. */
+#ifdef WOLFMQTT_V5
+TEST(encode_connect_v5_binary_password_with_len_not_truncated)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    static const char password[] = { 'A', '\0', 'B', '\0' };
+    int rc;
+    int off;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "cid";
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_5;
+    conn.clean_session = 1;
+    conn.username = "user";
+    conn.password = password;
+    conn.password_len = 3;
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+
+    /* 2 fixed header + 10 variable header + 1 property length + ClientId
+     * (2+3) + User Name (2+4). */
+    off = 2 + 10 + 1 + 2 + 3 + 2 + 4;
+    ASSERT_EQ(0x00, (int)tx_buf[off]);
+    ASSERT_EQ(0x03, (int)tx_buf[off + 1]);
+    ASSERT_EQ('A',  (int)tx_buf[off + 2]);
+    ASSERT_EQ(0x00, (int)tx_buf[off + 3]);
+    ASSERT_EQ('B',  (int)tx_buf[off + 4]);
+    ASSERT_EQ(off + 5, rc);
+}
+#endif /* WOLFMQTT_V5 */
+
+/* password_len describes `password`; with no password there is no Password
+ * field and the Password flag must stay clear, whatever the field says. */
+TEST(encode_connect_password_len_without_password_ignored)
+{
+    byte tx_buf[256];
+    MqttConnect conn;
+    int rc;
+
+    XMEMSET(&conn, 0, sizeof(conn));
+    conn.client_id = "cid";
+    conn.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    conn.clean_session = 1;
+    conn.username = "user";
+    conn.password = NULL;
+    conn.password_len = 3;
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &conn);
+    ASSERT_TRUE(rc > 0);
+    /* 2 fixed header + 10 variable header + ClientId (2+3) + User Name (2+4),
+     * and nothing after it. */
+    ASSERT_EQ(2 + 10 + 2 + 3 + 2 + 4, rc);
+    /* [MQTT-3.1.2-20] Password Flag (bit 6) must be 0 when absent. */
+    ASSERT_EQ(0, (int)(tx_buf[9] & 0x40));
+}
+
+#ifdef WOLFMQTT_BROKER
+/* MqttDecode_Connect must report the wire Password length: the decoded
+ * pointer is into rx_buf, which is not NUL terminated, so a caller that
+ * re-encodes the CONNECT would otherwise fall back to XSTRLEN and either
+ * truncate at an embedded 0x00 or read past the buffer [MQTT-3.1.3.5]. */
+TEST(decode_connect_reports_password_len)
+{
+    byte tx_buf[256];
+    MqttConnect enc;
+    MqttConnect dec;
+    MqttMessage lwt;
+    static const char password[] = { 'A', '\0', 'B', '\0' };
+    int rc;
+
+    XMEMSET(&enc, 0, sizeof(enc));
+    enc.client_id = "cid";
+    enc.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    enc.clean_session = 1;
+    enc.username = "user";
+    enc.password = password;
+    enc.password_len = 3;
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &enc);
+    ASSERT_TRUE(rc > 0);
+
+    XMEMSET(&dec, 0, sizeof(dec));
+    XMEMSET(&lwt, 0, sizeof(lwt));
+    dec.lwt_msg = &lwt;
+    /* Pre-set it to a wrong value: the decoder must overwrite, and must also
+     * clear it when no Password is present. */
+    dec.password_len = 0xFFFF;
+    ASSERT_TRUE(MqttDecode_Connect(tx_buf, rc, &dec) > 0);
+    ASSERT_NOT_NULL(dec.password);
+    ASSERT_EQ(3, (int)dec.password_len);
+    ASSERT_EQ('A', (int)((byte*)dec.password)[0]);
+    ASSERT_EQ(0x00, (int)((byte*)dec.password)[1]);
+    ASSERT_EQ('B', (int)((byte*)dec.password)[2]);
+}
+
+/* The same CONNECT without a Password must leave password_len at 0, so a
+ * reused MqttConnect cannot carry a stale length into the next encode. */
+TEST(decode_connect_without_password_clears_password_len)
+{
+    byte tx_buf[256];
+    MqttConnect enc;
+    MqttConnect dec;
+    MqttMessage lwt;
+    int rc;
+
+    XMEMSET(&enc, 0, sizeof(enc));
+    enc.client_id = "cid";
+    enc.protocol_level = MQTT_CONNECT_PROTOCOL_LEVEL_4;
+    enc.clean_session = 1;
+
+    rc = MqttEncode_Connect(tx_buf, (int)sizeof(tx_buf), &enc);
+    ASSERT_TRUE(rc > 0);
+
+    XMEMSET(&dec, 0, sizeof(dec));
+    XMEMSET(&lwt, 0, sizeof(lwt));
+    dec.lwt_msg = &lwt;
+    dec.password_len = 0xFFFF;
+    ASSERT_TRUE(MqttDecode_Connect(tx_buf, rc, &dec) > 0);
+    ASSERT_NULL(dec.password);
+    ASSERT_EQ(0, (int)dec.password_len);
+}
+#endif /* WOLFMQTT_BROKER */
 
 TEST(encode_connect_binary_password_accepted)
 {
@@ -6705,6 +6859,7 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(decode_connack_v311_exact_remain_len_accepted);
 #ifdef WOLFMQTT_V5
     RUN_TEST(decode_connack_v5_longer_remain_len_accepted);
+    RUN_TEST(decode_connack_v5_shape_without_protocol_level_rejected);
     RUN_TEST(decode_connack_v5_props_cannot_cross_packet_end);
     RUN_TEST(decode_connack_v5_rejects_bytes_after_property_block);
 #endif
@@ -6765,6 +6920,14 @@ void run_mqtt_packet_tests(void)
     RUN_TEST(encode_connect_username_and_password);
     RUN_TEST(encode_connect_binary_password_with_len_not_truncated);
     RUN_TEST(encode_connect_password_len_zero_uses_strlen);
+#ifdef WOLFMQTT_V5
+    RUN_TEST(encode_connect_v5_binary_password_with_len_not_truncated);
+#endif
+    RUN_TEST(encode_connect_password_len_without_password_ignored);
+#ifdef WOLFMQTT_BROKER
+    RUN_TEST(decode_connect_reports_password_len);
+    RUN_TEST(decode_connect_without_password_clears_password_len);
+#endif
     RUN_TEST(encode_connect_binary_password_accepted);
     RUN_TEST(encode_connect_invalid_utf8_clientid_rejected);
     RUN_TEST(encode_connect_invalid_utf8_username_rejected);

--- a/tests/test_mqtt_props_init.c
+++ b/tests/test_mqtt_props_init.c
@@ -268,6 +268,11 @@ static int test_ping_response_completed_during_read_lock(void)
         return 1;
     }
 
+    /* [MQTT-3.1.0-1] makes CONNECT the first packet a Client sends, so
+     * MqttClient_Ping_ex refuses to run before one. This test drives the ping
+     * path directly, so declare the post-CONNECT state it presumes. */
+    (void)MqttClient_Flags(&client, 0, MQTT_CLIENT_FLAG_CONNECT_SENT);
+
     /* Model another reader delivering PINGRESP after the waiter's first
      * pending-response check but while that waiter acquires lockRecv. */
     sem_complete_on_lock = &client.lockRecv;

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -670,10 +670,15 @@ typedef struct BrokerClient {
 #endif
     byte          session_established;
 #ifndef WOLFMQTT_STATIC_MEMORY
-    /* Length of an accepted CONNACK still being written (0 = none). While
-     * nonzero, tx_buf is owned by that write and no other packet may be
-     * read from or written to this client. */
+    /* Length of a CONNACK still being written (0 = none). While nonzero,
+     * tx_buf is owned by that write and no other packet may be read from or
+     * written to this client. */
     int           connack_pending_len;
+    /* The pending CONNACK carries a non-zero return code. MQTT 3.1.1 section
+     * 3.1.4 requires the Server to send the refusal and then close the
+     * Network Connection, so the client is kept only until those bytes are
+     * fully delivered and is then dropped without becoming connected. */
+    unsigned int  connack_refused : 1;
 #endif
 } BrokerClient;
 

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -641,6 +641,15 @@ typedef struct BrokerClient {
     int                qos2_pending_count;
 #endif
 #endif /* WOLFMQTT_MAX_QOS >= 2 */
+#ifdef WOLFMQTT_STATIC_MEMORY
+    /* Outbound QoS 1/2 Packet Identifiers sent to this client and not yet
+     * released by its PUBACK or PUBCOMP. [MQTT-2.3.1-4] applies the Client
+     * identifier rule to a Server sending a QoS > 0 PUBLISH, so a new one
+     * must not reuse an identifier still awaiting acknowledgement. Slot value
+     * 0 is empty. Dynamic-memory builds derive this from the per-subscriber
+     * out_q instead, via BrokerNextPacketIdForQueue. */
+    word16  out_inflight[BROKER_MAX_INFLIGHT_PER_SUB];
+#endif
 #ifndef WOLFMQTT_STATIC_MEMORY
     /* Per-subscriber outbound publish queue. FIFO from head to tail;
      * drain pulls from head. out_q_inflight is the number of entries in

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -568,6 +568,12 @@ typedef struct BrokerOrphanSession {
 /* -------------------------------------------------------------------------- */
 /* Broker client tracking                                                      */
 /* -------------------------------------------------------------------------- */
+/* One outbound QoS > 0 delivery this client has not acknowledged yet. */
+typedef struct BrokerStaticOutId {
+    word16  packet_id;      /* 0 = empty slot */
+    MqttQoS qos;            /* QoS the delivery went out with */
+} BrokerStaticOutId;
+
 typedef struct BrokerClient {
 #ifdef WOLFMQTT_STATIC_MEMORY
     byte    in_use;
@@ -645,10 +651,13 @@ typedef struct BrokerClient {
     /* Outbound QoS 1/2 Packet Identifiers sent to this client and not yet
      * released by its PUBACK or PUBCOMP. [MQTT-2.3.1-4] applies the Client
      * identifier rule to a Server sending a QoS > 0 PUBLISH, so a new one
-     * must not reuse an identifier still awaiting acknowledgement. Slot value
-     * 0 is empty. Dynamic-memory builds derive this from the per-subscriber
-     * out_q instead, via BrokerNextPacketIdForQueue. */
-    word16  out_inflight[BROKER_MAX_INFLIGHT_PER_SUB];
+     * must not reuse an identifier still awaiting acknowledgement. The QoS is
+     * kept with it so a mismatched acknowledgement (a PUBACK for a QoS 2
+     * delivery, say) cannot free a slot whose PUBREC/PUBCOMP flow is still
+     * running. packet_id 0 marks an empty slot. Dynamic-memory builds derive
+     * this from the per-subscriber out_q instead, via
+     * BrokerNextPacketIdForQueue. */
+    BrokerStaticOutId out_inflight[BROKER_MAX_INFLIGHT_PER_SUB];
 #endif
 #ifndef WOLFMQTT_STATIC_MEMORY
     /* Per-subscriber outbound publish queue. FIFO from head to tail;

--- a/wolfmqtt/mqtt_broker.h
+++ b/wolfmqtt/mqtt_broker.h
@@ -571,7 +571,7 @@ typedef struct BrokerOrphanSession {
 /* One outbound QoS > 0 delivery this client has not acknowledged yet. */
 typedef struct BrokerStaticOutId {
     word16  packet_id;      /* 0 = empty slot */
-    MqttQoS qos;            /* QoS the delivery went out with */
+    byte    qos;            /* MqttQoS the delivery went out with */
 } BrokerStaticOutId;
 
 typedef struct BrokerClient {

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -447,8 +447,12 @@ WOLFMQTT_API int MqttClient_SetPropertyCallback(
  *  \return     MQTT_CODE_SUCCESS if the broker accepted the connection,
                 MQTT_CODE_ERROR_CONNECT_REFUSED if the broker returned a
                 non-zero CONNACK return_code (check
-                connect->ack.return_code for the specific reason), or
-                another MQTT_CODE_ERROR_* for transport/protocol failures
+                connect->ack.return_code for the specific reason),
+                MQTT_CODE_ERROR_STAT if a CONNECT has already been sent on
+                this Network Connection - close it with
+                MqttClient_NetDisconnect before connecting again
+                [MQTT-3.1.0-2] - or another MQTT_CODE_ERROR_* for
+                transport/protocol failures
                 (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Connect(
@@ -477,8 +481,12 @@ WOLFMQTT_API int MqttClient_Connect(
                 MQTT_CODE_ERROR_SERVER_PROP if the request violates a
                 CONNACK-advertised v5 server property before sending (QoS above
                 Maximum QoS, Retain unavailable, Topic Alias above the server
-                maximum, or Receive Maximum quota exhausted), or
-                MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
+                maximum, or Receive Maximum quota exhausted),
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                MQTT_CODE_ERROR_PACKET_ID if the Packet Identifier is still
+                awaiting its acknowledgement [MQTT-2.3.1-2],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish_WriteOnly
     \sa         MqttClient_Publish_ex
  */
@@ -541,8 +549,12 @@ WOLFMQTT_API int MqttClient_Publish_ex(
                 >= 0x80 is NOT detected on this path and the publish appears
                 successful. Use MqttClient_Publish/_ex when reliable v5
                 broker-rejection detection for QoS>0 is required.
- *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking) or
-                MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS, MQTT_CODE_CONTINUE (for non-blocking),
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                MQTT_CODE_ERROR_PACKET_ID if the Packet Identifier is still
+                awaiting its acknowledgement [MQTT-2.3.1-2],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
     \sa         MqttClient_Publish
     \sa         MqttClient_Publish_ex
     \sa         MqttClient_WaitMessage_ex
@@ -564,7 +576,12 @@ WOLFMQTT_API int MqttClient_Publish_WriteOnly(
                 received but one or more filters were rejected (inspect each
                 subscribe->topics[i].return_code for the per-filter result;
                 v3.1.1 rejection is 0x80, v5 rejection is any reason_code
-                >= 0x80), or another MQTT_CODE_ERROR_* for transport/protocol
+                >= 0x80),
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                MQTT_CODE_ERROR_PACKET_ID if the Packet Identifier is still
+                awaiting its acknowledgement [MQTT-2.3.1-2],
+                or another MQTT_CODE_ERROR_* for transport/protocol
                 failures (see enum MqttPacketResponseCodes).
  */
 WOLFMQTT_API int MqttClient_Subscribe(
@@ -577,8 +594,12 @@ WOLFMQTT_API int MqttClient_Subscribe(
  *  \param      client      Pointer to MqttClient structure
  *  \param      unsubscribe Pointer to MqttUnsubscribe structure initialized
                             with topic list.
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                MQTT_CODE_ERROR_PACKET_ID if the Packet Identifier is still
+                awaiting its acknowledgement [MQTT-2.3.1-2],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Unsubscribe(
     MqttClient *client,
@@ -588,8 +609,10 @@ WOLFMQTT_API int MqttClient_Unsubscribe(
                 Ping Response packet
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Ping(
     MqttClient *client);
@@ -600,8 +623,10 @@ WOLFMQTT_API int MqttClient_Ping(
  *  \note This is a blocking function that will wait for MqttNet.read
  *  \param      client      Pointer to MqttClient structure
  *  \param      ping        Pointer to MqttPing structure
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Ping_ex(MqttClient *client, MqttPing* ping);
 
@@ -643,8 +668,10 @@ WOLFMQTT_API int MqttClient_PropsFree(
  *  \note This is a non-blocking function that will try and send using
                 MqttNet.write
  *  \param      client      Pointer to MqttClient structure
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Disconnect(
     MqttClient *client);
@@ -655,8 +682,10 @@ WOLFMQTT_API int MqttClient_Disconnect(
                 MqttNet.write
  *  \param      client      Pointer to MqttClient structure
  *  \param      disconnect  Pointer to MqttDisconnect structure. NULL is valid.
- *  \return     MQTT_CODE_SUCCESS or MQTT_CODE_ERROR_*
-                (see enum MqttPacketResponseCodes)
+ *  \return     MQTT_CODE_SUCCESS,
+                MQTT_CODE_ERROR_STAT if CONNECT has not been sent on this
+                Network Connection [MQTT-3.1.0-1],
+                or MQTT_CODE_ERROR_* (see enum MqttPacketResponseCodes)
  */
 WOLFMQTT_API int MqttClient_Disconnect_ex(
     MqttClient *client,

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -274,6 +274,12 @@ typedef struct _MqttSk {
 #ifndef MQTT_MAX_REPLAY_MSGS
     #define MQTT_MAX_REPLAY_MSGS 4
 #endif
+/* A zero-length array is a GNU extension, not C89, and would silently disable
+ * the store rather than fail the build. Use WOLFMQTT_NO_SESSION_REPLAY to
+ * remove it deliberately. */
+#if (MQTT_MAX_REPLAY_MSGS < 1) || (MQTT_MAX_REPLAY_MSGS > 65535)
+    #error "MQTT_MAX_REPLAY_MSGS must be between 1 and 65535"
+#endif
 #ifdef WOLFMQTT_STATIC_MEMORY
     /* Bounds of the in-struct copies when there is no allocator. */
     #ifndef MQTT_MAX_REPLAY_TOPIC
@@ -281,6 +287,14 @@ typedef struct _MqttSk {
     #endif
     #ifndef MQTT_MAX_REPLAY_PAYLOAD
         #define MQTT_MAX_REPLAY_PAYLOAD 256
+    #endif
+    /* The topic copy is NUL terminated, so it needs room for the terminator
+     * plus at least one character [MQTT-4.7.3-1]. */
+    #if (MQTT_MAX_REPLAY_TOPIC < 2) || (MQTT_MAX_REPLAY_TOPIC > 65536)
+        #error "MQTT_MAX_REPLAY_TOPIC must be between 2 and 65536"
+    #endif
+    #if (MQTT_MAX_REPLAY_PAYLOAD < 1)
+        #error "MQTT_MAX_REPLAY_PAYLOAD must be at least 1"
     #endif
 #endif
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -171,7 +171,16 @@ enum MqttClientFlags {
      * Managed by the library - set by MqttClient_Connect and cleared by
      * MqttSocket_Connect and MqttSocket_Disconnect. Applications must not set
      * or clear it through MqttClient_Flags. */
-    MQTT_CLIENT_FLAG_CONNECT_SENT = 0x01 << 5
+    MQTT_CLIENT_FLAG_CONNECT_SENT = 0x01 << 5,
+    /* A DISCONNECT has been written on the current Network Connection.
+     * [MQTT-3.14.4-1] forbids any further Control Packet on it, so the send
+     * APIs refuse one. Kept separate from MQTT_CLIENT_FLAG_CONNECT_SENT
+     * because MqttClient_Disconnect does not close the transport: clearing
+     * CONNECT_SENT instead would reopen the [MQTT-3.1.0-2] duplicate-CONNECT
+     * guard and let a second CONNECT go out on the same Network Connection.
+     * Managed by the library - set by MqttClient_Disconnect_ex and cleared by
+     * MqttSocket_Connect and MqttSocket_Disconnect. */
+    MQTT_CLIENT_FLAG_DISCONNECT_SENT = 0x01 << 6
 };
 /*! \brief      Sets flags in the MqttClient structure. To be used from
                 the application before calling MqttClient_NetConnect.
@@ -325,7 +334,23 @@ typedef struct _MqttReplayMsg {
  * a fingerprint of it to tell a resumed Session from a different one, so the
  * fingerprint exists whenever either of them does. */
 #if (WOLFMQTT_MAX_QOS >= 2) || !defined(WOLFMQTT_NO_SESSION_REPLAY)
-    #define WOLFMQTT_SESSION_ID_HASH
+    #define WOLFMQTT_SESSION_ID_TRACK
+    /* Bytes of the ClientId retained for that comparison. It is an exact
+     * match, not a digest: a digest of this state is attacker-relevant when
+     * the ClientId derives from untrusted input (a per-tenant or per-device
+     * name), because finding two inputs with the same short digest is cheap
+     * and would let one identity's Session state be replayed into another's.
+     * A ClientId longer than this is simply not recorded, so the next Session
+     * Present is treated as a different Session and the state is dropped -
+     * safe, at the cost of no replay for such Clients. Raise it in
+     * user_settings.h if longer ClientIds need Session replay. MQTT 3.1.1
+     * section 3.1.3.1 requires Servers to accept at least 23 bytes. */
+    #ifndef MQTT_MAX_SESSION_CLIENT_ID
+        #define MQTT_MAX_SESSION_CLIENT_ID 64
+    #endif
+    #if (MQTT_MAX_SESSION_CLIENT_ID < 23)
+        #error "MQTT_MAX_SESSION_CLIENT_ID must be at least 23"
+    #endif
 #endif
 
 /* One outbound Packet Identifier reservation. packet_id 0 marks a free slot;
@@ -443,12 +468,13 @@ typedef struct _MqttClient {
      * is empty; a QoS 2 packet id is never 0. */
     word16 recv_qos2_pending[MQTT_MAX_RECV_QOS2];
 #endif
-#ifdef WOLFMQTT_SESSION_ID_HASH
-    /* Fingerprint of the ClientId whose Session state this client holds - the
-     * inbound QoS 2 pending ids and the outbound replay pool. A Session
-     * Present answer for a different ClientId is a different Session and must
-     * not inherit either [MQTT-3.1.3-2]. 0 means no Session recorded. */
-    word32 session_client_id_hash;
+#ifdef WOLFMQTT_SESSION_ID_TRACK
+    /* The ClientId whose Session state this client holds - the inbound QoS 2
+     * pending ids and the outbound replay pool. A Session Present answer for a
+     * different ClientId is a different Session and must not inherit either
+     * [MQTT-3.1.3-2]. Length 0 means no Session is recorded. */
+    char   session_client_id[MQTT_MAX_SESSION_CLIENT_ID];
+    word16 session_client_id_len;
 #endif
 
     /* Outbound Packet Identifiers written on the current Network Connection

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -243,6 +243,27 @@ typedef struct _MqttSk {
     #endif
 #endif
 
+/* Max distinct outbound Packet Identifiers tracked as in flight. Each new
+ * SUBSCRIBE, UNSUBSCRIBE or QoS>0 PUBLISH must use a currently unused
+ * identifier [MQTT-2.3.1-2], and it only becomes reusable once the matching
+ * SUBACK / UNSUBACK / PUBACK / PUBCOMP has been processed [MQTT-2.3.1-3].
+ * Override in user_settings.h to trade memory for a larger in-flight window. */
+#ifndef MQTT_MAX_SEND_INFLIGHT
+    #define MQTT_MAX_SEND_INFLIGHT 16
+#endif
+#if (MQTT_MAX_SEND_INFLIGHT < 1) || (MQTT_MAX_SEND_INFLIGHT > 65535)
+    #error "MQTT_MAX_SEND_INFLIGHT must be between 1 and 65535"
+#endif
+
+/* One outbound Packet Identifier reservation. packet_id 0 marks a free slot;
+ * a Packet Identifier is never 0 [MQTT-2.3.1-1]. owner is the message object
+ * that made the reservation, so MqttClient_CancelMessage can give it back
+ * without knowing which packet type the object holds. */
+typedef struct _MqttSendId {
+    void*  owner;
+    word16 packet_id;
+} MqttSendId;
+
 /* Client structure */
 typedef struct _MqttClient {
     word32       flags; /* MqttClientFlags */
@@ -344,6 +365,12 @@ typedef struct _MqttClient {
      * is empty; a QoS 2 packet id is never 0. */
     word16 recv_qos2_pending[MQTT_MAX_RECV_QOS2];
 #endif
+
+    /* Outbound Packet Identifiers written on the current Network Connection
+     * and not yet released by their acknowledgement. Cleared when a connection
+     * starts or ends, since the client keeps no outbound session state across
+     * one. */
+    MqttSendId send_inflight[MQTT_MAX_SEND_INFLIGHT];
 } MqttClient;
 
 #ifdef WOLFMQTT_SN

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -364,6 +364,11 @@ typedef struct _MqttClient {
      * with PUBREC but not delivered a second time [MQTT-4.3.3-10]. Slot value 0
      * is empty; a QoS 2 packet id is never 0. */
     word16 recv_qos2_pending[MQTT_MAX_RECV_QOS2];
+    /* Fingerprint of the ClientId that populated recv_qos2_pending.
+     * [MQTT-3.1.3-2] makes the ClientId identify the Session state, so a
+     * Session Present answer for a different ClientId must not inherit the
+     * previous one's pending ids. 0 means no Session has been recorded. */
+    word32 session_client_id_hash;
 #endif
 
     /* Outbound Packet Identifiers written on the current Network Connection

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -255,6 +255,57 @@ typedef struct _MqttSk {
     #error "MQTT_MAX_SEND_INFLIGHT must be between 1 and 65535"
 #endif
 
+/* Client-side Session state for outbound QoS > 0 messages. MQTT 3.1.1
+ * section 4.1 lists "QoS 1 and QoS 2 messages which have been sent to the
+ * Server, but have not been completely acknowledged" as Session state the
+ * Client stores, and [MQTT-4.4.0-1] requires them re-sent with their original
+ * Packet Identifiers when it reconnects with CleanSession 0.
+ *
+ * Replaying a PUBLISH needs its topic and payload after the caller's
+ * MqttPublish is gone, so the client keeps its own copy. That costs memory,
+ * hence a pool sized separately from the (much cheaper) identifier table:
+ * raise MQTT_MAX_REPLAY_MSGS to retain more in-flight messages, or define
+ * WOLFMQTT_NO_SESSION_REPLAY to compile the store out entirely. A message
+ * that does not fit is still sent, just not retained for replay.
+ *
+ * A PUBREL awaiting its PUBCOMP is retained regardless of the size limits:
+ * it carries no payload, only the Packet Identifier. */
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+#ifndef MQTT_MAX_REPLAY_MSGS
+    #define MQTT_MAX_REPLAY_MSGS 4
+#endif
+#ifdef WOLFMQTT_STATIC_MEMORY
+    /* Bounds of the in-struct copies when there is no allocator. */
+    #ifndef MQTT_MAX_REPLAY_TOPIC
+        #define MQTT_MAX_REPLAY_TOPIC 64
+    #endif
+    #ifndef MQTT_MAX_REPLAY_PAYLOAD
+        #define MQTT_MAX_REPLAY_PAYLOAD 256
+    #endif
+#endif
+
+typedef struct _MqttReplayMsg {
+    word32  payload_len;
+#ifdef WOLFMQTT_STATIC_MEMORY
+    char    topic[MQTT_MAX_REPLAY_TOPIC];
+    byte    payload[MQTT_MAX_REPLAY_PAYLOAD];
+#else
+    char*   topic;      /* heap-owned, NUL-terminated */
+    byte*   payload;    /* heap-owned, NULL when payload_len is 0 */
+#endif
+    word16  packet_id;  /* 0 = free slot */
+    byte    qos;
+    byte    retain;
+    /* QoS 2 has advanced past PUBREC, so the replay is a PUBREL rather than
+     * the PUBLISH [MQTT-4.4.0-1]. */
+    byte    pubrelSent;
+    /* The topic/payload copy is present. Clear when the message was too large
+     * for the pool or came from a payload callback, which has nothing to
+     * copy; such an entry can still replay a PUBREL but not a PUBLISH. */
+    byte    haveCopy;
+} MqttReplayMsg;
+#endif /* !WOLFMQTT_NO_SESSION_REPLAY */
+
 /* One outbound Packet Identifier reservation. packet_id 0 marks a free slot;
  * a Packet Identifier is never 0 [MQTT-2.3.1-1]. owner is the message object
  * that made the reservation, so MqttClient_CancelMessage can give it back
@@ -376,6 +427,16 @@ typedef struct _MqttClient {
      * starts or ends, since the client keeps no outbound session state across
      * one. */
     MqttSendId send_inflight[MQTT_MAX_SEND_INFLIGHT];
+
+#ifndef WOLFMQTT_NO_SESSION_REPLAY
+    /* Unacknowledged outbound QoS > 0 messages retained for [MQTT-4.4.0-1]
+     * replay after a CleanSession 0 reconnect. */
+    MqttReplayMsg replay[MQTT_MAX_REPLAY_MSGS];
+    /* Next replay slot to send; MQTT_MAX_REPLAY_MSGS when none is pending.
+     * Kept on the client so a nonblocking replay can resume where it left
+     * off. */
+    int replayIdx;
+#endif
 } MqttClient;
 
 #ifdef WOLFMQTT_SN

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -320,6 +320,14 @@ typedef struct _MqttReplayMsg {
 } MqttReplayMsg;
 #endif /* !WOLFMQTT_NO_SESSION_REPLAY */
 
+/* [MQTT-3.1.3-2] The ClientId identifies the Client and its Session. Both the
+ * inbound QoS 2 de-duplication table and the outbound Session replay store use
+ * a fingerprint of it to tell a resumed Session from a different one, so the
+ * fingerprint exists whenever either of them does. */
+#if (WOLFMQTT_MAX_QOS >= 2) || !defined(WOLFMQTT_NO_SESSION_REPLAY)
+    #define WOLFMQTT_SESSION_ID_HASH
+#endif
+
 /* One outbound Packet Identifier reservation. packet_id 0 marks a free slot;
  * a Packet Identifier is never 0 [MQTT-2.3.1-1]. owner is the message object
  * that made the reservation, so MqttClient_CancelMessage can give it back
@@ -434,10 +442,12 @@ typedef struct _MqttClient {
      * with PUBREC but not delivered a second time [MQTT-4.3.3-10]. Slot value 0
      * is empty; a QoS 2 packet id is never 0. */
     word16 recv_qos2_pending[MQTT_MAX_RECV_QOS2];
-    /* Fingerprint of the ClientId that populated recv_qos2_pending.
-     * [MQTT-3.1.3-2] makes the ClientId identify the Session state, so a
-     * Session Present answer for a different ClientId must not inherit the
-     * previous one's pending ids. 0 means no Session has been recorded. */
+#endif
+#ifdef WOLFMQTT_SESSION_ID_HASH
+    /* Fingerprint of the ClientId whose Session state this client holds - the
+     * inbound QoS 2 pending ids and the outbound replay pool. A Session
+     * Present answer for a different ClientId is a different Session and must
+     * not inherit either [MQTT-3.1.3-2]. 0 means no Session recorded. */
     word32 session_client_id_hash;
 #endif
 

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -327,6 +327,11 @@ typedef struct _MqttReplayMsg {
 typedef struct _MqttSendId {
     void*  owner;
     word16 packet_id;
+    /* MqttPacketType of the acknowledgement that ends this exchange (PUBACK,
+     * PUBCOMP, SUBACK or UNSUBACK), so a different response type naming the
+     * same identifier cannot release it early [MQTT-2.3.1-3].
+     * MQTT_PACKET_TYPE_RESERVED means "any". */
+    byte   ack_type;
 } MqttSendId;
 
 /* Client structure */

--- a/wolfmqtt/mqtt_client.h
+++ b/wolfmqtt/mqtt_client.h
@@ -162,7 +162,16 @@ enum MqttClientFlags {
      * application that schedules its own ping, without changing the keep-alive
      * negotiated with the broker. Set via MqttClient_Flags before connecting.
      * Has no effect when built with WOLFMQTT_NO_TIME. */
-    MQTT_CLIENT_FLAG_NO_AUTO_KEEPALIVE = 0x01 << 4
+    MQTT_CLIENT_FLAG_NO_AUTO_KEEPALIVE = 0x01 << 4,
+    /* A CONNECT has been written on the current Network Connection. Tracks the
+     * MQTT handshake, which MQTT_CLIENT_FLAG_IS_CONNECTED does not: that flag
+     * means only that the transport is up. [MQTT-3.1.0-1] requires CONNECT to
+     * be the first packet a Client sends on a Network Connection and
+     * [MQTT-3.1.0-2] allows only one, so the send APIs consult this flag.
+     * Managed by the library - set by MqttClient_Connect and cleared by
+     * MqttSocket_Connect and MqttSocket_Disconnect. Applications must not set
+     * or clear it through MqttClient_Flags. */
+    MQTT_CLIENT_FLAG_CONNECT_SENT = 0x01 << 5
 };
 /*! \brief      Sets flags in the MqttClient structure. To be used from
                 the application before calling MqttClient_NetConnect.

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -488,6 +488,14 @@ typedef struct _MqttConnect {
 #ifdef WOLFMQTT_V5
     MqttProp* props;
 #endif
+
+    /* Length of `password` in bytes. [MQTT-3.1.3.5] defines the Password as
+     * Binary Data, which may legally contain 0x00, so a NUL-terminated string
+     * cannot express every valid value. Leave 0 to keep the original
+     * behaviour of measuring `password` with XSTRLEN; set it to send binary
+     * password bytes verbatim. Added at the end of the struct so existing
+     * binaries keep their layout. */
+    word16      password_len;
 } MqttConnect;
 
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -350,12 +350,14 @@ typedef struct _MqttMsgStat {
      * being dropped and the send lock being taken. Kept as the encodable
      * fields rather than a whole MqttPublishResp, which embeds this struct.
      * ackPacketType is MQTT_PACKET_TYPE_RESERVED when nothing is staged. */
+#ifdef WOLFMQTT_V5
+    MqttProp* ackProps;
+#endif
     word16 ackPacketId;
     byte   ackPacketType;
 #ifdef WOLFMQTT_V5
     byte   ackReasonCode;
     byte   ackProtocolLevel;
-    MqttProp* ackProps;
 #endif
 } MqttMsgStat;
 
@@ -509,8 +511,10 @@ typedef struct _MqttConnect {
      * Binary Data, which may legally contain 0x00, so a NUL-terminated string
      * cannot express every valid value. Leave 0 to keep the original
      * behaviour of measuring `password` with XSTRLEN; set it to send binary
-     * password bytes verbatim. Added at the end of the struct so existing
-     * binaries keep their layout. */
+     * password bytes verbatim. MqttDecode_Connect reports the wire length
+     * here. Added at the end of the struct so the offsets of the existing
+     * members are unchanged; sizeof(MqttConnect) still grows, so a caller
+     * must be rebuilt against this header rather than relinked against it. */
     word16      password_len;
 } MqttConnect;
 

--- a/wolfmqtt/mqtt_packet.h
+++ b/wolfmqtt/mqtt_packet.h
@@ -341,6 +341,22 @@ typedef struct _MqttMsgStat {
      * while the owning thread writes isReadActive/isWriteActive outside that
      * lock; sharing a byte would make those a racy read-modify-write. */
     byte recvQuotaHeld;
+
+    /* QoS acknowledgement staged for this wait object while its PUBLISH was
+     * read, encoded later once the send lock is held. [MQTT-4.6.0-2] requires
+     * PUBACKs to go out in the order their PUBLISHes arrived, so the response
+     * cannot sit in a field shared by every reader: another thread finishing
+     * its own read would overwrite it in the window between the read lock
+     * being dropped and the send lock being taken. Kept as the encodable
+     * fields rather than a whole MqttPublishResp, which embeds this struct.
+     * ackPacketType is MQTT_PACKET_TYPE_RESERVED when nothing is staged. */
+    word16 ackPacketId;
+    byte   ackPacketType;
+#ifdef WOLFMQTT_V5
+    byte   ackReasonCode;
+    byte   ackProtocolLevel;
+    MqttProp* ackProps;
+#endif
 } MqttMsgStat;
 
 #ifdef WOLFMQTT_MULTITHREAD


### PR DESCRIPTION
* Fixes #585 - Zero-byte ClientId can be sent without CleanSession
* Fixes #589 - Nonblocking client reuses in-flight Packet Identifier
* Fixes #590 - Client can send PUBLISH before CONNECT
* Fixes #591 - Client can send CONNECT twice on one Network Connection
* Fixes #592 - Refused CONNACK Partial Write Closes Before Return Code Delivery
* Fixes #594 - Keepalive Can Close Accepted CONNECT Before CONNACK Completes
* Fixes #596 - QoS 0 PUBLISH Replayed on Persistent Reconnect
* Fixes #599 - QoS2 WriteOnly PUBLISH reuses Packet Identifier before PUBCOMP
* Fixes #601 - QoS1 WriteOnly PUBLISH releases Packet Identifier before PUBACK
* Fixes #603 - MQTT 3.1.1 CONNACK decoder accepts extra payload
* Fixes #604 - PUBLISH retransmission keeps DUP clear after partial blocking write failure
* Fixes #605 - QoS2 PUBLISH is not kept unacknowledged before PUBREC
* Fixes #607 - Broker publish-response protocol violations with Packet Identifier 0 do not close the connection
* Fixes #610 - WebSocket non-binary data frame does not close the connection
* Fixes #611 - Client reuses an unacknowledged UNSUBSCRIBE Packet Identifier
* Fixes #612 - SUBSCRIBE can reuse an unacknowledged Packet Identifier
* Fixes #613 - QoS 1 PUBLISH reuses Packet Identifier before PUBACK
* Fixes #588 - CONNECT Password binary data is truncated by client encoder
* Fixes #595 - ClientId change can reuse client-side QoS2 session state
* Fixes #614 - Broker static QoS1/QoS2 PUBLISH can reuse Packet Identifier before ACK completion
* Fixes #608 - PUBACK/PUBREL order can be corrupted under WOLFMQTT_MULTITHREAD
* Fixes #597 - Client outbound Session state is not preserved
* Fixes #598 - wolfMQTT client does not replay unacknowledged QoS PUBLISH after persistent-session reconnect
* Fixes #602 - CleanSession=0 reconnect does not retransmit an unacknowledged PUBREL

